### PR TITLE
bug: attester fetching

### DIFF
--- a/services/ethereum-listener/src/environment.ts
+++ b/services/ethereum-listener/src/environment.ts
@@ -1,7 +1,4 @@
-import {
-  type L2NetworkId,
-  l2NetworkIdSchema,
-} from "@chicmoz-pkg/types";
+import { type L2NetworkId, l2NetworkIdSchema } from "@chicmoz-pkg/types";
 
 export const BLOCK_POLL_INTERVAL_MS =
   Number(process.env.BLOCK_POLL_INTERVAL_MS) || 5000;
@@ -17,5 +14,25 @@ export const ETHEREUM_WS_RPC_URL =
 export const ETHEREUM_ALCHEMY_HTTP_URL = process.env.ETHEREUM_ALCHEMY_HTTP_URL;
 
 export const L2_NETWORK_ID: L2NetworkId = l2NetworkIdSchema.parse(
-  process.env.L2_NETWORK_ID
+  process.env.L2_NETWORK_ID,
+);
+
+// Attesters calls
+export const BATCH_SIZE = parseInt(process.env.ATTESTER_BATCH_SIZE ?? "5", 10);
+export const BATCH_DELAY_MS = parseInt(
+  process.env.BATCH_DELAY_MS ?? "1000",
+  10,
+);
+export const MAX_RETRIES = parseInt(process.env.MAX_RETRIES ?? "3", 10);
+export const INITIAL_BACKOFF_MS = parseInt(
+  process.env.INITIAL_BACKOFF_MS ?? "1000",
+  10,
+);
+export const CIRCUIT_BREAKER_THRESHOLD = parseInt(
+  process.env.CIRCUIT_BREAKER_THRESHOLD ?? "5",
+  10,
+);
+export const CIRCUIT_BREAKER_TIMEOUT_MS = parseInt(
+  process.env.CIRCUIT_BREAKER_TIMEOUT_MS ?? "30000",
+  10,
 );

