### PR TITLE
fix: semi decouple the tables

### DIFF
--- a/services/explorer-ui/src/components/tx-effects/tx-effects-schema.ts
+++ b/services/explorer-ui/src/components/tx-effects/tx-effects-schema.ts
@@ -1,4 +1,5 @@
 import {
+  type ChicmozL2TxEffectDeluxe,
   type ChicmozL2BlockLight,
   type ChicmozL2TxEffect,
 } from "@chicmoz-pkg/types";
@@ -7,19 +8,19 @@ import { z } from "zod";
 export type TxEffectTableSchema = z.infer<typeof txEffectSchema>;
 
 export const getTxEffectTableObj = (
-  txEffect: ChicmozL2TxEffect,
-  block?: ChicmozL2BlockLight
+  txEffect: ChicmozL2TxEffectDeluxe | ChicmozL2TxEffect,
+  block?: ChicmozL2BlockLight,
 ): TxEffectTableSchema => {
   // If we have a ChicmozL2TxEffectDeluxe (with timestamp) and no block
-  if (!block && 'timestamp' in txEffect) {
+  if (!block && "timestamp" in txEffect) {
     return txEffectSchema.parse({
       txHash: txEffect.txHash,
       transactionFee: txEffect.transactionFee,
-      blockNumber: txEffect.blockHeight,
+      blockNumber: txEffect.privateLogs,
       timestamp: txEffect.timestamp,
     });
   }
-  
+
   // If we have a block, use the block data (original approach)
   if (block) {
     return txEffectSchema.parse({
@@ -29,7 +30,7 @@ export const getTxEffectTableObj = (
       timestamp: block.header.globalVariables.timestamp,
     });
   }
-  
+
   // Fallback for basic ChicmozL2TxEffect without block
   throw new Error("Block data required for basic ChicmozL2TxEffect objects");
 };

--- a/services/explorer-ui/src/components/tx-effects/tx-effects-schema.ts
+++ b/services/explorer-ui/src/components/tx-effects/tx-effects-schema.ts
@@ -8,14 +8,30 @@ export type TxEffectTableSchema = z.infer<typeof txEffectSchema>;
 
 export const getTxEffectTableObj = (
   txEffect: ChicmozL2TxEffect,
-  block: ChicmozL2BlockLight
+  block?: ChicmozL2BlockLight
 ): TxEffectTableSchema => {
-  return txEffectSchema.parse({
-    txHash: txEffect.txHash,
-    transactionFee: txEffect.transactionFee,
-    blockNumber: block.height,
-    timestamp: block.header.globalVariables.timestamp,
-  });
+  // If we have a ChicmozL2TxEffectDeluxe (with timestamp) and no block
+  if (!block && 'timestamp' in txEffect) {
+    return txEffectSchema.parse({
+      txHash: txEffect.txHash,
+      transactionFee: txEffect.transactionFee,
+      blockNumber: txEffect.blockHeight,
+      timestamp: txEffect.timestamp,
+    });
+  }
+  
+  // If we have a block, use the block data (original approach)
+  if (block) {
+    return txEffectSchema.parse({
+      txHash: txEffect.txHash,
+      transactionFee: txEffect.transactionFee,
+      blockNumber: block.height,
+      timestamp: block.header.globalVariables.timestamp,
+    });
+  }
+  
+  // Fallback for basic ChicmozL2TxEffect without block
+  throw new Error("Block data required for basic ChicmozL2TxEffect objects");
 };
 
 const txEffectSchema = z.object({

--- a/services/explorer-ui/src/lib/map-for-table.ts
+++ b/services/explorer-ui/src/lib/map-for-table.ts
@@ -29,6 +29,10 @@ export const mapLatestTxEffects = (
     return latestTxEffects.map((txEffect) => getTxEffectTableObj(txEffect));
   }
 
+  const blockByHeight = new Map(
+    latestBlocks.map((block) => [block.height, block]),
+  );
+
   const blockTxHashes = new Set<string>();
   latestBlocks.forEach((block) => {
     block.body.txEffects.forEach((tx) => {
@@ -39,9 +43,7 @@ export const mapLatestTxEffects = (
   const blockTxEffects = latestTxEffects
     .filter((txEffect) => blockTxHashes.has(txEffect.txHash))
     .map((txEffect) => {
-      const matchingBlock = latestBlocks.find(
-        (block) => block.height === txEffect.blockHeight,
-      );
+      const matchingBlock = blockByHeight.get(txEffect.blockHeight);
       return getTxEffectTableObj(txEffect, matchingBlock);
     });
 
@@ -50,9 +52,7 @@ export const mapLatestTxEffects = (
   }
 
   return latestTxEffects.map((txEffect) => {
-    const matchingBlock = latestBlocks.find(
-      (block) => block.height === txEffect.blockHeight,
-    );
+    const matchingBlock = blockByHeight.get(txEffect.blockHeight);
     return getTxEffectTableObj(txEffect, matchingBlock);
   });
 };

--- a/services/explorer-ui/src/pages/landing/index.tsx
+++ b/services/explorer-ui/src/pages/landing/index.tsx
@@ -198,7 +198,7 @@ export const Landing: FC = () => {
                 <TxEffectsTable
                   txEffects={mapLatestTxEffects(
                     latestTxEffectsData ?? [],
-                    latestBlocks ?? [],
+                    latestBlocks,
                   )}
                   isLoading={isLoadingTxEffects}
                   title="Latest Transactions"


### PR DESCRIPTION
This Pr semi decouples the landing page tables. now the loading state should not show even if the latest block are not fetched.