### PR TITLE
fix block time in blocks page

### DIFF
--- a/k8s/production/aztec-listener/testnet/deployment.yaml
+++ b/k8s/production/aztec-listener/testnet/deployment.yaml
@@ -38,7 +38,7 @@ spec:
           resources:
             limits:
               memory: 2000Mi
-              cpu: 500m
+              cpu: 1000m
           envFrom:
             - configMapRef:
                 name: postgres-config-global

--- a/services/explorer-ui/src/components/block-countdown-progress.tsx
+++ b/services/explorer-ui/src/components/block-countdown-progress.tsx
@@ -107,10 +107,10 @@ export const BlockCountdownProgress: FC<BlockCountdownProgressProps> = ({
     }
 
     if (isOverdue) {
-      return `should have arrived ${formatDuration(timeLeft / 1000, true)} ago`;
+      return `should have arrived ${formatDuration(timeLeft, true)} ago`;
     }
 
-    return `in ${formatDuration(timeLeft / 1000, true)}`;
+    return `in ${formatDuration(timeLeft, true)}`;
   };
 
   return (

--- a/services/explorer-ui/src/hooks/system-health.ts
+++ b/services/explorer-ui/src/hooks/system-health.ts
@@ -48,7 +48,7 @@ const evaluateHealth = ({
   const evaluations: ComponentHealth[] = [];
   const reasonableTimeStamp = Date.now() - REASONABLE_API_LIVENESS_TIME;
   const reasonableTimeString = formatDuration(
-    REASONABLE_API_LIVENESS_TIME / 1000
+    REASONABLE_API_LIVENESS_TIME
   );
 
   const isApiConnectionHealthy = !!lastSuccessfulRequest;

--- a/services/explorer-ui/src/lib/utils.ts
+++ b/services/explorer-ui/src/lib/utils.ts
@@ -73,7 +73,8 @@ const intervals = [
   { label: "second", seconds: 1, shortLabel: "sec" },
 ];
 
-export const formatDuration = (durationSeconds: number, short?: boolean) => {
+export const formatDuration = (durationMilliseconds: number, short?: boolean) => {
+  const durationSeconds = durationMilliseconds / 1000
   for (const interval of intervals) {
     const count = Math.floor(durationSeconds / interval.seconds);
     if (count >= 1) {

--- a/services/explorer-ui/src/pages/block/index.tsx
+++ b/services/explorer-ui/src/pages/block/index.tsx
@@ -71,7 +71,7 @@ export const Blocks: FC = () => {
   } = useAvarageBlockTime();
 
   const averageBlockTimeFormatted = formatDuration(
-    Number(avarageBlockTime) / 1000,
+    Number(avarageBlockTime),
   );
 
   return (

--- a/services/explorer-ui/src/pages/block/index.tsx
+++ b/services/explorer-ui/src/pages/block/index.tsx
@@ -71,7 +71,7 @@ export const Blocks: FC = () => {
   } = useAvarageBlockTime();
 
   const averageBlockTimeFormatted = formatDuration(
-    Number(avarageBlockTime),
+    Number(avarageBlockTime) / 1000,
   );
 
   return (

--- a/services/explorer-ui/src/pages/landing/index.tsx
+++ b/services/explorer-ui/src/pages/landing/index.tsx
@@ -171,7 +171,7 @@ export const Landing: FC = () => {
               error={errorAvarageBlockTime}
               data={
                 avarageBlockTimeMs
-                  ? formatDuration(Number(avarageBlockTimeMs) / 1000, true)
+                  ? formatDuration(Number(avarageBlockTimeMs), true)
                   : "calculating..."
               }
             />


### PR DESCRIPTION
Fixes display of average block time to correctly divide the miliseconds