--- a/services/ethereum-listener/src/network-client/client/get-attester-view.ts
+++ b/services/ethereum-listener/src/network-client/client/get-attester-view.ts
@@ -127,14 +127,14 @@ const fetchAllAttesters = async (
 ): Promise<ChicmozL1L2Validator[]> => {
   const attesters: ChicmozL1L2Validator[] = [];
   const totalBatches = Math.ceil(totalCount / BATCH_SIZE);
+  const startTime = Date.now();
 
   logger.info(
-    `Processing ${totalCount} attesters in ${totalBatches} batches with ${BATCH_DELAY_MS}ms delays`,
+    `🔍 Starting: ${totalCount} attesters in ${totalBatches} batches (${BATCH_DELAY_MS}ms delays)`,
   );
 
   for (let batchStart = 0; batchStart < totalCount; batchStart += BATCH_SIZE) {
     const batchNumber = Math.floor(batchStart / BATCH_SIZE) + 1;
-    logger.info(`Processing batch ${batchNumber}/${totalBatches}`);
 
     const batchAttesters = await processBatchWithRetry(
       rollupAddress,
@@ -144,12 +144,30 @@ const fetchAllAttesters = async (
     );
     attesters.push(...batchAttesters);
 
+    // Log progress every 100 batches or on completion
+    if (batchNumber % 100 === 0 || batchNumber === totalBatches) {
+      const totalProgress = ((batchNumber / totalBatches) * 100).toFixed(1);
+      const elapsedTime = (Date.now() - startTime) / 1000;
+      const estimatedTotal = (elapsedTime * totalBatches) / batchNumber;
+      const estimatedRemaining = Math.max(0, estimatedTotal - elapsedTime);
+
+      logger.info(
+        `🔍 Batch ${batchNumber}/${totalBatches} (${totalProgress}%) | ` +
+          `Attesters: ${attesters.length}/${totalCount} | ` +
+          `ETA: ${Math.round(estimatedRemaining)}s`,
+      );
+    }
+
     // Add delay between batches (except for the last batch)
     if (batchStart + BATCH_SIZE < totalCount) {
-      logger.info(`Waiting ${BATCH_DELAY_MS}ms before next batch`);
       await sleep(BATCH_DELAY_MS);
     }
   }
+
+  const totalDuration = (Date.now() - startTime) / 1000;
+  logger.info(
+    `🔍 Completed: ${attesters.length}/${totalCount} attesters in ${Math.round(totalDuration)}s`,
+  );
 
   return attesters;
 };

--- a/services/ethereum-listener/src/network-client/client/get-attester-view.ts
+++ b/services/ethereum-listener/src/network-client/client/get-attester-view.ts
@@ -1,0 +1,320 @@
+import { RollupAbi } from "@aztec/l1-artifacts";
+import {
+  ChicmozL1L2Validator,
+  chicmozL1L2ValidatorSchema,
+} from "@chicmoz-pkg/types";
+import { emit } from "../../events/index.js";
+import { logger } from "../../logger.js";
+import { AztecContracts } from "../contracts/utils.js";
+import { getPublicHttpBackupClient, getPublicHttpClient } from "./index.js";
+import {
+  BATCH_DELAY_MS,
+  BATCH_SIZE,
+  CIRCUIT_BREAKER_THRESHOLD,
+  CIRCUIT_BREAKER_TIMEOUT_MS,
+  INITIAL_BACKOFF_MS,
+  MAX_RETRIES,
+} from "../../environment.js";
+export { startContractWatchers as watchContractsEvents } from "../contracts/index.js";
+
+type AttesterView = {
+  status: number;
+  effectiveBalance: bigint;
+  exit: {
+    withdrawalId: bigint;
+    amount: bigint;
+    exitableAt: bigint;
+    recipientOrWithdrawer: `0x${string}`;
+    isRecipient: boolean;
+    exists: boolean;
+  };
+  config: {
+    publicKey: {
+      x: bigint;
+      y: bigint;
+    };
+    withdrawer: `0x${string}`;
+  };
+};
+
+let latestPublishedHeight = 0n;
+let consecutiveFailures = 0;
+let circuitBreakerOpenUntil = 0;
+
+export const queryStakingStateAndEmitUpdates = async ({
+  contracts,
+  latestHeight,
+}: {
+  contracts: AztecContracts;
+  latestHeight: bigint;
+}): Promise<void> => {
+  if (latestHeight <= latestPublishedHeight) {
+    logger.info(`Skipping - height ${latestHeight} already processed`);
+    return;
+  }
+
+  const attesterCount = await getAttesterCount(
+    contracts.rollup.address,
+    latestHeight,
+  );
+  logger.info(`Found ${attesterCount} active attesters`);
+
+  if (attesterCount === 0) {
+    await emit.l1Validator([]);
+    latestPublishedHeight = latestHeight;
+    return;
+  }
+
+  const indexOffset = await determineIndexOffset(contracts.rollup.address);
+  const attesters = await fetchAllAttesters(
+    contracts.rollup.address,
+    attesterCount,
+    indexOffset,
+  );
+
+  await emit.l1Validator(attesters);
+  latestPublishedHeight = latestHeight;
+};
+
+const getAttesterCount = async (
+  rollupAddress: `0x${string}`,
+  blockNumber: bigint,
+): Promise<number> => {
+  const count = await getPublicHttpClient().readContract({
+    address: rollupAddress,
+    abi: RollupAbi,
+    blockNumber,
+    functionName: "getActiveAttesterCount",
+  });
+  return Number(count);
+};
+
+const determineIndexOffset = async (
+  rollupAddress: `0x${string}`,
+): Promise<number> => {
+  const client = getPublicHttpBackupClient() ?? getPublicHttpClient();
+
+  try {
+    await client.readContract({
+      address: rollupAddress,
+      abi: RollupAbi,
+      functionName: "getAttesterAtIndex",
+      args: [0n],
+    });
+    logger.info("Using 0-based indexing");
+    return 0;
+  } catch {
+    try {
+      await client.readContract({
+        address: rollupAddress,
+        abi: RollupAbi,
+        functionName: "getAttesterAtIndex",
+        args: [1n],
+      });
+      logger.info("Using 1-based indexing");
+      return 1;
+    } catch {
+      logger.warn("Unable to determine indexing - assuming 0-based");
+      return 0;
+    }
+  }
+};
+
+const fetchAllAttesters = async (
+  rollupAddress: `0x${string}`,
+  totalCount: number,
+  indexOffset: number,
+): Promise<ChicmozL1L2Validator[]> => {
+  const attesters: ChicmozL1L2Validator[] = [];
+  const totalBatches = Math.ceil(totalCount / BATCH_SIZE);
+
+  logger.info(
+    `Processing ${totalCount} attesters in ${totalBatches} batches with ${BATCH_DELAY_MS}ms delays`,
+  );
+
+  for (let batchStart = 0; batchStart < totalCount; batchStart += BATCH_SIZE) {
+    const batchNumber = Math.floor(batchStart / BATCH_SIZE) + 1;
+    logger.info(`Processing batch ${batchNumber}/${totalBatches}`);
+
+    const batchAttesters = await processBatchWithRetry(
+      rollupAddress,
+      batchStart,
+      totalCount,
+      indexOffset,
+    );
+    attesters.push(...batchAttesters);
+
+    // Add delay between batches (except for the last batch)
+    if (batchStart + BATCH_SIZE < totalCount) {
+      logger.info(`Waiting ${BATCH_DELAY_MS}ms before next batch`);
+      await sleep(BATCH_DELAY_MS);
+    }
+  }
+
+  return attesters;
+};
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+const isCircuitBreakerOpen = (): boolean => {
+  return Date.now() < circuitBreakerOpenUntil;
+};
+
+const openCircuitBreaker = (): void => {
+  circuitBreakerOpenUntil = Date.now() + CIRCUIT_BREAKER_TIMEOUT_MS;
+  logger.warn(
+    `Circuit breaker opened for ${CIRCUIT_BREAKER_TIMEOUT_MS}ms after ${consecutiveFailures} consecutive failures`,
+  );
+};
+
+const resetCircuitBreaker = (): void => {
+  consecutiveFailures = 0;
+  circuitBreakerOpenUntil = 0;
+};
+
+const processBatchWithRetry = async (
+  rollupAddress: `0x${string}`,
+  batchStart: number,
+  totalCount: number,
+  indexOffset: number,
+): Promise<ChicmozL1L2Validator[]> => {
+  if (isCircuitBreakerOpen()) {
+    logger.warn(`Circuit breaker is open, skipping batch ${batchStart}`);
+    return [];
+  }
+
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const result = await processBatch(
+        rollupAddress,
+        batchStart,
+        totalCount,
+        indexOffset,
+      );
+      resetCircuitBreaker();
+      return result;
+    } catch (error) {
+      lastError = error;
+      if (attempt === MAX_RETRIES) {
+        break;
+      }
+
+      const backoffDelay = INITIAL_BACKOFF_MS * Math.pow(2, attempt - 1);
+      logger.warn(
+        `Batch attempt ${attempt}/${MAX_RETRIES} failed, retrying in ${backoffDelay}ms: ${String(error)}`,
+      );
+      await sleep(backoffDelay);
+    }
+  }
+
+  consecutiveFailures++;
+  if (consecutiveFailures >= CIRCUIT_BREAKER_THRESHOLD) {
+    openCircuitBreaker();
+  }
+
+  logger.error(
+    `All ${MAX_RETRIES} attempts failed for batch ${batchStart}: ${String(lastError)}`,
+  );
+  return [];
+};
+
+const processBatch = async (
+  rollupAddress: `0x${string}`,
+  batchStart: number,
+  totalCount: number,
+  indexOffset: number,
+): Promise<ChicmozL1L2Validator[]> => {
+  const batchEnd = Math.min(batchStart + BATCH_SIZE, totalCount);
+
+  const addresses = await fetchAttesterAddresses(
+    rollupAddress,
+    batchStart,
+    batchEnd,
+    indexOffset,
+  );
+  const views = await fetchAttesterViews(rollupAddress, addresses);
+
+  return createValidatorObjects(rollupAddress, addresses, views);
+};
+
+const fetchAttesterAddresses = async (
+  rollupAddress: `0x${string}`,
+  start: number,
+  end: number,
+  indexOffset: number,
+): Promise<`0x${string}`[]> => {
+  const client = getPublicHttpBackupClient() ?? getPublicHttpClient();
+  const promises = [];
+
+  for (let i = start; i < end; i++) {
+    const contractIndex = i + indexOffset;
+    promises.push(
+      client
+        .readContract({
+          address: rollupAddress,
+          abi: RollupAbi,
+          functionName: "getAttesterAtIndex",
+          args: [BigInt(contractIndex)],
+        })
+        .catch((error: unknown) => {
+          logger.warn(
+            `Failed to get attester at index ${contractIndex}: ${String(error)}`,
+          );
+          return null;
+        }),
+    );
+  }
+
+  const results = await Promise.all(promises);
+  return results.filter((addr): addr is `0x${string}` => addr !== null);
+};
+
+const fetchAttesterViews = async (
+  rollupAddress: `0x${string}`,
+  addresses: `0x${string}`[],
+): Promise<AttesterView[]> => {
+  const promises = addresses.map((address) =>
+    getPublicHttpClient().readContract({
+      address: rollupAddress,
+      abi: RollupAbi,
+      functionName: "getAttesterView",
+      args: [address],
+    }),
+  );
+
+  return Promise.all(promises) as Promise<AttesterView[]>;
+};
+
+const createValidatorObjects = (
+  rollupAddress: `0x${string}`,
+  addresses: `0x${string}`[],
+  views: AttesterView[],
+): ChicmozL1L2Validator[] => {
+  const validators: ChicmozL1L2Validator[] = [];
+
+  for (let i = 0; i < addresses.length; i++) {
+    const address = addresses[i];
+    const view = views[i];
+
+    if (!view) {
+      logger.warn(`No view data for attester ${address}`);
+      continue;
+    }
+
+    validators.push(
+      chicmozL1L2ValidatorSchema.parse({
+        rollupAddress,
+        attester: address,
+        stake: view.effectiveBalance,
+        withdrawer: view.config.withdrawer,
+        proposer: view.config.withdrawer,
+        status: view.status,
+      }),
+    );
+  }
+
+  return validators;
+};

