### PR TITLE
fix: correct testnet service image names and build configs

### DIFF
--- a/.github/workflows/aztecscan-prod.yml
+++ b/.github/workflows/aztecscan-prod.yml
@@ -129,6 +129,7 @@ jobs:
           AZTEC_RPC_NODES_TESTNET: ${{ vars.AZTEC_RPC_NODES_TESTNET }}
           AZTEC_RPC_NODES_MAINNET: ${{ vars.AZTEC_RPC_NODES_MAINNET }}
           ETHEREUM_HTTP_ALCHEMY_MAINNET_URL: ${{ vars.ETHEREUM_HTTP_ALCHEMY_MAINNET_URL }}
+          ETHEREUM_HTTP_ALCHEMY_SEPOLIA_URL: ${{ vars.ETHEREUM_HTTP_ALCHEMY_SEPOLIA_URL }}
         run: |
           MAX_RETRIES=3
           RETRY_DELAY=10
@@ -148,6 +149,7 @@ jobs:
             --from-literal=AZTEC_RPC_NODES_TESTNET=$AZTEC_RPC_NODES_TESTNET \
             --from-literal=AZTEC_RPC_NODES_MAINNET=$AZTEC_RPC_NODES_MAINNET \
             --from-literal=ETHEREUM_HTTP_ALCHEMY_MAINNET_URL=$ETHEREUM_HTTP_ALCHEMY_MAINNET_URL \
+            --from-literal=ETHEREUM_HTTP_ALCHEMY_SEPOLIA_URL=$ETHEREUM_HTTP_ALCHEMY_SEPOLIA_URL \
             -n chicmoz-prod --dry-run=client -o yaml | kubectl apply -f -
 
           for i in $(seq 1 $MAX_RETRIES); do

--- a/k8s/production/aztec-listener/skaffold.testnet.yaml
+++ b/k8s/production/aztec-listener/skaffold.testnet.yaml
@@ -1,7 +1,16 @@
 apiVersion: skaffold/v4beta6
 kind: Config
 requires:
-  - path: ./common/skaffold.base.yaml
+  - path: ../common/skaffold.chicmoz-base-image.yaml
+build:
+  artifacts:
+    - image: registry.digitalocean.com/aztlan-containers/aztec-listener-testnet
+      context: ../../../../services/aztec-listener
+      docker:
+        dockerfile: Dockerfile
+      requires:
+        - image: registry.digitalocean.com/aztlan-containers/chicmoz-base
+          alias: BASE
 deploy:
   kubectl:
     flags:

--- a/k8s/production/aztec-listener/testnet/deployment.yaml
+++ b/k8s/production/aztec-listener/testnet/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       imagePullSecrets:
         - name: registry-aztlan-containers
       initContainers:
-        - image: registry.digitalocean.com/aztlan-containers/aztec-listener:latest
+        - image: registry.digitalocean.com/aztlan-containers/aztec-listener-testnet:latest
           name: run-migrations
           command: ["yarn", run, "migrate"]
           envFrom:
@@ -33,7 +33,7 @@ spec:
             - name: TOTAL_DB_RESET
               value: "false"
       containers:
-        - image: registry.digitalocean.com/aztlan-containers/aztec-listener:latest
+        - image: registry.digitalocean.com/aztlan-containers/aztec-listener-testnet:latest
           name: aztec-listener
           resources:
             limits:

--- a/k8s/production/ethereum-listener/skaffold.testnet.yaml
+++ b/k8s/production/ethereum-listener/skaffold.testnet.yaml
@@ -1,7 +1,16 @@
 apiVersion: skaffold/v4beta6
 kind: Config
 requires:
-  - path: ./common/skaffold.base.yaml
+  - path: ../common/skaffold.chicmoz-base-image.yaml
+build:
+  artifacts:
+    - image: registry.digitalocean.com/aztlan-containers/ethereum-listener-testnet
+      context: ../../../../services/ethereum-listener
+      docker:
+        dockerfile: Dockerfile
+      requires:
+        - image: registry.digitalocean.com/aztlan-containers/chicmoz-base
+          alias: BASE
 deploy:
   kubectl:
     flags:

