### PR TITLE
feat: optimize rollup version filtering by adding version column to l2Block table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,12 @@ yarn lint
 
 # Lint only shared packages
 yarn lint:packages
+
+# Run tests for a specific service
+cd services/{service} && yarn test
+
+# Run tests in watch mode
+cd services/{service} && yarn test:watch
 ```
 
 ### Local Development Setup
@@ -110,6 +116,18 @@ The project uses **yarn workspaces** with shared packages in `/packages/@chicmoz
 - **backend-utils**: Shared backend utility functions
 
 **Important**: Always run `yarn build:packages` before building services, as services depend on these shared packages.
+
+## Code Style Guidelines
+
+- **Imports**: Use named imports, no default exports (`import/no-default-export` rule)
+- **Types**: Use TypeScript with strict type checking, prefer `type` over `interface`
+- **Naming**: Use camelCase for variables/functions, PascalCase for types/classes
+- **Error Handling**: Use structured error handling with proper logging
+- **Formatting**: Prettier with organize-imports plugin, no semicolons preference
+- **ESLint Rules**: No console.log (`no-console`), curly braces required, no param reassignment
+- **File Extensions**: Use `.js` imports in TypeScript files (ES modules)
+- **Database**: Use Drizzle ORM with type-safe queries
+- **Testing**: Vitest for unit tests with globals enabled
 
 ## Database Patterns
 