--- a/services/ethereum-listener/src/network-client/contracts/index.ts
+++ b/services/ethereum-listener/src/network-client/contracts/index.ts
@@ -9,11 +9,11 @@ import { controllers as dbControllers } from "../../svcs/database/index.js";
 import {
   getLatestFinalizedHeight,
   getPublicHttpClient,
-  queryStakingStateAndEmitUpdates,
 } from "../client/index.js";
 import { getAllContractsEvents } from "./get-events.js";
 import { AztecContracts, UnwatchCallback, getTypedContract } from "./utils.js";
 import { watchAllContractsEvents } from "./watch-events.js";
+import { queryStakingStateAndEmitUpdates } from "../client/get-attester-view.js";
 
 export const getL1Contracts = async (): Promise<AztecContracts> => {
   const dbContracts = await dbControllers.getL1Contracts();
@@ -56,16 +56,18 @@ export const startContractWatchers = async (): Promise<UnwatchCallback> => {
 export const getFinalizedContractEvents = async () => {
   const contracts = await getL1Contracts();
   const latestHeight = await getLatestFinalizedHeight();
-  const [, allContractsEventsRes] = await Promise.all([
-    queryStakingStateAndEmitUpdates({
-      contracts,
-      latestHeight,
-    }),
-    getAllContractsEvents({
-      contracts,
-      latestHeight,
-      toBlock: "finalized",
-    }),
-  ]);
-  return allContractsEventsRes;
+  return getAllContractsEvents({
+    contracts,
+    latestHeight,
+    toBlock: "finalized",
+  });
+};
+
+export const getAttestersView = async () => {
+  const contracts = await getL1Contracts();
+  const latestHeight = await getLatestFinalizedHeight();
+  return queryStakingStateAndEmitUpdates({
+    contracts,
+    latestHeight,
+  });
 };

--- a/services/ethereum-listener/src/svcs/index.ts
+++ b/services/ethereum-listener/src/svcs/index.ts
@@ -3,6 +3,7 @@ import { databaseService } from "./database/index.js";
 import { messageBusService } from "./message-bus/index.js";
 import { ethereumNetworkClientService } from "./network-client/index.js";
 import { finalizedEventsPollerService } from "./poller-finalized-events/index.js";
+import { attesterPollerService } from "./poller-attester-updates/index.js";
 import { eventsWatcherService } from "./events-watcher/index.js";
 
 export const services: MicroserviceBaseSvc[] = [
@@ -11,4 +12,5 @@ export const services: MicroserviceBaseSvc[] = [
   ethereumNetworkClientService,
   eventsWatcherService,
   finalizedEventsPollerService,
+  attesterPollerService,
 ];

--- a/services/ethereum-listener/src/svcs/poller-attester-updates/index.ts
+++ b/services/ethereum-listener/src/svcs/poller-attester-updates/index.ts
@@ -1,0 +1,106 @@
+import { MicroserviceBaseSvc } from "@chicmoz-pkg/microservice-base";
+import { logger } from "../../logger.js";
+import { getAttestersView } from "../../network-client/contracts/index.js";
+
+let started = false;
+let timeoutId: NodeJS.Timeout | undefined;
+let isUpdating = false;
+let lastUpdateStartTime = 0;
+let lastUpdateDuration = 0;
+
+// Poll attesters every 15 minutes (900,000ms) instead of every minute
+const ATTESTER_POLL_INTERVAL_MS = 15 * 60 * 1000;
+
+// eslint-disable-next-line @typescript-eslint/require-await
+const init = async () => {
+  if (started) {
+    return;
+  }
+  started = true;
+
+  // Run immediately on startup
+  updateAttesters().catch((e) => {
+    logger.error(`🔍 error on initial attester update: ${(e as Error).stack}`);
+  });
+
+  // Then schedule regular updates
+  timeoutId = setInterval(() => {
+    updateAttesters().catch((e) => {
+      logger.error(`🔍 error updating attesters: ${(e as Error).stack}`);
+    });
+  }, ATTESTER_POLL_INTERVAL_MS);
+
+  logger.info(
+    `🔍 Attester poller started - will update every ${ATTESTER_POLL_INTERVAL_MS / 1000 / 60} minutes`,
+  );
+};
+
+const updateAttesters = async () => {
+  if (isUpdating) {
+    const timeSinceStart = Date.now() - lastUpdateStartTime;
+    const estimatedTimeLeft = Math.max(0, lastUpdateDuration - timeSinceStart);
+
+    logger.warn(
+      `🔍 Skipping attester update - already in progress for ${Math.round(timeSinceStart / 1000)}s. ` +
+        `Estimated time remaining: ${Math.round(estimatedTimeLeft / 1000)}s`,
+    );
+    return;
+  }
+
+  isUpdating = true;
+  lastUpdateStartTime = Date.now();
+
+  try {
+    logger.info("🔍 Starting attester view update...");
+
+    await getAttestersView();
+
+    const duration = Date.now() - lastUpdateStartTime;
+    lastUpdateDuration = duration;
+    logger.info(
+      `🔍 Attester update completed in ${Math.round(duration / 1000)}s`,
+    );
+  } catch (error) {
+    const duration = Date.now() - lastUpdateStartTime;
+    lastUpdateDuration = duration;
+
+    if (
+      error instanceof Error &&
+      error.message === "L1 contracts not initialized"
+    ) {
+      logger.info("🔍 Waiting for contracts to be initialized...");
+    } else {
+      logger.error(
+        `🔍 Attester update failed after ${Math.round(duration / 1000)}s: ${String(error)}`,
+      );
+      throw error;
+    }
+  } finally {
+    isUpdating = false;
+  }
+};
+
+// eslint-disable-next-line @typescript-eslint/require-await
+const shutdown = async () => {
+  if (timeoutId) {
+    clearInterval(timeoutId);
+    timeoutId = undefined;
+  }
+  started = false;
+  logger.info("🔍 Attester poller stopped");
+};
+
+export const attesterPollerService: MicroserviceBaseSvc = {
+  svcId: "attesterPoller",
+  init,
+  shutdown,
+  health: () => true,
+  getConfigStr: () => {
+    const intervalMin = ATTESTER_POLL_INTERVAL_MS / 1000 / 60;
+    const status = isUpdating ? "UPDATING" : "IDLE";
+    const lastDurationMin = lastUpdateDuration
+      ? Math.round(lastUpdateDuration / 1000 / 60)
+      : "N/A";
+    return `Interval: ${intervalMin}min, Status: ${status}, Last duration: ${lastDurationMin}min`;
+  },
+};


### PR DESCRIPTION
## Summary

- Refactored attester view fetching - Cleaned up get-attester-view.ts by
extracting helper functions, improving error handling, and adding proper
TypeScript types 
- Added rate limiting and resilience - Implemented configurable
batch processing, delays between batches, exponential backoff, and circuit
breaker pattern to handle 12,604 attesters without overwhelming the server 
-Separated concerns - Moved attester updates from the main event poller to a
dedicated service that runs every 15 minutes instead of every 60 seconds,
preventing blocking of critical contract event processing 
- Added concurrency protection - Implemented locking mechanism to prevent overlapping attester update operations that could stack up when updates take longer than the polling interval

## Performance Impact

• Before: 25,211 contract calls every 60 seconds blocking event processing for
~42 minutes
• After: Same calls spread over ~42 minutes every 15 minutes, with contract
events processing independently

## Configuration

Added environment variables for fine-tuning:

• ATTESTER_BATCH_SIZE (default: 5)
• BATCH_DELAY_MS (default: 1000)
• MAX_RETRIES, INITIAL_BACKOFF_MS, circuit breaker settings

This ensures reliable attester data updates while maintaining responsive event
processing for the rest of the system