### PR TITLE
Set correct eth block poll interval in listener

### DIFF
--- a/services/ethereum-listener/src/environment.ts
+++ b/services/ethereum-listener/src/environment.ts
@@ -4,7 +4,7 @@ import {
 } from "@chicmoz-pkg/types";
 
 export const BLOCK_POLL_INTERVAL_MS =
-  Number(process.env.BLOCK_POLL_INTERVAL_MS) || 500;
+  Number(process.env.BLOCK_INTERVAL_MS) || 5000;
 export const LISTEN_FOR_BLOCKS = process.env.LISTEN_FOR_BLOCKS === "true";
 export const GENESIS_CATCHUP = process.env.GENESIS_CATCHUP === "true";
 export const LISTENER_DISABLED = process.env.LISTENER_DISABLED === "true";

--- a/services/ethereum-listener/src/environment.ts
+++ b/services/ethereum-listener/src/environment.ts
@@ -4,7 +4,7 @@ import {
 } from "@chicmoz-pkg/types";
 
 export const BLOCK_POLL_INTERVAL_MS =
-  Number(process.env.BLOCK_INTERVAL_MS) || 500;
+  Number(process.env.BLOCK_POLL_INTERVAL_MS) || 500;
 export const LISTEN_FOR_BLOCKS = process.env.LISTEN_FOR_BLOCKS === "true";
 export const GENESIS_CATCHUP = process.env.GENESIS_CATCHUP === "true";
 export const LISTENER_DISABLED = process.env.LISTENER_DISABLED === "true";


### PR DESCRIPTION
Correctly set the ethereum listener to only poll blocks every 5 seconds, also update the default value to 5 seconds.