--- a/packages/postgres-helper/src/environment.ts
+++ b/packages/postgres-helper/src/environment.ts
@@ -14,7 +14,7 @@ export const dbCredentials = {
 };
 
 export const getConfigStr = () => {
-  if (!POSTGRES_DB_NAME) throw new Error("POSTGRES_DB_NAME is not set");
+  if (!POSTGRES_DB_NAME) {throw new Error("POSTGRES_DB_NAME is not set");}
   return `POSTGRES
 POSTGRES_IP        ${POSTGRES_IP}
 POSTGRES_PORT      ${POSTGRES_PORT}

--- a/packages/postgres-helper/src/migrate-db.ts
+++ b/packages/postgres-helper/src/migrate-db.ts
@@ -65,7 +65,7 @@ async function run(
     },
   });
   console.log("🤩 Migrations complete!");
-  if (TOTAL_DB_RESET) console.log("🔥🔥🔥 Total DB reset!");
+  if (TOTAL_DB_RESET) {console.log("🔥🔥🔥 Total DB reset!");}
 }
 
 async function dropAllTables(client: PoolClient) {

--- a/services/explorer-api/migrations/0007_yellow_tenebrous.sql
+++ b/services/explorer-api/migrations/0007_yellow_tenebrous.sql
@@ -1,0 +1,18 @@
+-- First add the column as nullable
+ALTER TABLE "l2Block" ADD COLUMN "version" bigint;--> statement-breakpoint
+
+-- Populate the version column from existing data
+UPDATE "l2Block" 
+SET "version" = (
+  SELECT gv."version" 
+  FROM "header" h 
+  INNER JOIN "global_variables" gv ON h."id" = gv."header_id" 
+  WHERE h."block_hash" = "l2Block"."hash"
+);--> statement-breakpoint
+
+-- Make the column NOT NULL after populating data
+ALTER TABLE "l2Block" ALTER COLUMN "version" SET NOT NULL;--> statement-breakpoint
+
+-- Create indexes for performance
+CREATE INDEX IF NOT EXISTS "l2block_version_idx" ON "l2Block" USING btree ("version");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "l2block_height_version_idx" ON "l2Block" USING btree ("height","version");

--- a/services/explorer-api/migrations/meta/0007_snapshot.json
+++ b/services/explorer-api/migrations/meta/0007_snapshot.json
@@ -1,0 +1,2683 @@
+{
+  "id": "cf93a0de-e746-423f-af1b-f9396a5065c6",
+  "prevId": "04483ec8-95a2-4392-824a-2656758f008a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.aztec-chain-connection": {
+      "name": "aztec-chain-connection",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "chain_height": {
+          "name": "chain_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latest_processed_height": {
+          "name": "latest_processed_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rpc_url": {
+          "name": "rpc_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_version": {
+          "name": "node_version",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_chain_id": {
+          "name": "l1_chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollup_version": {
+          "name": "rollup_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enr": {
+          "name": "enr",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "l1_contract_addresses": {
+          "name": "l1_contract_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol_contract_addresses": {
+          "name": "protocol_contract_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.contract_instance_balance": {
+      "name": "contract_instance_balance",
+      "schema": "",
+      "columns": {
+        "contract_address": {
+          "name": "contract_address",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric(77, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "contract_instance_balance_pk": {
+          "name": "contract_instance_balance_pk",
+          "columns": ["contract_address", "timestamp"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.dropped_tx": {
+      "name": "dropped_tx",
+      "schema": "",
+      "columns": {
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_as_pending_at": {
+          "name": "created_as_pending_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dropped_at": {
+          "name": "dropped_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.body": {
+      "name": "body",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "block_hash": {
+          "name": "block_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "body_block_hash_idx": {
+          "name": "body_block_hash_idx",
+          "columns": [
+            {
+              "expression": "block_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "body_block_hash_l2Block_hash_fk": {
+          "name": "body_block_hash_l2Block_hash_fk",
+          "tableFrom": "body",
+          "tableTo": "l2Block",
+          "columnsFrom": ["block_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.public_data_write": {
+      "name": "public_data_write",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tx_effect_hash": {
+          "name": "tx_effect_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "leaf_slot": {
+          "name": "leaf_slot",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "public_data_write_tx_effect_hash_idx": {
+          "name": "public_data_write_tx_effect_hash_idx",
+          "columns": [
+            {
+              "expression": "tx_effect_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_data_write_index_idx": {
+          "name": "public_data_write_index_idx",
+          "columns": [
+            {
+              "expression": "index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_data_write_tx_effect_hash_index_idx": {
+          "name": "public_data_write_tx_effect_hash_index_idx",
+          "columns": [
+            {
+              "expression": "tx_effect_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "public_data_write_tx_effect_hash_tx_effect_tx_hash_fk": {
+          "name": "public_data_write_tx_effect_hash_tx_effect_tx_hash_fk",
+          "tableFrom": "public_data_write",
+          "tableTo": "tx_effect",
+          "columnsFrom": ["tx_effect_hash"],
+          "columnsTo": ["tx_hash"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.tx_effect": {
+      "name": "tx_effect",
+      "schema": "",
+      "columns": {
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "body_id": {
+          "name": "body_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_time_of_birth": {
+          "name": "tx_time_of_birth",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revert_code": {
+          "name": "revert_code",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_fee": {
+          "name": "transaction_fee",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_hashes": {
+          "name": "note_hashes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nullifiers": {
+          "name": "nullifiers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l2_to_l1_msgs": {
+          "name": "l2_to_l1_msgs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_logs": {
+          "name": "private_logs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_logs": {
+          "name": "public_logs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_class_logs": {
+          "name": "contract_class_logs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tx_hash_index": {
+          "name": "tx_hash_index",
+          "columns": [
+            {
+              "expression": "tx_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tx_effect_body_id_idx": {
+          "name": "tx_effect_body_id_idx",
+          "columns": [
+            {
+              "expression": "body_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tx_effect_index_idx": {
+          "name": "tx_effect_index_idx",
+          "columns": [
+            {
+              "expression": "index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tx_effect_body_id_index_idx": {
+          "name": "tx_effect_body_id_index_idx",
+          "columns": [
+            {
+              "expression": "body_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tx_effect_body_id_body_id_fk": {
+          "name": "tx_effect_body_id_body_id_fk",
+          "tableFrom": "tx_effect",
+          "tableTo": "body",
+          "columnsFrom": ["body_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.content_commitment": {
+      "name": "content_commitment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "header_id": {
+          "name": "header_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blobs_hash": {
+          "name": "blobs_hash",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "in_hash": {
+          "name": "in_hash",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "out_hash": {
+          "name": "out_hash",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "content_commitment_header_id_idx": {
+          "name": "content_commitment_header_id_idx",
+          "columns": [
+            {
+              "expression": "header_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_commitment_header_id_header_id_fk": {
+          "name": "content_commitment_header_id_header_id_fk",
+          "tableFrom": "content_commitment",
+          "tableTo": "header",
+          "columnsFrom": ["header_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.gas_fees": {
+      "name": "gas_fees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "global_variables_id": {
+          "name": "global_variables_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_per_da_gas": {
+          "name": "fee_per_da_gas",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_per_l2_gas": {
+          "name": "fee_per_l2_gas",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "gas_fees_global_variables_id_idx": {
+          "name": "gas_fees_global_variables_id_idx",
+          "columns": [
+            {
+              "expression": "global_variables_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gas_fees_global_variables_id_global_variables_id_fk": {
+          "name": "gas_fees_global_variables_id_global_variables_id_fk",
+          "tableFrom": "gas_fees",
+          "tableTo": "global_variables",
+          "columnsFrom": ["global_variables_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.global_variables": {
+      "name": "global_variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "header_id": {
+          "name": "header_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_number": {
+          "name": "slot_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coinbase": {
+          "name": "coinbase",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_recipient": {
+          "name": "fee_recipient",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "global_variables_header_id_idx": {
+          "name": "global_variables_header_id_idx",
+          "columns": [
+            {
+              "expression": "header_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "global_variables_version_idx": {
+          "name": "global_variables_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "global_variables_header_id_header_id_fk": {
+          "name": "global_variables_header_id_header_id_fk",
+          "tableFrom": "global_variables",
+          "tableTo": "header",
+          "columnsFrom": ["header_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.header": {
+      "name": "header",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "block_hash": {
+          "name": "block_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_fees": {
+          "name": "total_fees",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_mana_used": {
+          "name": "total_mana_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "header_block_hash_idx": {
+          "name": "header_block_hash_idx",
+          "columns": [
+            {
+              "expression": "block_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "header_block_hash_l2Block_hash_fk": {
+          "name": "header_block_hash_l2Block_hash_fk",
+          "tableFrom": "header",
+          "tableTo": "l2Block",
+          "columnsFrom": ["block_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l1_to_l2_message_tree": {
+      "name": "l1_to_l2_message_tree",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "root": {
+          "name": "root",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_available_leaf_index": {
+          "name": "next_available_leaf_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_id": {
+          "name": "state_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l1_to_l2_message_tree_state_id_state_id_fk": {
+          "name": "l1_to_l2_message_tree_state_id_state_id_fk",
+          "tableFrom": "l1_to_l2_message_tree",
+          "tableTo": "state",
+          "columnsFrom": ["state_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.last_archive": {
+      "name": "last_archive",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "root": {
+          "name": "root",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_available_leaf_index": {
+          "name": "next_available_leaf_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header_id": {
+          "name": "header_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "last_archive_header_id_header_id_fk": {
+          "name": "last_archive_header_id_header_id_fk",
+          "tableFrom": "last_archive",
+          "tableTo": "header",
+          "columnsFrom": ["header_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.note_hash_tree": {
+      "name": "note_hash_tree",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "root": {
+          "name": "root",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_available_leaf_index": {
+          "name": "next_available_leaf_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_partial_id": {
+          "name": "state_partial_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "note_hash_tree_state_partial_id_partial_id_fk": {
+          "name": "note_hash_tree_state_partial_id_partial_id_fk",
+          "tableFrom": "note_hash_tree",
+          "tableTo": "partial",
+          "columnsFrom": ["state_partial_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.nullifier_tree": {
+      "name": "nullifier_tree",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "root": {
+          "name": "root",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_available_leaf_index": {
+          "name": "next_available_leaf_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_partial_id": {
+          "name": "state_partial_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nullifier_tree_state_partial_id_partial_id_fk": {
+          "name": "nullifier_tree_state_partial_id_partial_id_fk",
+          "tableFrom": "nullifier_tree",
+          "tableTo": "partial",
+          "columnsFrom": ["state_partial_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.partial": {
+      "name": "partial",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "state_id": {
+          "name": "state_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "partial_state_id_idx": {
+          "name": "partial_state_id_idx",
+          "columns": [
+            {
+              "expression": "state_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "partial_state_id_state_id_fk": {
+          "name": "partial_state_id_state_id_fk",
+          "tableFrom": "partial",
+          "tableTo": "state",
+          "columnsFrom": ["state_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.public_data_tree": {
+      "name": "public_data_tree",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "root": {
+          "name": "root",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_available_leaf_index": {
+          "name": "next_available_leaf_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_partial_id": {
+          "name": "state_partial_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "public_data_tree_state_partial_id_partial_id_fk": {
+          "name": "public_data_tree_state_partial_id_partial_id_fk",
+          "tableFrom": "public_data_tree",
+          "tableTo": "partial",
+          "columnsFrom": ["state_partial_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.state": {
+      "name": "state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "header_id": {
+          "name": "header_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "state_header_id_idx": {
+          "name": "state_header_id_idx",
+          "columns": [
+            {
+              "expression": "header_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "state_header_id_header_id_fk": {
+          "name": "state_header_id_header_id_fk",
+          "tableFrom": "state",
+          "tableTo": "header",
+          "columnsFrom": ["header_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l1_l2_block_proposed": {
+      "name": "l1_l2_block_proposed",
+      "schema": "",
+      "columns": {
+        "l1_contract_address": {
+          "name": "l1_contract_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l2_block_number": {
+          "name": "l2_block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_block_number": {
+          "name": "l1_block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_block_hash": {
+          "name": "l1_block_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_block_timestamp": {
+          "name": "l1_block_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_finalized": {
+          "name": "is_finalized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "archive": {
+          "name": "archive",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "block_proposal": {
+          "name": "block_proposal",
+          "columns": ["l2_block_number", "archive"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.l1_l2_proof_verified": {
+      "name": "l1_l2_proof_verified",
+      "schema": "",
+      "columns": {
+        "l1_contract_address": {
+          "name": "l1_contract_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l2_block_number": {
+          "name": "l2_block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_block_number": {
+          "name": "l1_block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_block_hash": {
+          "name": "l1_block_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_block_timestamp": {
+          "name": "l1_block_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_finalized": {
+          "name": "is_finalized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "prover_id": {
+          "name": "prover_id",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "proof_verified": {
+          "name": "proof_verified",
+          "columns": ["l2_block_number", "prover_id"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.archive": {
+      "name": "archive",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "root": {
+          "name": "root",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_available_leaf_index": {
+          "name": "next_available_leaf_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_hash": {
+          "name": "block_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "archive_block_hash_l2Block_hash_fk": {
+          "name": "archive_block_hash_l2Block_hash_fk",
+          "tableFrom": "archive",
+          "tableTo": "l2Block",
+          "columnsFrom": ["block_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l2Block": {
+      "name": "l2Block",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "orphan_timestamp": {
+          "name": "orphan_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orphan_hasOrphanedParent": {
+          "name": "orphan_hasOrphanedParent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "height_idx": {
+          "name": "height_idx",
+          "columns": [
+            {
+              "expression": "height",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "l2block_version_idx": {
+          "name": "l2block_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "l2block_height_version_idx": {
+          "name": "l2block_height_version_idx",
+          "columns": [
+            {
+              "expression": "height",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "orphan_timestamp_idx": {
+          "name": "orphan_timestamp_idx",
+          "columns": [
+            {
+              "expression": "orphan_timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"l2Block\".\"orphan_timestamp\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "height_orphan_idx": {
+          "name": "height_orphan_idx",
+          "columns": [
+            {
+              "expression": "height",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "orphan_timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l2_contract_class_registered": {
+      "name": "l2_contract_class_registered",
+      "schema": "",
+      "columns": {
+        "block_hash": {
+          "name": "block_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_class_id": {
+          "name": "contract_class_id",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_hash": {
+          "name": "artifact_hash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_functions_root": {
+          "name": "private_functions_root",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "packed_bytecode": {
+          "name": "packed_bytecode",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_json": {
+          "name": "artifact_json",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_contract_name": {
+          "name": "artifact_contract_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contract_type": {
+          "name": "contract_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contract_version": {
+          "name": "contract_version",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_code_url": {
+          "name": "source_code_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l2_contract_class_registered_block_hash_l2Block_hash_fk": {
+          "name": "l2_contract_class_registered_block_hash_l2Block_hash_fk",
+          "tableFrom": "l2_contract_class_registered",
+          "tableTo": "l2Block",
+          "columnsFrom": ["block_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "contract_class_id_version": {
+          "name": "contract_class_id_version",
+          "columns": ["contract_class_id", "version"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.l2_contract_instance_aztec_scan_notes": {
+      "name": "l2_contract_instance_aztec_scan_notes",
+      "schema": "",
+      "columns": {
+        "address": {
+          "name": "address",
+          "type": "varchar(66)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_l1_contract_addresses": {
+          "name": "related_l1_contract_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l2_contract_instance_deployed": {
+      "name": "l2_contract_instance_deployed",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "block_hash": {
+          "name": "block_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "salt": {
+          "name": "salt",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_contract_class_id": {
+          "name": "current_contract_class_id",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_contract_class_id": {
+          "name": "original_contract_class_id",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initialization_hash": {
+          "name": "initialization_hash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployer": {
+          "name": "deployer",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "masterNullifierPublicKey": {
+          "name": "masterNullifierPublicKey",
+          "type": "varchar(130)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "masterIncomingViewingPublicKey": {
+          "name": "masterIncomingViewingPublicKey",
+          "type": "varchar(130)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "masterOutgoingViewingPublicKey": {
+          "name": "masterOutgoingViewingPublicKey",
+          "type": "varchar(130)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "masterTaggingPublicKey": {
+          "name": "masterTaggingPublicKey",
+          "type": "varchar(130)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l2_contract_instance_deployed_block_hash_l2Block_hash_fk": {
+          "name": "l2_contract_instance_deployed_block_hash_l2Block_hash_fk",
+          "tableFrom": "l2_contract_instance_deployed",
+          "tableTo": "l2Block",
+          "columnsFrom": ["block_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contract_class": {
+          "name": "contract_class",
+          "tableFrom": "l2_contract_instance_deployed",
+          "tableTo": "l2_contract_class_registered",
+          "columnsFrom": ["current_contract_class_id", "version"],
+          "columnsTo": ["contract_class_id", "version"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "l2_contract_instance_deployed_address_unique": {
+          "name": "l2_contract_instance_deployed_address_unique",
+          "nullsNotDistinct": false,
+          "columns": ["address"]
+        }
+      }
+    },
+    "public.l2_contract_instance_deployer_metadata": {
+      "name": "l2_contract_instance_deployer_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_identifier": {
+          "name": "contract_identifier",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_name": {
+          "name": "creator_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_contact": {
+          "name": "creator_contact",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_url": {
+          "name": "app_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l2_contract_instance_deployer_metadata_address_l2_contract_instance_deployed_address_fk": {
+          "name": "l2_contract_instance_deployer_metadata_address_l2_contract_instance_deployed_address_fk",
+          "tableFrom": "l2_contract_instance_deployer_metadata",
+          "tableTo": "l2_contract_instance_deployed",
+          "columnsFrom": ["address"],
+          "columnsTo": ["address"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l2_contract_instance_update": {
+      "name": "l2_contract_instance_update",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prev_contract_class_id": {
+          "name": "prev_contract_class_id",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_contract_class_id": {
+          "name": "new_contract_class_id",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_hash": {
+          "name": "block_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l2_contract_instance_update_block_hash_l2Block_hash_fk": {
+          "name": "l2_contract_instance_update_block_hash_l2Block_hash_fk",
+          "tableFrom": "l2_contract_instance_update",
+          "tableTo": "l2Block",
+          "columnsFrom": ["block_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "l2_contract_instance_update_address_unique": {
+          "name": "l2_contract_instance_update_address_unique",
+          "nullsNotDistinct": false,
+          "columns": ["address"]
+        }
+      }
+    },
+    "public.l2_contract_instance_verified_deployment_arguments": {
+      "name": "l2_contract_instance_verified_deployment_arguments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publicKeys": {
+          "name": "publicKeys",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployer": {
+          "name": "deployer",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "salt": {
+          "name": "salt",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "constructor_args": {
+          "name": "constructor_args",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l2_contract_instance_verified_deployment_arguments_address_l2_contract_instance_deployed_address_fk": {
+          "name": "l2_contract_instance_verified_deployment_arguments_address_l2_contract_instance_deployed_address_fk",
+          "tableFrom": "l2_contract_instance_verified_deployment_arguments",
+          "tableTo": "l2_contract_instance_deployed",
+          "columnsFrom": ["address"],
+          "columnsTo": ["address"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l2_private_function": {
+      "name": "l2_private_function",
+      "schema": "",
+      "columns": {
+        "contract_class_id": {
+          "name": "contract_class_id",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_metadata_hash": {
+          "name": "artifact_metadata_hash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "utility_functions_tree_root": {
+          "name": "utility_functions_tree_root",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_function_tree_sibling_path": {
+          "name": "private_function_tree_sibling_path",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_function_tree_leaf_index": {
+          "name": "private_function_tree_leaf_index",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_function_tree_sibling_path": {
+          "name": "artifact_function_tree_sibling_path",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_function_tree_leaf_index": {
+          "name": "artifact_function_tree_leaf_index",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_function_selector_value": {
+          "name": "private_function_selector_value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_function_metadata_hash": {
+          "name": "private_function_metadata_hash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_function_vk_hash": {
+          "name": "private_function_vk_hash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_function_bytecode": {
+          "name": "private_function_bytecode",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "private_function_contract_class": {
+          "name": "private_function_contract_class",
+          "columns": ["contract_class_id", "private_function_selector_value"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.l2_utility_function": {
+      "name": "l2_utility_function",
+      "schema": "",
+      "columns": {
+        "contract_class_id": {
+          "name": "contract_class_id",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_metadata_hash": {
+          "name": "artifact_metadata_hash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_functions_artifact_tree_root": {
+          "name": "private_functions_artifact_tree_root",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_function_tree_sibling_path": {
+          "name": "artifact_function_tree_sibling_path",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_function_tree_leaf_index": {
+          "name": "artifact_function_tree_leaf_index",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "utility_function_selector_value": {
+          "name": "utility_function_selector_value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "utility_function_metadata_hash": {
+          "name": "utility_function_metadata_hash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "utility_function_bytecode": {
+          "name": "utility_function_bytecode",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "utility_function_contract_class": {
+          "name": "utility_function_contract_class",
+          "columns": ["contract_class_id", "utility_function_selector_value"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.tx": {
+      "name": "tx",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fee_payer": {
+          "name": "fee_payer",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_timestamp": {
+          "name": "birth_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l1_generic_contract_event": {
+      "name": "l1_generic_contract_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "l1_block_hash": {
+          "name": "l1_block_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_block_number": {
+          "name": "l1_block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_block_timestamp": {
+          "name": "l1_block_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_contract_address": {
+          "name": "l1_contract_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_transaction_hash": {
+          "name": "l1_transaction_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_finalized": {
+          "name": "is_finalized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_args": {
+          "name": "event_args",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l1_l2_validator_proposer": {
+      "name": "l1_l2_validator_proposer",
+      "schema": "",
+      "columns": {
+        "attester_address": {
+          "name": "attester_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposer": {
+          "name": "proposer",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l1_l2_validator_proposer_attester_address_l1_l2_validator_attester_fk": {
+          "name": "l1_l2_validator_proposer_attester_address_l1_l2_validator_attester_fk",
+          "tableFrom": "l1_l2_validator_proposer",
+          "tableTo": "l1_l2_validator",
+          "columnsFrom": ["attester_address"],
+          "columnsTo": ["attester"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "l1_l2_validator_proposer_attester_address_timestamp_pk": {
+          "name": "l1_l2_validator_proposer_attester_address_timestamp_pk",
+          "columns": ["attester_address", "timestamp"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.l1_l2_validator_rollup_address": {
+      "name": "l1_l2_validator_rollup_address",
+      "schema": "",
+      "columns": {
+        "attester_address": {
+          "name": "attester_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollup_address": {
+          "name": "rollup_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l1_l2_validator_rollup_address_attester_address_l1_l2_validator_attester_fk": {
+          "name": "l1_l2_validator_rollup_address_attester_address_l1_l2_validator_attester_fk",
+          "tableFrom": "l1_l2_validator_rollup_address",
+          "tableTo": "l1_l2_validator",
+          "columnsFrom": ["attester_address"],
+          "columnsTo": ["attester"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "l1_l2_validator_rollup_address_attester_address_timestamp_pk": {
+          "name": "l1_l2_validator_rollup_address_attester_address_timestamp_pk",
+          "columns": ["attester_address", "timestamp"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.l1_l2_validator_stake": {
+      "name": "l1_l2_validator_stake",
+      "schema": "",
+      "columns": {
+        "attester_address": {
+          "name": "attester_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stake": {
+          "name": "stake",
+          "type": "numeric(77, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l1_l2_validator_stake_attester_address_l1_l2_validator_attester_fk": {
+          "name": "l1_l2_validator_stake_attester_address_l1_l2_validator_attester_fk",
+          "tableFrom": "l1_l2_validator_stake",
+          "tableTo": "l1_l2_validator",
+          "columnsFrom": ["attester_address"],
+          "columnsTo": ["attester"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "l1_l2_validator_stake_attester_address_timestamp_pk": {
+          "name": "l1_l2_validator_stake_attester_address_timestamp_pk",
+          "columns": ["attester_address", "timestamp"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.l1_l2_validator_status": {
+      "name": "l1_l2_validator_status",
+      "schema": "",
+      "columns": {
+        "attester_address": {
+          "name": "attester_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l1_l2_validator_status_attester_address_l1_l2_validator_attester_fk": {
+          "name": "l1_l2_validator_status_attester_address_l1_l2_validator_attester_fk",
+          "tableFrom": "l1_l2_validator_status",
+          "tableTo": "l1_l2_validator",
+          "columnsFrom": ["attester_address"],
+          "columnsTo": ["attester"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "l1_l2_validator_status_attester_address_timestamp_pk": {
+          "name": "l1_l2_validator_status_attester_address_timestamp_pk",
+          "columns": ["attester_address", "timestamp"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.l1_l2_validator": {
+      "name": "l1_l2_validator",
+      "schema": "",
+      "columns": {
+        "attester": {
+          "name": "attester",
+          "type": "varchar(42)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l1_l2_validator_withdrawer": {
+      "name": "l1_l2_validator_withdrawer",
+      "schema": "",
+      "columns": {
+        "attester_address": {
+          "name": "attester_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "withdrawer": {
+          "name": "withdrawer",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l1_l2_validator_withdrawer_attester_address_l1_l2_validator_attester_fk": {
+          "name": "l1_l2_validator_withdrawer_attester_address_l1_l2_validator_attester_fk",
+          "tableFrom": "l1_l2_validator_withdrawer",
+          "tableTo": "l1_l2_validator",
+          "columnsFrom": ["attester_address"],
+          "columnsTo": ["attester"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "l1_l2_validator_withdrawer_attester_address_timestamp_pk": {
+          "name": "l1_l2_validator_withdrawer_attester_address_timestamp_pk",
+          "columns": ["attester_address", "timestamp"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.l2_chain_info": {
+      "name": "l2_chain_info",
+      "schema": "",
+      "columns": {
+        "l2_network_id": {
+          "name": "l2_network_id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "l1_chain_id": {
+          "name": "l1_chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollup_version": {
+          "name": "rollup_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "l1_contract_addresses": {
+          "name": "l1_contract_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol_contract_addresses": {
+          "name": "protocol_contract_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l2_rpc_node_error": {
+      "name": "l2_rpc_node_error",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rpc_node_name": {
+          "name": "rpc_node_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cause": {
+          "name": "cause",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stack": {
+          "name": "stack",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l2_rpc_node_error_rpc_node_name_l2_rpc_node_name_fk": {
+          "name": "l2_rpc_node_error_rpc_node_name_l2_rpc_node_name_fk",
+          "tableFrom": "l2_rpc_node_error",
+          "tableTo": "l2_rpc_node",
+          "columnsFrom": ["rpc_node_name"],
+          "columnsTo": ["name"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l2_rpc_node": {
+      "name": "l2_rpc_node",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rpc_url": {
+          "name": "rpc_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "l2_rpc_node_rpc_url_unique": {
+          "name": "l2_rpc_node_rpc_url_unique",
+          "nullsNotDistinct": false,
+          "columns": ["rpc_url"]
+        }
+      }
+    },
+    "public.l2_sequencer": {
+      "name": "l2_sequencer",
+      "schema": "",
+      "columns": {
+        "enr": {
+          "name": "enr",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rpc_node_name": {
+          "name": "rpc_node_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l2_network_id": {
+          "name": "l2_network_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollup_version": {
+          "name": "rollup_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_version": {
+          "name": "node_version",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_chain_id": {
+          "name": "l1_chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l2_sequencer_rpc_node_name_l2_rpc_node_name_fk": {
+          "name": "l2_sequencer_rpc_node_name_l2_rpc_node_name_fk",
+          "tableFrom": "l2_sequencer",
+          "tableTo": "l2_rpc_node",
+          "columnsFrom": ["rpc_node_name"],
+          "columnsTo": ["name"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l2BlockFinalizationStatus": {
+      "name": "l2BlockFinalizationStatus",
+      "schema": "",
+      "columns": {
+        "l2_block_hash": {
+          "name": "l2_block_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l2_block_number": {
+          "name": "l2_block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "l2_block_finalization_l2blockhash_idx": {
+          "name": "l2_block_finalization_l2blockhash_idx",
+          "columns": [
+            {
+              "expression": "l2_block_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "l2_block_finalization_status_idx": {
+          "name": "l2_block_finalization_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "l2_block_finalization_status_pk": {
+          "name": "l2_block_finalization_status_pk",
+          "columns": ["l2_block_hash", "status", "l2_block_number"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.tx_public_call_request": {
+      "name": "tx_public_call_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "msg_sender": {
+          "name": "msg_sender",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_address": {
+          "name": "contract_address",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_static_call": {
+          "name": "is_static_call",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calldata_hash": {
+          "name": "calldata_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/services/explorer-api/migrations/meta/_journal.json
+++ b/services/explorer-api/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1753272424964,
       "tag": "0006_cultured_ben_parker",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1753361200978,
+      "tag": "0007_yellow_tenebrous",
+      "breakpoints": true
     }
   ]
 }

--- a/services/explorer-api/src/svcs/database/controllers/contract-instance-balance/get-balance.ts
+++ b/services/explorer-api/src/svcs/database/controllers/contract-instance-balance/get-balance.ts
@@ -6,7 +6,7 @@ import {
 } from "@chicmoz-pkg/types";
 import { and, desc, eq, gt, isNull } from "drizzle-orm";
 import { contractInstanceBalance } from "../../schema/contract-instance-balance/index.js";
-import { globalVariables, header, l2Block } from "../../schema/index.js";
+import { l2Block } from "../../schema/index.js";
 import { l2ContractInstanceDeployed } from "../../schema/l2contract/index.js";
 import { CURRENT_ROLLUP_VERSION } from "../../../../constants/versions.js";
 
@@ -45,13 +45,11 @@ export const getCotractInstacesWithBalance = async (): Promise<
       ),
     )
     .innerJoin(l2Block, eq(l2ContractInstanceDeployed.blockHash, l2Block.hash))
-    .innerJoin(header, eq(l2Block.hash, header.blockHash))
-    .innerJoin(globalVariables, eq(header.id, globalVariables.headerId))
     .where(
       and(
         gt(contractInstanceBalance.balance, "0"),
         isNull(l2Block.orphan_timestamp),
-        eq(globalVariables.version, parseInt(CURRENT_ROLLUP_VERSION)),
+        eq(l2Block.version, parseInt(CURRENT_ROLLUP_VERSION)),
       ),
     )
     .orderBy(

--- a/services/explorer-api/src/svcs/database/controllers/l2/search.ts
+++ b/services/explorer-api/src/svcs/database/controllers/l2/search.ts
@@ -11,8 +11,6 @@ import { and, eq, or, sql, isNull } from "drizzle-orm";
 import { z } from "zod";
 import {
   droppedTx,
-  globalVariables,
-  header,
   l2Block,
   l2ContractClassRegistered,
   l2ContractInstanceDeployed,
@@ -30,13 +28,11 @@ const getBlockHashByHeight = async (
       hash: l2Block.hash,
     })
     .from(l2Block)
-    .innerJoin(header, eq(l2Block.hash, header.blockHash))
-    .innerJoin(globalVariables, eq(header.id, globalVariables.headerId))
     .where(
       and(
         eq(l2Block.height, height),
         isNull(l2Block.orphan_timestamp),
-        eq(globalVariables.version, parseInt(CURRENT_ROLLUP_VERSION)),
+        eq(l2Block.version, parseInt(CURRENT_ROLLUP_VERSION)),
       ),
     )
     .execute();

--- a/services/explorer-api/src/svcs/database/controllers/l2TxEffect/stats.ts
+++ b/services/explorer-api/src/svcs/database/controllers/l2TxEffect/stats.ts
@@ -15,12 +15,10 @@ export const getTotalTxEffects = async (): Promise<number> => {
     .from(txEffect)
     .innerJoin(body, eq(body.id, txEffect.bodyId))
     .innerJoin(l2Block, eq(l2Block.hash, body.blockHash))
-    .innerJoin(header, eq(l2Block.hash, header.blockHash))
-    .innerJoin(globalVariables, eq(header.id, globalVariables.headerId))
     .where(
       and(
         isNull(l2Block.orphan_timestamp),
-        eq(globalVariables.version, parseInt(CURRENT_ROLLUP_VERSION)),
+        eq(l2Block.version, parseInt(CURRENT_ROLLUP_VERSION)),
       ),
     )
     .execute();
@@ -41,7 +39,7 @@ export const getTotalTxEffectsLast24h = async (): Promise<number> => {
         gt(globalVariables.timestamp, Date.now() - ONE_DAY),
         lt(globalVariables.timestamp, Date.now()),
         isNull(l2Block.orphan_timestamp),
-        eq(globalVariables.version, parseInt(CURRENT_ROLLUP_VERSION)),
+        eq(l2Block.version, parseInt(CURRENT_ROLLUP_VERSION)),
       ),
     )
     .execute();

--- a/services/explorer-api/src/svcs/database/controllers/l2block/add_l1_data.ts
+++ b/services/explorer-api/src/svcs/database/controllers/l2block/add_l1_data.ts
@@ -15,6 +15,7 @@ import {
   l2Block,
 } from "../../schema/index.js";
 import { ensureFinalizationStatusStored } from "./store.js";
+import { CURRENT_ROLLUP_VERSION } from "../../../../constants/versions.js";
 
 export const addL1L2BlockProposed = async (
   proposedData: ChicmozL1L2BlockProposed,
@@ -44,7 +45,12 @@ export const addL1L2BlockProposed = async (
     })
     .from(l2Block)
     .innerJoin(archive, eq(l2Block.hash, archive.fk))
-    .where(eq(l2Block.height, proposedData.l2BlockNumber))
+    .where(
+      and(
+        eq(l2Block.height, proposedData.l2BlockNumber),
+        eq(l2Block.version, parseInt(CURRENT_ROLLUP_VERSION)),
+      ),
+    )
     .limit(1);
   const l2BlockHash = l2BlockHashRes?.[0]?.l2BlockHash;
   if (!l2BlockHash) {
@@ -165,6 +171,7 @@ export const addL1L2ProofVerified = async (
       and(
         isNull(l2Block.orphan_timestamp),
         eq(l2Block.height, proofVerifiedData.l2BlockNumber),
+        eq(l2Block.version, parseInt(CURRENT_ROLLUP_VERSION)),
       ),
     );
   let l2BlockHash;

--- a/services/explorer-api/src/svcs/database/controllers/l2block/get-block.ts
+++ b/services/explorer-api/src/svcs/database/controllers/l2block/get-block.ts
@@ -269,15 +269,16 @@ const _getBlocks = async (
         if (!includeOrphaned) {
           whereQuery = whereQuery.where(
             and(
-              isNull(l2Block.orphan_timestamp), eq(globalVariables.version, parseInt(CURRENT_ROLLUP_VERSION)),
+              isNull(l2Block.orphan_timestamp),
+              eq(l2Block.version, parseInt(CURRENT_ROLLUP_VERSION)),
             ),
           );
         } else {
-          whereQuery = whereQuery.where(eq(globalVariables.version, parseInt(CURRENT_ROLLUP_VERSION)));
+          whereQuery = whereQuery.where(
+            eq(l2Block.version, parseInt(CURRENT_ROLLUP_VERSION)),
+          );
         }
-        whereQuery = whereQuery
-          .orderBy(desc(l2Block.height))
-          .limit(1);
+        whereQuery = whereQuery.orderBy(desc(l2Block.height)).limit(1);
       } else {
         // Get specific height
         whereQuery = joinQuery
@@ -285,7 +286,10 @@ const _getBlocks = async (
             and(
               eq(l2Block.height, args.height),
               includeOrphaned ? undefined : isNull(l2Block.orphan_timestamp),
-              eq(globalVariables.version, options.rollupVersion ?? parseInt(CURRENT_ROLLUP_VERSION)),
+              eq(
+                l2Block.version,
+                options.rollupVersion ?? parseInt(CURRENT_ROLLUP_VERSION),
+              ),
             ),
           )
           .limit(1);
@@ -303,7 +307,7 @@ const _getBlocks = async (
             includeOrphaned
               ? whereRange
               : and(whereRange, isNull(l2Block.orphan_timestamp)),
-            eq(globalVariables.version, parseInt(CURRENT_ROLLUP_VERSION)),
+            eq(l2Block.version, parseInt(CURRENT_ROLLUP_VERSION)),
           ),
         )
         .orderBy(desc(l2Block.height))

--- a/services/explorer-api/src/svcs/database/controllers/l2block/get-latest.ts
+++ b/services/explorer-api/src/svcs/database/controllers/l2block/get-latest.ts
@@ -1,11 +1,7 @@
 import { getDb as db } from "@chicmoz-pkg/postgres-helper";
 import { ChicmozL2BlockLight } from "@chicmoz-pkg/types";
 import { and, desc, eq, isNull } from "drizzle-orm";
-import {
-  globalVariables,
-  header,
-  l2Block,
-} from "../../../database/schema/l2block/index.js";
+import { l2Block } from "../../../database/schema/l2block/index.js";
 import { CURRENT_ROLLUP_VERSION } from "../../../../constants/versions.js";
 import { BlockQueryOptions, getBlock } from "./get-block.js";
 
@@ -26,9 +22,7 @@ export const getLatestHeight = async (
       ? db()
           .select({ height: l2Block.height })
           .from(l2Block)
-          .innerJoin(header, eq(l2Block.hash, header.blockHash))
-          .innerJoin(globalVariables, eq(header.id, globalVariables.headerId))
-          .where(eq(globalVariables.version, parseInt(CURRENT_ROLLUP_VERSION)))
+          .where(eq(l2Block.version, parseInt(CURRENT_ROLLUP_VERSION)))
           .orderBy(desc(l2Block.height))
           .limit(1)
       : db()
@@ -37,11 +31,9 @@ export const getLatestHeight = async (
           .where(
             and(
               isNull(l2Block.orphan_timestamp),
-              eq(globalVariables.version, parseInt(CURRENT_ROLLUP_VERSION)),
+              eq(l2Block.version, parseInt(CURRENT_ROLLUP_VERSION)),
             ),
           )
-          .innerJoin(header, eq(l2Block.hash, header.blockHash))
-          .innerJoin(globalVariables, eq(header.id, globalVariables.headerId))
           .orderBy(desc(l2Block.height))
           .limit(1)
   ).execute();

--- a/services/explorer-api/src/svcs/database/controllers/l2block/stats.ts
+++ b/services/explorer-api/src/svcs/database/controllers/l2block/stats.ts
@@ -14,11 +14,10 @@ export const getAverageFees = async (): Promise<string> => {
     })
     .from(header)
     .innerJoin(l2Block, eq(header.blockHash, l2Block.hash))
-    .innerJoin(globalVariables, eq(header.id, globalVariables.headerId))
     .where(
       and(
         isNull(l2Block.orphan_timestamp),
-        eq(globalVariables.version, parseInt(CURRENT_ROLLUP_VERSION)),
+        eq(l2Block.version, parseInt(CURRENT_ROLLUP_VERSION)),
       ),
     )
     .execute();
@@ -38,7 +37,7 @@ export const getAverageBlockTime = async (): Promise<string> => {
     .where(
       and(
         isNull(l2Block.orphan_timestamp),
-        eq(globalVariables.version, parseInt(CURRENT_ROLLUP_VERSION)),
+        eq(l2Block.version, parseInt(CURRENT_ROLLUP_VERSION)),
       ),
     )
     .execute();

--- a/services/explorer-api/src/svcs/database/controllers/l2block/store.ts
+++ b/services/explorer-api/src/svcs/database/controllers/l2block/store.ts
@@ -39,6 +39,7 @@ export const store = async (
     await dbTx.insert(l2Block).values({
       hash: block.hash,
       height: BigInt(block.header.globalVariables.blockNumber),
+      version: block.header.globalVariables.version,
       orphan_timestamp: block.orphan?.timestamp ?? null,
       orphan_hasOrphanedParent: block.orphan?.hasOrphanedParent ?? false,
     });

--- a/services/explorer-api/src/svcs/database/controllers/l2contract/get-contract-instances.ts
+++ b/services/explorer-api/src/svcs/database/controllers/l2contract/get-contract-instances.ts
@@ -155,13 +155,11 @@ export const getL2DeployedContractInstances = async ({
       ),
     )
     .innerJoin(l2Block, eq(l2Block.hash, l2ContractInstanceDeployed.blockHash))
-    .innerJoin(header, eq(l2Block.hash, header.blockHash))
-    .innerJoin(globalVariables, eq(header.id, globalVariables.headerId))
     .where(
       and(
         whereRange,
         isNull(l2Block.orphan_timestamp),
-        eq(globalVariables.version, parseInt(CURRENT_ROLLUP_VERSION)),
+        eq(l2Block.version, parseInt(CURRENT_ROLLUP_VERSION)),
       ),
     )
     .orderBy(DEFAULT_SORT)

--- a/services/explorer-api/src/svcs/database/controllers/l2contract/get-registered-contract-class.ts
+++ b/services/explorer-api/src/svcs/database/controllers/l2contract/get-registered-contract-class.ts
@@ -5,11 +5,11 @@ import {
 } from "@chicmoz-pkg/types";
 import { and, desc, eq, isNull } from "drizzle-orm";
 import { DB_MAX_CONTRACTS } from "../../../../environment.js";
-import { globalVariables, header, l2Block } from "../../schema/index.js";
+import { l2Block } from "../../schema/index.js";
 import { CURRENT_ROLLUP_VERSION } from "../../../../constants/versions.js";
 import { l2ContractClassRegistered } from "../../schema/l2contract/index.js";
 import { getContractClassRegisteredColumns } from "./utils.js";
-import {z} from "zod";
+import { z } from "zod";
 
 export const getL2RegisteredContractClass = async (
   contractClassId: ChicmozL2ContractClassRegisteredEvent["contractClassId"],
@@ -41,9 +41,9 @@ export const getL2RegisteredContractClasses = async ({
   }
   const whereQuery = version
     ? and(
-      eq(l2ContractClassRegistered.contractClassId, contractClassId),
-      eq(l2ContractClassRegistered.version, version)
-    )
+        eq(l2ContractClassRegistered.contractClassId, contractClassId),
+        eq(l2ContractClassRegistered.version, version),
+      )
     : eq(l2ContractClassRegistered.contractClassId, contractClassId);
   const limit = version ? 1 : DB_MAX_CONTRACTS;
 
@@ -71,12 +71,10 @@ export const getLatestL2RegisteredContractClasses = async (): Promise<
     })
     .from(l2ContractClassRegistered)
     .innerJoin(l2Block, eq(l2Block.hash, l2ContractClassRegistered.blockHash))
-    .innerJoin(header, eq(l2Block.hash, header.blockHash))
-    .innerJoin(globalVariables, eq(header.id, globalVariables.headerId))
     .where(
       and(
         isNull(l2Block.orphan_timestamp),
-        eq(globalVariables.version, parseInt(CURRENT_ROLLUP_VERSION)),
+        eq(l2Block.version, parseInt(CURRENT_ROLLUP_VERSION)),
       ),
     )
     .orderBy(desc(l2ContractClassRegistered.version), desc(l2Block.height))

--- a/services/explorer-api/src/svcs/database/controllers/l2contract/stats.ts
+++ b/services/explorer-api/src/svcs/database/controllers/l2contract/stats.ts
@@ -13,12 +13,10 @@ export const getTotalContracts = async (): Promise<number> => {
     .select({ count: count() })
     .from(l2ContractClassRegistered)
     .innerJoin(l2Block, eq(l2ContractClassRegistered.blockHash, l2Block.hash))
-    .innerJoin(header, eq(header.blockHash, l2Block.hash))
-    .innerJoin(globalVariables, eq(globalVariables.headerId, header.id))
     .where(
       and(
         isNull(l2Block.orphan_timestamp),
-        eq(globalVariables.version, parseInt(CURRENT_ROLLUP_VERSION)),
+        eq(l2Block.version, parseInt(CURRENT_ROLLUP_VERSION)),
       ),
     )
     .execute();
@@ -39,7 +37,7 @@ export const getTotalContractsLast24h = async (): Promise<number> => {
         gt(globalVariables.timestamp, Date.now() - ONE_DAY),
         lt(globalVariables.timestamp, Date.now()),
         isNull(l2Block.orphan_timestamp),
-        eq(globalVariables.version, parseInt(CURRENT_ROLLUP_VERSION)),
+        eq(l2Block.version, parseInt(CURRENT_ROLLUP_VERSION)),
       ),
     )
     .execute();

--- a/services/explorer-api/src/svcs/database/controllers/ui/tables.ts
+++ b/services/explorer-api/src/svcs/database/controllers/ui/tables.ts
@@ -55,7 +55,7 @@ export const getBlocksForUiTable = async ({
       and(
         whereRange,
         isNull(l2Block.orphan_timestamp),
-        eq(globalVariables.version, parseInt(CURRENT_ROLLUP_VERSION)),
+        eq(l2Block.version, parseInt(CURRENT_ROLLUP_VERSION)),
       ),
     )
     .orderBy(desc(l2Block.height))
@@ -187,7 +187,7 @@ export const getTxEffectForUiTable = async (
             and(
               getBlocksWhereRange({ from: args.from, to: args.to }),
               isNull(l2Block.orphan_timestamp),
-              eq(globalVariables.version, parseInt(CURRENT_ROLLUP_VERSION)),
+              eq(l2Block.version, parseInt(CURRENT_ROLLUP_VERSION)),
             ),
           )
           .orderBy(desc(l2Block.height), desc(txEffect.index))
@@ -197,7 +197,7 @@ export const getTxEffectForUiTable = async (
           .where(
             and(
               isNull(l2Block.orphan_timestamp),
-              eq(globalVariables.version, parseInt(CURRENT_ROLLUP_VERSION)),
+              eq(l2Block.version, parseInt(CURRENT_ROLLUP_VERSION)),
             ),
           )
           .orderBy(desc(l2Block.height), desc(txEffect.index))
@@ -208,7 +208,7 @@ export const getTxEffectForUiTable = async (
       whereQuery = joinQuery.where(
         and(
           eq(l2Block.height, args.blockHeight),
-          eq(globalVariables.version, parseInt(CURRENT_ROLLUP_VERSION)),
+          eq(l2Block.version, parseInt(CURRENT_ROLLUP_VERSION)),
         ),
       );
       break;

--- a/services/explorer-api/src/svcs/database/schema/l2block/root.ts
+++ b/services/explorer-api/src/svcs/database/schema/l2block/root.ts
@@ -9,22 +9,31 @@ import {
 } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
 
-import { generateTreeTable } from "../utils.js";
+import { generateTreeTable, generateFrNumberColumn } from "../utils.js";
 
 export const l2Block = pgTable(
   "l2Block",
   {
     hash: varchar("hash").primaryKey().notNull().$type<HexString>(),
     height: bigint("height", { mode: "bigint" }).notNull(),
+    version: generateFrNumberColumn("version").notNull(),
     orphan_timestamp: timestamp("orphan_timestamp"),
     orphan_hasOrphanedParent: boolean("orphan_hasOrphanedParent"),
   },
   (t) => ({
     heightIdx: index("height_idx").on(t.height),
+    versionIdx: index("l2block_version_idx").on(t.version),
+    heightVersionIdx: index("l2block_height_version_idx").on(
+      t.height,
+      t.version,
+    ),
     orphanTimestampIdx: index("orphan_timestamp_idx")
       .on(t.orphan_timestamp)
       .where(sql`${t.orphan_timestamp} IS NOT NULL`),
-    heightOrphanIdx: index("height_orphan_idx").on(t.height, t.orphan_timestamp),
+    heightOrphanIdx: index("height_orphan_idx").on(
+      t.height,
+      t.orphan_timestamp,
+    ),
   }),
 );
 


### PR DESCRIPTION
## Summary
- Add version column directly to l2Block table to eliminate expensive joins
- Update all 20+ queries to use direct version filtering instead of joining through globalVariables
- Create migration to populate existing data and add performance indexes

## Performance Impact
- Eliminates expensive join path: l2Block → header → globalVariables
- Reduces API response times from 7-9 seconds back to acceptable levels
- Affects all core endpoints: stats, search, contract operations, UI tables

## Changes
- Added version column to l2Block schema with proper indexing
- Created migration to populate existing data from globalVariables table
- Updated block insertion logic to include version field
- Optimized 20+ database queries across 10 controller files
- Removed unnecessary joins where only version filtering was needed
