### PR TITLE
This PR adds polling of sentinel data from the Aztec node and pushes it through the MB for the validator-metrics service to store

### DIFF
--- a/k8s/local/aztec-listener/testnet/deployment.yaml
+++ b/k8s/local/aztec-listener/testnet/deployment.yaml
@@ -53,6 +53,8 @@ spec:
               value: "true"
             - name: AZTEC_DISABLE_ETERNAL_CATCHUP
               value: "true"
+            - name: AZTEC_LISTEN_FOR_SENTINEL_INFO
+              value: "true"
             - name: AZTEC_RPC_URLS
               valueFrom:
                 secretKeyRef:

--- a/packages/message-registry/src/aztec.ts
+++ b/packages/message-registry/src/aztec.ts
@@ -54,6 +54,7 @@ export type ChicmozSentinelEvent = {
 };
 
 export type ChicmozSentinelHistoryEvent = {
+  attester: string;
   sentinelHistoryEntry: SentinelHistory;
 };
 

--- a/packages/message-registry/src/aztec.ts
+++ b/packages/message-registry/src/aztec.ts
@@ -9,6 +9,8 @@ import {
   ChicmozL2RpcNodeError,
   ChicmozL2Sequencer,
   L2NetworkId,
+  SentinelHistory,
+  SentinelValidatorStats,
 } from "@chicmoz-pkg/types";
 
 export type NewBlockEvent = {
@@ -47,6 +49,15 @@ export type ChicmozSequencerEvent = {
   sequencer: ChicmozL2Sequencer;
 };
 
+export type ChicmozSentinelEvent = {
+  validatorStats: SentinelValidatorStats;
+};
+
+export type ChicmozSentinelHistoryEvent = {
+  sentinelHistoryEntry: SentinelHistory;
+};
+
+
 export type ChicmozChainInfoEvent = {
   chainInfo: ChicmozChainInfo;
 };
@@ -72,6 +83,8 @@ export type L2_MESSAGES = {
   L2_RPC_NODE_ERROR_EVENT: ChicmozL2RpcNodeErrorEvent;
   L2_RPC_NODE_ALIVE_EVENT: ChicmozL2RpcNodeAliveEvent;
   SEQUENCER_INFO_EVENT: ChicmozSequencerEvent;
+  SENTINEL_INFO_EVENT: ChicmozSentinelEvent;
+  SENTINEL_HISTORY_EVENT: ChicmozSentinelHistoryEvent;
   CHAIN_INFO_EVENT: ChicmozChainInfoEvent;
   L2_BLOCK_FINALIZATION_UPDATE_EVENT: ChicmozL2BlockFinalizationUpdateEvent;
 };

--- a/services/aztec-listener/migrations/0004_supreme_brother_voodoo.sql
+++ b/services/aztec-listener/migrations/0004_supreme_brother_voodoo.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS "slots" (
+	"network_id" varchar PRIMARY KEY NOT NULL,
+	"last_processed_slot" bigint NOT NULL
+);

--- a/services/aztec-listener/migrations/meta/0004_snapshot.json
+++ b/services/aztec-listener/migrations/meta/0004_snapshot.json
@@ -1,0 +1,113 @@
+{
+  "id": "9301ce29-3a6d-41f3-ad62-d737eb52a9e7",
+  "prevId": "2e0f96ca-fe5d-4fb6-a59a-350d99a3e150",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.heights": {
+      "name": "heights",
+      "schema": "",
+      "columns": {
+        "networkId": {
+          "name": "networkId",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "processedProposedBlockHeight": {
+          "name": "processedProposedBlockHeight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chainProposedBlockHeight": {
+          "name": "chainProposedBlockHeight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processedProvenBlockHeight": {
+          "name": "processedProvenBlockHeight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chainProvenBlockHeight": {
+          "name": "chainProvenBlockHeight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.slots": {
+      "name": "slots",
+      "schema": "",
+      "columns": {
+        "network_id": {
+          "name": "network_id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_processed_slot": {
+          "name": "last_processed_slot",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.txs_table": {
+      "name": "txs_table",
+      "schema": "",
+      "columns": {
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fee_payer": {
+          "name": "fee_payer",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_timestamp": {
+          "name": "birth_timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "EXTRACT(EPOCH FROM NOW()) * 1000"
+        },
+        "tx_state": {
+          "name": "tx_state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/services/aztec-listener/migrations/meta/_journal.json
+++ b/services/aztec-listener/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1753714930792,
       "tag": "0003_youthful_black_widow",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1759926122767,
+      "tag": "0004_supreme_brother_voodoo",
+      "breakpoints": true
     }
   ]
 }

--- a/services/aztec-listener/src/environment.ts
+++ b/services/aztec-listener/src/environment.ts
@@ -21,6 +21,10 @@ export const CHAIN_INFO_POLL_INTERVAL_MS = z.coerce
   .number()
   .default(30000)
   .parse(process.env.CHAIN_INFO_POLL_INTERVAL_MS);
+export const SENTINEL_POLL_INTERVAL_MS = z.coerce
+  .number()
+  .default(30000)
+  .parse(process.env.SENTINEL_POLL_INTERVAL_MS);
 export const MAX_BATCH_SIZE_FETCH_MISSED_BLOCKS = z.coerce
   .number()
   .default(50)
@@ -131,6 +135,9 @@ AZTEC_LISTEN_FOR_CHAIN_INFO:                               ${
 }
 CHAIN_INFO_POLL_INTERVAL_MS:                               ${
   CHAIN_INFO_POLL_INTERVAL_MS / 1000
+}s
+SENTINEL_POLL_INTERVAL_MS:                            ${
+  SENTINEL_POLL_INTERVAL_MS / 1000
 }s
 IGNORE_PROCESSED_HEIGHT:                                   ${
   IGNORE_PROCESSED_HEIGHT ? "✅" : "❌"

--- a/services/aztec-listener/src/environment.ts
+++ b/services/aztec-listener/src/environment.ts
@@ -50,6 +50,8 @@ export const AZTEC_LISTEN_FOR_PENDING_TXS =
   process.env.AZTEC_LISTEN_FOR_PENDING_TXS === "true";
 export const AZTEC_LISTEN_FOR_CHAIN_INFO =
   process.env.AZTEC_LISTEN_FOR_CHAIN_INFO === "true";
+export const AZTEC_LISTEN_FOR_SENTINEL_INFO =
+  process.env.AZTEC_LISTEN_FOR_SENTINEL_INFO === "true";
 export const AZTEC_DISABLED = process.env.AZTEC_DISABLED === "true";
 export const AZTEC_DISABLE_ETERNAL_CATCHUP = z.coerce
   .boolean()
@@ -121,10 +123,10 @@ AZTEC_LISTEN_FOR_PENDING_TXS:                              ${
 TX_POLL_INTERVAL_MS:                                       ${
   TX_POLL_INTERVAL_MS / 1000
 }s
-DROPPED_TX_VERIFICATION_INTERVAL_MS:                      ${
+DROPPED_TX_VERIFICATION_INTERVAL_MS:                       ${
   DROPPED_TX_VERIFICATION_INTERVAL_MS / 1000
 }s
-DROPPED_TX_AGE_THRESHOLD_MS:                              ${
+DROPPED_TX_AGE_THRESHOLD_MS:                               ${
   DROPPED_TX_AGE_THRESHOLD_MS / 1000
 }s
 MEMPOOL_SYNC_GRACE_PERIOD_MS:                              ${
@@ -136,7 +138,10 @@ AZTEC_LISTEN_FOR_CHAIN_INFO:                               ${
 CHAIN_INFO_POLL_INTERVAL_MS:                               ${
   CHAIN_INFO_POLL_INTERVAL_MS / 1000
 }s
-SENTINEL_POLL_INTERVAL_MS:                            ${
+AZTEC_LISTEN_FOR_SENTINEL_INFO:                            ${
+  AZTEC_LISTEN_FOR_SENTINEL_INFO ? "✅" : "❌"
+}
+SENTINEL_POLL_INTERVAL_MS:                                 ${
   SENTINEL_POLL_INTERVAL_MS / 1000
 }s
 IGNORE_PROCESSED_HEIGHT:                                   ${

--- a/services/aztec-listener/src/events/emitted/sentinel.ts
+++ b/services/aztec-listener/src/events/emitted/sentinel.ts
@@ -10,8 +10,8 @@ export const onL2SentinelInfo = async (validatorStats: SentinelValidatorStats) =
   await publishMessage("SENTINEL_INFO_EVENT", event);
 };
 
-export const onL2SentinelHistory = async (sentinelHistoryEntry: SentinelHistory) => {
-  const event = { sentinelHistoryEntry };
+export const onL2SentinelHistory = async (attester: string, sentinelHistoryEntry: SentinelHistory) => {
+  const event = { sentinelHistoryEntry, attester };
   logger.info(`🔍 publishing SENTINEL_INFO_EVENT ${jsonStringify(event)}`);
   await publishMessage("SENTINEL_HISTORY_EVENT", event);
 };

--- a/services/aztec-listener/src/events/emitted/sentinel.ts
+++ b/services/aztec-listener/src/events/emitted/sentinel.ts
@@ -1,0 +1,17 @@
+import { SentinelHistory, SentinelValidatorStats, jsonStringify } from "@chicmoz-pkg/types";
+import { logger } from "../../logger.js";
+import {
+  publishMessage,
+} from "../../svcs/message-bus/index.js";
+
+export const onL2SentinelInfo = async (validatorStats: SentinelValidatorStats) => {
+  const event = { validatorStats };
+  logger.info(`🔍 publishing SENTINEL_INFO_EVENT ${jsonStringify(event)}`);
+  await publishMessage("SENTINEL_INFO_EVENT", event);
+};
+
+export const onL2SentinelHistory = async (sentinelHistoryEntry: SentinelHistory) => {
+  const event = { sentinelHistoryEntry };
+  logger.info(`🔍 publishing SENTINEL_INFO_EVENT ${jsonStringify(event)}`);
+  await publishMessage("SENTINEL_HISTORY_EVENT", event);
+};

--- a/services/aztec-listener/src/events/emitted/sentinel.ts
+++ b/services/aztec-listener/src/events/emitted/sentinel.ts
@@ -12,6 +12,6 @@ export const onL2SentinelInfo = async (validatorStats: SentinelValidatorStats) =
 
 export const onL2SentinelHistory = async (attester: string, sentinelHistoryEntry: SentinelHistory) => {
   const event = { sentinelHistoryEntry, attester };
-  logger.info(`🔍 publishing SENTINEL_INFO_EVENT ${jsonStringify(event)}`);
+  logger.info(`🔍 publishing SENTINEL_HISTORY_EVENT ${jsonStringify(event)}`);
   await publishMessage("SENTINEL_HISTORY_EVENT", event);
 };

--- a/services/aztec-listener/src/svcs/database/schema.ts
+++ b/services/aztec-listener/src/svcs/database/schema.ts
@@ -34,7 +34,7 @@ export const txsTable = pgTable("txs_table", {
   txState: varchar("tx_state").notNull().$type<TxState>(),
 });
 
-export const slotsTable = pgTable("heights", {
+export const slotsTable = pgTable("slots", {
   networkId: varchar("network_id").primaryKey().notNull(),
-  lastProcessedSlot: bigint("last_processed_slot", { mode: "bigint" }).notNull().default(0n),
+  lastProcessedSlot: bigint("last_processed_slot", { mode: "bigint" }).notNull(),
 });

--- a/services/aztec-listener/src/svcs/database/schema.ts
+++ b/services/aztec-listener/src/svcs/database/schema.ts
@@ -33,3 +33,8 @@ export const txsTable = pgTable("txs_table", {
     .default(sql`EXTRACT(EPOCH FROM NOW()) * 1000`),
   txState: varchar("tx_state").notNull().$type<TxState>(),
 });
+
+export const slotsTable = pgTable("heights", {
+  networkId: varchar("network_id").primaryKey().notNull(),
+  lastProcessedSlot: bigint("last_processed_slot", { mode: "bigint" }).notNull().default(0n),
+});

--- a/services/aztec-listener/src/svcs/database/slots.controller.ts
+++ b/services/aztec-listener/src/svcs/database/slots.controller.ts
@@ -1,0 +1,32 @@
+import { getDb as db } from "@chicmoz-pkg/postgres-helper";
+import { eq, getTableColumns } from "drizzle-orm";
+import { L2_NETWORK_ID } from "../../environment.js";
+import { slotsTable } from "./schema.js";
+
+export async function storeLastProcessedSlot(slot: bigint) {
+  await db()
+    .update(slotsTable)
+    .set({ lastProcessedSlot: slot })
+    .where(eq(slotsTable.networkId, L2_NETWORK_ID));
+}
+
+
+export async function ensureInitializedSlots() {
+  await db()
+    .insert(slotsTable)
+    .values({
+      networkId: L2_NETWORK_ID,
+      lastProcessedSlot: 0n,
+    })
+    .onConflictDoNothing();
+}
+
+export async function getLastProcessedSlot() {
+  const result = await db()
+    .select(getTableColumns(slotsTable))
+    .from(slotsTable)
+    .where(eq(slotsTable.networkId, L2_NETWORK_ID))
+    .limit(1);
+  if (result.length === 0) {throw new Error("FATAL: slots not initialized");}
+  return result[0].lastProcessedSlot;
+}

--- a/services/aztec-listener/src/svcs/poller/network-client/index.ts
+++ b/services/aztec-listener/src/svcs/poller/network-client/index.ts
@@ -55,6 +55,7 @@ const callNodeFunction = async <K extends keyof AztecNode>(
         currentNode.instance,
         args,
       )) as Promise<ReturnType<AztecNode[K]>>;
+
       void onL2RpcNodeAlive(currentNode.url, currentNode.name);
       return result;
     },

--- a/services/aztec-listener/src/svcs/poller/network-client/index.ts
+++ b/services/aztec-listener/src/svcs/poller/network-client/index.ts
@@ -218,3 +218,5 @@ export const getBalanceOf = async (
     slot,
   ]);
 };
+
+export const getSentinelInfo = async () => callNodeFunction("getValidatorsStats")

--- a/services/aztec-listener/src/svcs/poller/pollers/sentinel-poller.ts
+++ b/services/aztec-listener/src/svcs/poller/pollers/sentinel-poller.ts
@@ -92,11 +92,11 @@ export const stopPolling = () => {
 };
 
 const publishSentinelValidatorStats = async (validatorStats: SentinelValidatorStats) => {
-  // TODO: Maybe handle this better
-  await Promise.all(validatorStats.history.map((validatorHistoryEntry: SentinelHistory) => onL2SentinelHistory(validatorStats.attester, validatorHistoryEntry)))
-
   const validatorStatsCopy: SentinelValidatorStats = { ...validatorStats, history: [] };
   await onL2SentinelInfo(validatorStatsCopy)
+
+  // TODO: Maybe handle this better
+  await Promise.all(validatorStats.history.map((validatorHistoryEntry: SentinelHistory) => onL2SentinelHistory(validatorStats.attester, validatorHistoryEntry)))
 }
 
 const fetchAndPublishSentinelInfo = async () => {

--- a/services/aztec-listener/src/svcs/poller/pollers/sentinel-poller.ts
+++ b/services/aztec-listener/src/svcs/poller/pollers/sentinel-poller.ts
@@ -1,0 +1,125 @@
+
+import { ValidatorStats } from "@aztec/stdlib/validators"
+import { SentinelActivity, sentinelValidatorStatsSchema, SentinelValidatorStats, SentinelHistory } from "@chicmoz-pkg/types";
+import { parseTimeStamp } from "@chicmoz-pkg/backend-utils"
+
+import { SENTINEL_POLL_INTERVAL_MS } from "../../../environment.js";
+import { onL2SentinelHistory, onL2SentinelInfo } from "../../../events/emitted/sentinel.js";
+
+import { logger } from "../../../logger.js";
+import { getSentinelInfo } from "../network-client/index.js";
+import { getLastProcessedSlot, storeLastProcessedSlot } from "../../database/slots.controller.js";
+
+let pollInterval: NodeJS.Timeout;
+
+const pickLatestActivity = (
+  a?: { timestamp: bigint; slot: bigint; date: string },
+  b?: { timestamp: bigint; slot: bigint; date: string }
+) =>  {
+  if (!a && !b) {return undefined;}
+  if (!a) {return b;}
+  if (!b) {return a;}
+
+  return Number(a.slot) > Number(b.slot) ? a : b;
+}
+
+const parseSentinelValidatorResponse = (sentinelValidator: ValidatorStats) => {
+
+  const { address, totalSlots, missedProposals, missedAttestations, history, lastProposal, lastAttestation } = sentinelValidator
+
+  const attestations: SentinelActivity = {
+    total: missedAttestations.total,
+    missed: missedAttestations.count,
+  }
+
+  if (lastAttestation){
+    attestations.lastSeenAt = parseTimeStamp(Number(lastAttestation.timestamp))
+    attestations.lastSeenAtSlot = lastAttestation.slot
+  }
+
+  const blocks: SentinelActivity= {
+    total: missedProposals.total,
+    missed: missedProposals.count,
+  }
+
+  if (lastProposal){
+    blocks.lastSeenAt = parseTimeStamp(Number(lastProposal.timestamp))
+    blocks.lastSeenAtSlot = lastProposal.slot
+  }
+
+  const validator:SentinelValidatorStats = {
+    attester: address.toString(),
+    history: history,
+    attestations: attestations,
+    blocks: blocks,
+    totalSlots: totalSlots,
+  }
+
+  const latest = pickLatestActivity(lastProposal, lastAttestation)
+  if (latest) {
+    validator.lastSeenAtSlot = latest.slot
+    validator.lastSeenAt = parseTimeStamp(Number(latest.timestamp))
+  }
+
+
+  return sentinelValidatorStatsSchema.parse(validator)
+
+}
+
+const filterSentinelStats = (sentinelStats: SentinelValidatorStats[], lastProcessedSlot: bigint) => {
+  return sentinelStats.filter((validatorStats: SentinelValidatorStats) => {
+    if (validatorStats.totalSlots == 0) {return false}
+
+    validatorStats.history = validatorStats.history.filter(({ slot }: SentinelHistory) => slot > lastProcessedSlot)
+
+    if (validatorStats.history.length > 0) {return true}
+
+    return false
+  })
+}
+
+
+export const startPolling = () => {
+  pollInterval = setInterval(() => {
+    void fetchAndPublishSentinelInfo();
+  }, SENTINEL_POLL_INTERVAL_MS);
+};
+
+export const stopPolling = () => {
+  if (pollInterval) {
+    clearInterval(pollInterval);
+  }
+};
+
+const publishSentinelValidatorStats = async (validatorStats: SentinelValidatorStats) => {
+  // TODO: Maybe handle this better
+  await Promise.all(validatorStats.history.map((validatorHistoryEntry: SentinelHistory) => onL2SentinelHistory(validatorHistoryEntry)))
+
+  validatorStats.history = [] //TODO: make this prettier, we dont need to dupe send the history so just make it empty for now
+  await onL2SentinelInfo(validatorStats)
+}
+
+const fetchAndPublishSentinelInfo = async () => {
+  try {
+    // If this whole thing gets waaaay to big with tis 20-30k validators might need to look at a way to look at the l1 contract and only fetch those individually
+    const sentinelInfo = await getSentinelInfo();
+    const lastProcessedSlot = await getLastProcessedSlot()
+    if (sentinelInfo.lastProcessedSlot && sentinelInfo.lastProcessedSlot > lastProcessedSlot) {
+      logger.warn("Error encountered a reorg in sentinel")
+    } 
+
+    const parsedSentinelStats = Object.values(sentinelInfo.stats).map((sentinelStats: ValidatorStats) => parseSentinelValidatorResponse(sentinelStats))
+
+    if (lastProcessedSlot > 0n) {
+      const filteredSentinelStats = filterSentinelStats(parsedSentinelStats, lastProcessedSlot)
+
+      await Promise.all(filteredSentinelStats.map((validatorStats: SentinelValidatorStats) => publishSentinelValidatorStats(validatorStats)))
+    } else {
+      await Promise.all(parsedSentinelStats.map((validatorStats: SentinelValidatorStats) => publishSentinelValidatorStats(validatorStats)))
+    }
+
+    await storeLastProcessedSlot(sentinelInfo.lastProcessedSlot!) // Can probably get away with ! here as it seems to always be returned
+  } catch (error) {
+    logger.warn("Error fetching pending txs", error);
+  }
+};

--- a/services/validator-metrics/src/events/received/index.ts
+++ b/services/validator-metrics/src/events/received/index.ts
@@ -1,9 +1,12 @@
 import { startSubscribe } from "../../svcs/message-bus/index.js";
 
 import { l1L2ValidatorHandler } from "./on-l1-l2-validator.js";
+import { sentinelHistoryHandler, sentinelInfoHandler } from "./on-sentinel-info.js";
 
 export const subscribeHandlers = async () => {
   await Promise.all([
     startSubscribe(l1L2ValidatorHandler),
+    startSubscribe(sentinelInfoHandler),
+    startSubscribe(sentinelHistoryHandler),
   ]);
 };

--- a/services/validator-metrics/src/events/received/on-sentinel-info.ts
+++ b/services/validator-metrics/src/events/received/on-sentinel-info.ts
@@ -1,0 +1,51 @@
+import { EventHandler } from "@chicmoz-pkg/message-bus";
+import {
+  ChicmozSentinelEvent,
+  ChicmozSentinelHistoryEvent,
+  generateL2TopicName,
+  getConsumerGroupId,
+} from "@chicmoz-pkg/message-registry";
+import { SERVICE_NAME } from "../../constants.js";
+import { L2_NETWORK_ID } from "../../environment.js";
+import { logger } from "../../logger.js";
+import { sentinel } from "../../svcs/database/controllers/index.js";
+
+const onSentinelInfo = async (event: ChicmozSentinelEvent) => {
+  logger.info(
+    `🤖 Sentinel info event (${event.validatorStats.attester} attester)`,
+  );
+  await sentinel.storeSentinelValidator(event.validatorStats);
+};
+
+export const sentinelInfoHandler: EventHandler = {
+  groupId: getConsumerGroupId({
+    serviceName: SERVICE_NAME,
+    networkId: L2_NETWORK_ID,
+    handlerName: "sentinelInfoHandler",
+  }),
+  topic: generateL2TopicName(
+    L2_NETWORK_ID,
+    "SENTINEL_INFO_EVENT",
+  ),
+  cb: onSentinelInfo as (arg0: unknown) => Promise<void>,
+};
+
+const onSentinelHistory = async (event: ChicmozSentinelHistoryEvent) => {
+  logger.info(
+    `🤖 Sentinel history event (${event.attester} attester)`,
+  );
+  await sentinel.storeSentinelValidatorHistoryEntry(event.attester, event.sentinelHistoryEntry);
+};
+
+export const sentinelHistoryHandler: EventHandler = {
+  groupId: getConsumerGroupId({
+    serviceName: SERVICE_NAME,
+    networkId: L2_NETWORK_ID,
+    handlerName: "sentinelHistoryHandler",
+  }),
+  topic: generateL2TopicName(
+    L2_NETWORK_ID,
+    "SENTINEL_HISTORY_EVENT",
+  ),
+  cb: onSentinelHistory as (arg0: unknown) => Promise<void>,
+};

--- a/services/validator-metrics/src/index.ts
+++ b/services/validator-metrics/src/index.ts
@@ -4,8 +4,8 @@ import {
 } from "@chicmoz-pkg/microservice-base";
 import { SERVICE_NAME } from "./constants.js";
 import { logger } from "./logger.js";
-import { start } from "./start.js";
 import { services } from "./svcs/index.js";
+import { start } from "./start.js";
 
 const formatConfigLog = () => {
   return `TODO: is this needed if each service logs?`;

--- a/services/validator-metrics/src/svcs/database/controllers/index.ts
+++ b/services/validator-metrics/src/svcs/database/controllers/index.ts
@@ -1,2 +1,3 @@
 export * as l1 from "./l1/index.js";
 export * as l2 from "./l2/index.js";
+export * as sentinel from "./sentinel/index.js";

--- a/services/validator-metrics/src/svcs/database/controllers/sentinel/store.ts
+++ b/services/validator-metrics/src/svcs/database/controllers/sentinel/store.ts
@@ -87,10 +87,9 @@ async function _store(
     await _insertOrUpdateCounterTable(tx, SentinelAttestationTable, attester, attestations)
 
     if(history && history.length > 0){
-      history.forEach(async entry => {
-        await _storeHistoryEntry(tx, attester, entry)
-      })
+      await Promise.all(history.map(entry => _storeHistoryEntry(tx, attester, entry)))
     }
+
   });
 }
 


### PR DESCRIPTION
Adds the following:
- Polling aztec node for sentinel data
- Parsing sentinel data to chicmoz types
- Filtering the results to ensure only relevant changes are left
- Pushing sentinel updates to message bus
- Validator metrics service listens to message bus for validator info and for history updates
- Validator metrics stores the validator info and the history updates

What's left:
- Handling reorgs for this data
- Merging the sentinel data with our current data
- Getting slashing information
- Creating an api in the explorer-api service