### PR TITLE
feat: add network selector dropdown to header

### DIFF
--- a/services/explorer-ui/src/components/header/desktop-header.tsx
+++ b/services/explorer-ui/src/components/header/desktop-header.tsx
@@ -1,8 +1,8 @@
 import { Link } from "@tanstack/react-router";
 import { SearchInput } from "~/components/ui/input";
-import { MagicDevLink } from "../magic-dev-link";
 import { ChicmozHomeLink } from "../ui/chicmoz-home-link";
 import { DesktopBurgerMenu } from "./desktop-burger-menu";
+import { NetworkSelector } from "./network-selector";
 import { type HeaderLink } from "./types";
 
 interface DesktopHeaderProps {
@@ -41,12 +41,15 @@ export const DesktopHeader = ({
   );
 
   return (
-    <div className="hidden md:flex md:w-full md:items-center md:justify-between">
-      <div className="flex items-center">
-        <ChicmozHomeLink className="-mt-1" textClasses="hidden md:block pr-6" />
-        <MagicDevLink textClasses="hidden md:block self-center" />
+    <div className="hidden lg:flex lg:w-full lg:items-center lg:gap-8">
+      {/* Left section: Logo + Network */}
+      <div className="flex items-center gap-4 shrink-0">
+        <ChicmozHomeLink className="-mt-1" textClasses="hidden lg:block" />
+        <NetworkSelector className="hidden lg:flex" />
       </div>
-      <div className="flex justify-center items-center w-1/2 sm:w-1/3">
+
+      {/* Center section: Search - grows to fill available space */}
+      <div className="flex-1 flex justify-center items-center max-w-md mx-auto">
         <SearchInput
           placeholder="Search"
           onIconClick={handleSearch}
@@ -54,15 +57,17 @@ export const DesktopHeader = ({
           onChange={(e) => handleOnChange(e.target.value)}
           isLoading={isLoading}
           noResults={hasNoResults}
+          className="w-full"
         />
       </div>
 
-      <div className="flex space-x-6 justify-center items-center pr-11">
+      {/* Right section: Nav links + Menu */}
+      <div className="flex items-center gap-6 shrink-0 pr-6">
         {groupedLinks?.main.map((link) => (
           <Link
             key={link.key}
             to={link.to}
-            className="text-white hover:text-secondary-foreground transition-colors"
+            className="text-white hover:text-secondary-foreground transition-colors whitespace-nowrap"
           >
             {link.name}
           </Link>

--- a/services/explorer-ui/src/components/header/mobile-header.tsx
+++ b/services/explorer-ui/src/components/header/mobile-header.tsx
@@ -1,10 +1,12 @@
 import { ExternalLinkIcon } from "@radix-ui/react-icons";
 import { Link } from "@tanstack/react-router";
-import { Menu, X } from "lucide-react";
+import { Menu, Search, X } from "lucide-react";
+import { useState } from "react";
+import { AztecIconWhite } from "~/assets";
 import { SearchInput } from "~/components/ui/input";
+import { routes } from "~/routes/__root";
 import { ThemeToggle } from "../theme-toggle";
 import { Button } from "../ui";
-import { ChicmozHomeLink } from "../ui/chicmoz-home-link";
 import { NetworkSelector } from "./network-selector";
 import { type HeaderLink } from "./types";
 
@@ -48,28 +50,75 @@ export const MobileHeader = ({
     .map((link) => link.group ?? "default")
     .filter((group, index, self) => self.indexOf(group) === index);
 
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
+
   return (
     <>
       {/* Mobile Navigation Header */}
       <div className="flex items-center justify-between w-full px-4 lg:hidden">
-        <ChicmozHomeLink textClasses="hidden lg:block" />
-        <NetworkSelector className="lg:hidden" />
-        <div className="flex items-center justify-between space-x-4">
+        {/* Left: Logo + Network */}
+        <div className="flex items-center gap-3">
+          <Link to={routes.home.route} className="flex items-center gap-1">
+            <AztecIconWhite className="size-5" />
+            <span className="text-white font-bold text-base font-space-grotesk">
+              Aztec-Scan
+            </span>
+          </Link>
+          <NetworkSelector className="lg:hidden" />
+        </div>
+
+        {/* Center: Search bar (tablet only) */}
+        <div className="hidden md:flex flex-1 justify-center mx-4 max-w-xs">
+          <SearchInput
+            placeholder="Search"
+            onIconClick={handleSearch}
+            onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+            onChange={(e) => handleOnChange(e.target.value)}
+            isLoading={isLoading}
+            noResults={hasNoResults}
+            className="w-full"
+          />
+        </div>
+
+        {/* Right: Search icon (mobile only) + Menu */}
+        <div className="flex items-center gap-2">
           <Button
             variant="ghost"
             size="sm"
-            className="text-white hover:bg-transparent"
+            className="text-white hover:bg-transparent p-2 md:hidden"
+            onClick={() => setIsSearchOpen(!isSearchOpen)}
+          >
+            <Search className="h-5 w-5 text-white" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-white hover:bg-transparent p-2"
             onClick={() => setIsMenuOpen(!isMenuOpen)}
           >
-            <span className="flex items-center">
-              {isMenuOpen ? (
-                <X className="h-6 w-6 mr-2 text-white" />
-              ) : (
-                <Menu className="h-6 w-6 mr-2 text-white" />
-              )}
-            </span>
+            {isMenuOpen ? (
+              <X className="h-6 w-6 text-white" />
+            ) : (
+              <Menu className="h-6 w-6 text-white" />
+            )}
           </Button>
         </div>
+      </div>
+
+      {/* Mobile Search Bar (expandable - mobile only) */}
+      <div
+        className={`md:hidden overflow-hidden transition-all duration-300 ease-in-out px-4
+        ${isSearchOpen ? "max-h-20 opacity-100 pt-3" : "max-h-0 opacity-0"}`}
+      >
+        <SearchInput
+          placeholder="Search"
+          onIconClick={handleSearch}
+          onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+          onChange={(e) => handleOnChange(e.target.value)}
+          isLoading={isLoading}
+          noResults={hasNoResults}
+          className="w-full"
+        />
       </div>
 
       {/* Mobile Menu Content */}
@@ -78,19 +127,6 @@ export const MobileHeader = ({
         ${isMenuOpen ? "max-h-[80vh] opacity-100" : "max-h-0 opacity-0"}`}
       >
         <div className="px-4 pt-4 space-y-3 overflow-y-auto">
-          {/* Search bar */}
-          <div className="flex items-center mt-1 w-full">
-            <SearchInput
-              placeholder="Search"
-              onIconClick={handleSearch}
-              onKeyDown={(e) => e.key === "Enter" && handleSearch()}
-              onChange={(e) => handleOnChange(e.target.value)}
-              isLoading={isLoading}
-              noResults={hasNoResults}
-              className="w-full"
-            />
-          </div>
-
           {/* Navigation Items */}
           <div className="flex flex-col space-y-2">
             {groups.map((group, groupIndex) => (

--- a/services/explorer-ui/src/components/header/mobile-header.tsx
+++ b/services/explorer-ui/src/components/header/mobile-header.tsx
@@ -2,10 +2,10 @@ import { ExternalLinkIcon } from "@radix-ui/react-icons";
 import { Link } from "@tanstack/react-router";
 import { Menu, X } from "lucide-react";
 import { SearchInput } from "~/components/ui/input";
-import { MagicDevLink } from "../magic-dev-link";
 import { ThemeToggle } from "../theme-toggle";
 import { Button } from "../ui";
 import { ChicmozHomeLink } from "../ui/chicmoz-home-link";
+import { NetworkSelector } from "./network-selector";
 import { type HeaderLink } from "./types";
 
 interface MobileHeaderProps {
@@ -51,9 +51,9 @@ export const MobileHeader = ({
   return (
     <>
       {/* Mobile Navigation Header */}
-      <div className="flex items-center justify-between w-full px-4 md:hidden">
-        <ChicmozHomeLink textClasses="hidden md:block" />
-        <MagicDevLink textClasses="md:hidden" />
+      <div className="flex items-center justify-between w-full px-4 lg:hidden">
+        <ChicmozHomeLink textClasses="hidden lg:block" />
+        <NetworkSelector className="lg:hidden" />
         <div className="flex items-center justify-between space-x-4">
           <Button
             variant="ghost"
@@ -74,7 +74,7 @@ export const MobileHeader = ({
 
       {/* Mobile Menu Content */}
       <div
-        className={`md:hidden overflow-hidden transition-all duration-300 ease-in-out
+        className={`lg:hidden overflow-hidden transition-all duration-300 ease-in-out
         ${isMenuOpen ? "max-h-[80vh] opacity-100" : "max-h-0 opacity-0"}`}
       >
         <div className="px-4 pt-4 space-y-3 overflow-y-auto">

--- a/services/explorer-ui/src/components/header/network-selector.tsx
+++ b/services/explorer-ui/src/components/header/network-selector.tsx
@@ -1,0 +1,54 @@
+import { Link } from "@tanstack/react-router";
+import { routes } from "~/routes/__root.tsx";
+import { CHICMOZ_ALL_UI_URLS, L2_NETWORK_ID } from "~/service/constants";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
+
+interface NetworkSelectorProps {
+  className?: string;
+}
+
+export const NetworkSelector = ({ className = "" }: NetworkSelectorProps) => {
+  const handleNetworkChange = (url: string) => {
+    // Preserve current path when switching networks
+    const currentPath = window.location.pathname + window.location.search;
+    window.location.href = url + currentPath;
+  };
+
+  // If no networks configured or only one network, show as plain text
+  const hasMultipleNetworks = CHICMOZ_ALL_UI_URLS.length > 1;
+
+  if (!hasMultipleNetworks) {
+    return (
+      <Link to={routes.dev.route} className={className}>
+        <span className="font-space-grotesk text-white">{L2_NETWORK_ID}</span>
+      </Link>
+    );
+  }
+
+  return (
+    <Select onValueChange={handleNetworkChange}>
+      <SelectTrigger
+        className={`${className} w-auto border-none bg-transparent font-space-grotesk text-white shadow-none focus:ring-0 focus:ring-offset-0 h-auto p-0 gap-1 [&>svg]:opacity-100 [&>svg]:text-white`}
+      >
+        <SelectValue placeholder={L2_NETWORK_ID} />
+      </SelectTrigger>
+      <SelectContent className="bg-purple-dark border-purple-light">
+        {CHICMOZ_ALL_UI_URLS.map((network) => (
+          <SelectItem
+            key={network.url}
+            value={network.url}
+            className="text-white focus:bg-purple-light focus:text-white cursor-pointer"
+          >
+            {network.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+};


### PR DESCRIPTION
## Summary
- Add network selector dropdown to header allowing users to switch between different Aztec networks (Mainnet, Testnet, Devnet)
- Preserve current URL path when switching networks for better UX

## Changes
- **New component**: `NetworkSelector` - dropdown using existing `Select` UI components, reads available networks from `CHICMOZ_ALL_UI_URLS` env variable
- **Desktop header**: Replaced `MagicDevLink` with `NetworkSelector`, improved spacing and alignment
- **Mobile header**: Added logo with text, search icon (expandable on small screens), inline search bar for tablet view
- **Responsive breakpoints**: Adjusted to `lg` (1024px) for desktop/mobile switch to prevent layout issues at medium widths