--- a/k8s/production/ethereum-listener/testnet/deployment.yaml
+++ b/k8s/production/ethereum-listener/testnet/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         - name: registry-aztlan-containers
       initContainers:
         - name: run-migrations
-          image: registry.digitalocean.com/aztlan-containers/ethereum-listener:latest
+          image: registry.digitalocean.com/aztlan-containers/ethereum-listener-testnet:latest
           command: ["yarn", run, "migrate"]
           envFrom:
             - configMapRef:
@@ -31,7 +31,7 @@ spec:
             - name: TOTAL_DB_RESET
               value: "false"
       containers:
-        - image: registry.digitalocean.com/aztlan-containers/ethereum-listener:latest
+        - image: registry.digitalocean.com/aztlan-containers/ethereum-listener-testnet:latest
           name: ethereum-listener
           resources:
             limits:

--- a/k8s/production/explorer-api/skaffold.testnet.yaml
+++ b/k8s/production/explorer-api/skaffold.testnet.yaml
@@ -2,6 +2,15 @@ apiVersion: skaffold/v4beta6
 kind: Config
 requires:
   - path: ./common/skaffold.base.yaml
+build:
+  artifacts:
+    - image: registry.digitalocean.com/aztlan-containers/explorer-api-testnet
+      context: ../../../services/explorer-api
+      docker:
+        dockerfile: Dockerfile
+      requires:
+        - image: registry.digitalocean.com/aztlan-containers/chicmoz-base
+          alias: BASE
 deploy:
   kubectl:
     flags:

--- a/k8s/production/explorer-api/testnet/deployment.yaml
+++ b/k8s/production/explorer-api/testnet/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       imagePullSecrets:
         - name: registry-aztlan-containers
       initContainers:
-        - image: registry.digitalocean.com/aztlan-containers/explorer-api:latest
+        - image: registry.digitalocean.com/aztlan-containers/explorer-api-testnet:latest
           name: run-migrations
           command: ["yarn", run, "migrate"]
           envFrom:
@@ -33,7 +33,7 @@ spec:
             - name: TOTAL_DB_RESET
               value: "false"
       containers:
-        - image: registry.digitalocean.com/aztlan-containers/explorer-api:latest
+        - image: registry.digitalocean.com/aztlan-containers/explorer-api-testnet:latest
           name: explorer-api
           resources:
             limits:

--- a/k8s/production/skaffold.light.yaml
+++ b/k8s/production/skaffold.light.yaml
@@ -4,4 +4,4 @@ metadata:
   name: chicmoz-prod-light
 requires:
   - path: ./skaffold.testnet.yaml
-  - path: ./skaffold.mainnet.yaml
+  # - path: ./skaffold.mainnet.yaml

--- a/k8s/production/websocket-event-publisher/skaffold.testnet.yaml
+++ b/k8s/production/websocket-event-publisher/skaffold.testnet.yaml
@@ -3,7 +3,16 @@ kind: Config
 metadata:
   name: websocket-event-publisher-testnet
 requires:
-  - path: ./common/skaffold.base.yaml
+  - path: ../common/skaffold.chicmoz-base-image.yaml
+build:
+  artifacts:
+    - image: registry.digitalocean.com/aztlan-containers/websocket-event-publisher-testnet
+      context: ../../../../services/websocket-event-publisher
+      docker:
+        dockerfile: Dockerfile
+      requires:
+        - image: registry.digitalocean.com/aztlan-containers/chicmoz-base
+          alias: BASE
 deploy:
   kubectl:
     flags:

--- a/k8s/production/websocket-event-publisher/testnet/deployment.yaml
+++ b/k8s/production/websocket-event-publisher/testnet/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         app: websocket-event-publisher-testnet-label
     spec:
       containers:
-        - image: registry.digitalocean.com/aztlan-containers/websocket-event-publisher:latest
+        - image: registry.digitalocean.com/aztlan-containers/websocket-event-publisher-testnet:latest
           name: websocket-event-publisher
           resources:
             limits:


### PR DESCRIPTION
## Problem
Testnet services were failing with Aztec SDK errors (Invalid RevertCode) because they were using wrong Docker images.

## Root Cause
- Testnet skaffold files were missing build configurations
- Deployment files referenced generic images (e.g., ) instead of testnet-specific images (e.g., )
- This caused version mismatches between listener services and API services
