### PR TITLE
feat: auth and event-cannon now uses same standard

### DIFF
--- a/k8s/local/auth/deployment.yaml
+++ b/k8s/local/auth/deployment.yaml
@@ -2,19 +2,19 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: auth
-  name: auth
+    app: auth-label
+  name: auth-deployment
   namespace: chicmoz
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: auth
+      app: auth-label
   strategy: {}
   template:
     metadata:
       labels:
-        app: auth
+        app: auth-label
     spec:
       containers:
         - image: auth:latest
@@ -23,7 +23,7 @@ spec:
               memory: 500Mi
               cpu: 50m
           ports:
-            - name: http-app
+            - name: http-app-port
               containerPort: 80
               protocol: TCP
           name: auth

--- a/k8s/local/auth/postgres-config.yaml
+++ b/k8s/local/auth/postgres-config.yaml
@@ -5,4 +5,3 @@ metadata:
   namespace: chicmoz
 data:
   POSTGRES_DB_NAME: "auth"
-  POSTGRES_PASSWORD: "secret-local-password"

--- a/k8s/local/auth/service.yaml
+++ b/k8s/local/auth/service.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: auth
+  name: auth-service
   namespace: chicmoz
 spec:
   selector:
-    app: auth
+    app: auth-label
   ports:
     - name: http-app
       protocol: TCP
       port: 80
-      targetPort: http-app
+      targetPort: http-app-port

--- a/k8s/local/auth/skaffold.yaml
+++ b/k8s/local/auth/skaffold.yaml
@@ -11,3 +11,13 @@ build:
       requires:
         - image: chicmoz-base
           alias: BASE
+deploy:
+  kubectl:
+    flags:
+      apply: ["--force"]
+manifests:
+  rawYaml:
+    - ./postgres-config.yaml
+    - ./service.yaml
+    - ./ingress.yaml
+    - ./deployment.yaml

--- a/k8s/local/auth/skaffold.yaml
+++ b/k8s/local/auth/skaffold.yaml
@@ -19,5 +19,4 @@ manifests:
   rawYaml:
     - ./postgres-config.yaml
     - ./service.yaml
-    - ./ingress.yaml
     - ./deployment.yaml

--- a/k8s/local/event-cannon/deployment.yaml
+++ b/k8s/local/event-cannon/deployment.yaml
@@ -2,19 +2,19 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: event-cannon
-  name: event-cannon
+    app: event-cannon-label
+  name: event-cannon-deployment
   namespace: chicmoz
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: event-cannon
+      app: event-cannon-label
   strategy: {}
   template:
     metadata:
       labels:
-        app: event-cannon
+        app: event-cannon-label
     spec:
       containers:
         - image: event-cannon:latest
@@ -24,8 +24,6 @@ spec:
               cpu: 250m
           name: event-cannon
           env:
-            - name: NODE_ENV
-              value: "development"
             - name: AZTEC_RPC_URL
               value: "http://aztec-sandbox-node:8081"
             - name: ETHEREUM_RPC_URL

--- a/k8s/local/event-cannon/skaffold.yaml
+++ b/k8s/local/event-cannon/skaffold.yaml
@@ -11,3 +11,10 @@ build:
       requires:
         - image: chicmoz-base
           alias: BASE
+deploy:
+  kubectl:
+    flags:
+      apply: ["--force"]
+manifests:
+  rawYaml:
+    - ./deployment.yaml

--- a/k8s/local/skaffold.no_ui.yaml
+++ b/k8s/local/skaffold.no_ui.yaml
@@ -10,11 +10,5 @@ requires:
   - path: ./ethereum-listener/skaffold.sandbox.yaml
   - path: ./explorer-api/skaffold.sandbox.yaml
   - path: ./auth/skaffold.yaml
+  - path: ./event-cannon/skaffold.yaml
   - path: ./websocket-event-publisher/skaffold.sandbox.yaml
-deploy:
-  kubectl:
-    flags:
-      apply: ["--force"]
-manifests:
-  rawYaml:
-    - ./event-cannon/deployment.yaml

--- a/k8s/local/skaffold.no_ui.yaml
+++ b/k8s/local/skaffold.no_ui.yaml
@@ -5,7 +5,6 @@ metadata:
 requires:
   - path: ./common/skaffold.manifests.yaml
   - path: ./common/skaffold.aztec_sanbox_nodes.yaml
-  - path: ./event-cannon/image.yaml
   - path: ./aztec-listener/skaffold.sandbox.yaml
   - path: ./ethereum-listener/skaffold.sandbox.yaml
   - path: ./explorer-api/skaffold.sandbox.yaml

--- a/k8s/local/skaffold.no_ui.yaml
+++ b/k8s/local/skaffold.no_ui.yaml
@@ -5,11 +5,11 @@ metadata:
 requires:
   - path: ./common/skaffold.manifests.yaml
   - path: ./common/skaffold.aztec_sanbox_nodes.yaml
-  - path: ./auth/image.yaml
   - path: ./event-cannon/image.yaml
   - path: ./aztec-listener/skaffold.sandbox.yaml
   - path: ./ethereum-listener/skaffold.sandbox.yaml
   - path: ./explorer-api/skaffold.sandbox.yaml
+  - path: ./auth/skaffold.yaml
   - path: ./websocket-event-publisher/skaffold.sandbox.yaml
 deploy:
   kubectl:
@@ -17,7 +17,4 @@ deploy:
       apply: ["--force"]
 manifests:
   rawYaml:
-    - ./auth/deployment.yaml
-    - ./auth/service.yaml
-    - ./auth/postgres-config.yaml
     - ./event-cannon/deployment.yaml

--- a/k8s/local/skaffold.sp_testnet.yaml
+++ b/k8s/local/skaffold.sp_testnet.yaml
@@ -5,18 +5,9 @@ metadata:
 requires:
   - path: ./common/skaffold.manifests.yaml
   - path: ./common/skaffold.aztec_sanbox_nodes.yaml
-  - path: ./auth/image.yaml
   - path: ./aztec-listener/skaffold.sp_testnet.yaml
   - path: ./explorer-ui/skaffold.sp_testnet.yaml
   - path: ./ethereum-listener/skaffold.sp_testnet.yaml
   - path: ./explorer-api/skaffold.sp_testnet.yaml
+  - path: ./auth/skaffold.yaml
   - path: ./websocket-event-publisher/skaffold.sp_testnet.yaml
-deploy:
-  kubectl:
-    flags:
-      apply: ["--force"]
-manifests:
-  rawYaml:
-    - ./auth/deployment.yaml
-    - ./auth/service.yaml
-    - ./auth/postgres-config.yaml


### PR DESCRIPTION
With this it's now possible to run `k8s/local/skaffold.sp_testnet.yaml` and `k8s/local/skaffold.no_ui.yaml` separatly.