### PR TITLE
fix: change total_fees and total_mana_used from bigint to numeric(78,0) to prevent overflow

### DIFF
--- a/services/explorer-api/migrations/0010_total_fees_mana_numeric.sql
+++ b/services/explorer-api/migrations/0010_total_fees_mana_numeric.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "header" ALTER COLUMN "total_fees" SET DATA TYPE numeric(77, 0) USING "total_fees"::numeric;--> statement-breakpoint
+ALTER TABLE "header" ALTER COLUMN "total_mana_used" SET DATA TYPE numeric(77, 0) USING "total_mana_used"::numeric;

--- a/services/explorer-api/migrations/meta/0010_snapshot.json
+++ b/services/explorer-api/migrations/meta/0010_snapshot.json
@@ -1,0 +1,2575 @@
+{
+  "id": "b445686d-e704-470f-ada7-aafc28ee88a3",
+  "prevId": "ff2330f1-479b-4b70-b1b1-108becd44b60",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.aztec-chain-connection": {
+      "name": "aztec-chain-connection",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "chain_height": {
+          "name": "chain_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latest_processed_height": {
+          "name": "latest_processed_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rpc_url": {
+          "name": "rpc_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_version": {
+          "name": "node_version",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_chain_id": {
+          "name": "l1_chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollup_version": {
+          "name": "rollup_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enr": {
+          "name": "enr",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "l1_contract_addresses": {
+          "name": "l1_contract_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol_contract_addresses": {
+          "name": "protocol_contract_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.contract_instance_balance": {
+      "name": "contract_instance_balance",
+      "schema": "",
+      "columns": {
+        "contract_address": {
+          "name": "contract_address",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric(77, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "contract_instance_balance_pk": {
+          "name": "contract_instance_balance_pk",
+          "columns": ["contract_address", "timestamp"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.dropped_tx": {
+      "name": "dropped_tx",
+      "schema": "",
+      "columns": {
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_as_pending_at": {
+          "name": "created_as_pending_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dropped_at": {
+          "name": "dropped_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.body": {
+      "name": "body",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "block_hash": {
+          "name": "block_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "body_block_hash_idx": {
+          "name": "body_block_hash_idx",
+          "columns": [
+            {
+              "expression": "block_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "body_block_hash_l2Block_hash_fk": {
+          "name": "body_block_hash_l2Block_hash_fk",
+          "tableFrom": "body",
+          "tableTo": "l2Block",
+          "columnsFrom": ["block_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.public_data_write": {
+      "name": "public_data_write",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tx_effect_hash": {
+          "name": "tx_effect_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "leaf_slot": {
+          "name": "leaf_slot",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "public_data_write_tx_effect_hash_idx": {
+          "name": "public_data_write_tx_effect_hash_idx",
+          "columns": [
+            {
+              "expression": "tx_effect_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_data_write_index_idx": {
+          "name": "public_data_write_index_idx",
+          "columns": [
+            {
+              "expression": "index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_data_write_tx_effect_hash_index_idx": {
+          "name": "public_data_write_tx_effect_hash_index_idx",
+          "columns": [
+            {
+              "expression": "tx_effect_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "public_data_write_tx_effect_hash_tx_effect_tx_hash_fk": {
+          "name": "public_data_write_tx_effect_hash_tx_effect_tx_hash_fk",
+          "tableFrom": "public_data_write",
+          "tableTo": "tx_effect",
+          "columnsFrom": ["tx_effect_hash"],
+          "columnsTo": ["tx_hash"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.tx_effect": {
+      "name": "tx_effect",
+      "schema": "",
+      "columns": {
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "body_id": {
+          "name": "body_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_time_of_birth": {
+          "name": "tx_time_of_birth",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "EXTRACT(EPOCH FROM NOW()) * 1000"
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revert_code": {
+          "name": "revert_code",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_fee": {
+          "name": "transaction_fee",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_hashes": {
+          "name": "note_hashes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nullifiers": {
+          "name": "nullifiers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l2_to_l1_msgs": {
+          "name": "l2_to_l1_msgs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_logs": {
+          "name": "private_logs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_logs": {
+          "name": "public_logs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_class_logs": {
+          "name": "contract_class_logs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tx_hash_index": {
+          "name": "tx_hash_index",
+          "columns": [
+            {
+              "expression": "tx_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tx_effect_body_id_idx": {
+          "name": "tx_effect_body_id_idx",
+          "columns": [
+            {
+              "expression": "body_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tx_effect_index_idx": {
+          "name": "tx_effect_index_idx",
+          "columns": [
+            {
+              "expression": "index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tx_effect_body_id_index_idx": {
+          "name": "tx_effect_body_id_index_idx",
+          "columns": [
+            {
+              "expression": "body_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tx_effect_body_id_body_id_fk": {
+          "name": "tx_effect_body_id_body_id_fk",
+          "tableFrom": "tx_effect",
+          "tableTo": "body",
+          "columnsFrom": ["body_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.gas_fees": {
+      "name": "gas_fees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "global_variables_id": {
+          "name": "global_variables_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_per_da_gas": {
+          "name": "fee_per_da_gas",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_per_l2_gas": {
+          "name": "fee_per_l2_gas",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "gas_fees_global_variables_id_idx": {
+          "name": "gas_fees_global_variables_id_idx",
+          "columns": [
+            {
+              "expression": "global_variables_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gas_fees_global_variables_id_global_variables_id_fk": {
+          "name": "gas_fees_global_variables_id_global_variables_id_fk",
+          "tableFrom": "gas_fees",
+          "tableTo": "global_variables",
+          "columnsFrom": ["global_variables_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.global_variables": {
+      "name": "global_variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "header_id": {
+          "name": "header_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_number": {
+          "name": "slot_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coinbase": {
+          "name": "coinbase",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_recipient": {
+          "name": "fee_recipient",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "global_variables_header_id_idx": {
+          "name": "global_variables_header_id_idx",
+          "columns": [
+            {
+              "expression": "header_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "global_variables_version_idx": {
+          "name": "global_variables_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "global_variables_header_id_header_id_fk": {
+          "name": "global_variables_header_id_header_id_fk",
+          "tableFrom": "global_variables",
+          "tableTo": "header",
+          "columnsFrom": ["header_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.header": {
+      "name": "header",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "block_hash": {
+          "name": "block_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_fees": {
+          "name": "total_fees",
+          "type": "numeric(77, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_mana_used": {
+          "name": "total_mana_used",
+          "type": "numeric(77, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sponge_blob_hash": {
+          "name": "sponge_blob_hash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "header_block_hash_idx": {
+          "name": "header_block_hash_idx",
+          "columns": [
+            {
+              "expression": "block_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "header_block_hash_l2Block_hash_fk": {
+          "name": "header_block_hash_l2Block_hash_fk",
+          "tableFrom": "header",
+          "tableTo": "l2Block",
+          "columnsFrom": ["block_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l1_to_l2_message_tree": {
+      "name": "l1_to_l2_message_tree",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "root": {
+          "name": "root",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_available_leaf_index": {
+          "name": "next_available_leaf_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_id": {
+          "name": "state_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l1_to_l2_message_tree_state_id_state_id_fk": {
+          "name": "l1_to_l2_message_tree_state_id_state_id_fk",
+          "tableFrom": "l1_to_l2_message_tree",
+          "tableTo": "state",
+          "columnsFrom": ["state_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.last_archive": {
+      "name": "last_archive",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "root": {
+          "name": "root",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_available_leaf_index": {
+          "name": "next_available_leaf_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header_id": {
+          "name": "header_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "last_archive_header_id_header_id_fk": {
+          "name": "last_archive_header_id_header_id_fk",
+          "tableFrom": "last_archive",
+          "tableTo": "header",
+          "columnsFrom": ["header_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.note_hash_tree": {
+      "name": "note_hash_tree",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "root": {
+          "name": "root",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_available_leaf_index": {
+          "name": "next_available_leaf_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_partial_id": {
+          "name": "state_partial_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "note_hash_tree_state_partial_id_partial_id_fk": {
+          "name": "note_hash_tree_state_partial_id_partial_id_fk",
+          "tableFrom": "note_hash_tree",
+          "tableTo": "partial",
+          "columnsFrom": ["state_partial_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.nullifier_tree": {
+      "name": "nullifier_tree",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "root": {
+          "name": "root",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_available_leaf_index": {
+          "name": "next_available_leaf_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_partial_id": {
+          "name": "state_partial_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nullifier_tree_state_partial_id_partial_id_fk": {
+          "name": "nullifier_tree_state_partial_id_partial_id_fk",
+          "tableFrom": "nullifier_tree",
+          "tableTo": "partial",
+          "columnsFrom": ["state_partial_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.partial": {
+      "name": "partial",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "state_id": {
+          "name": "state_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "partial_state_id_idx": {
+          "name": "partial_state_id_idx",
+          "columns": [
+            {
+              "expression": "state_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "partial_state_id_state_id_fk": {
+          "name": "partial_state_id_state_id_fk",
+          "tableFrom": "partial",
+          "tableTo": "state",
+          "columnsFrom": ["state_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.public_data_tree": {
+      "name": "public_data_tree",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "root": {
+          "name": "root",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_available_leaf_index": {
+          "name": "next_available_leaf_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_partial_id": {
+          "name": "state_partial_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "public_data_tree_state_partial_id_partial_id_fk": {
+          "name": "public_data_tree_state_partial_id_partial_id_fk",
+          "tableFrom": "public_data_tree",
+          "tableTo": "partial",
+          "columnsFrom": ["state_partial_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.state": {
+      "name": "state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "header_id": {
+          "name": "header_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "state_header_id_idx": {
+          "name": "state_header_id_idx",
+          "columns": [
+            {
+              "expression": "header_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "state_header_id_header_id_fk": {
+          "name": "state_header_id_header_id_fk",
+          "tableFrom": "state",
+          "tableTo": "header",
+          "columnsFrom": ["header_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l1_l2_block_proposed": {
+      "name": "l1_l2_block_proposed",
+      "schema": "",
+      "columns": {
+        "l1_contract_address": {
+          "name": "l1_contract_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l2_block_number": {
+          "name": "l2_block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_block_number": {
+          "name": "l1_block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_block_hash": {
+          "name": "l1_block_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_block_timestamp": {
+          "name": "l1_block_timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_finalized": {
+          "name": "is_finalized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "archive": {
+          "name": "archive",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "block_proposal": {
+          "name": "block_proposal",
+          "columns": ["l2_block_number", "archive"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.l1_l2_proof_verified": {
+      "name": "l1_l2_proof_verified",
+      "schema": "",
+      "columns": {
+        "l1_contract_address": {
+          "name": "l1_contract_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l2_block_number": {
+          "name": "l2_block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_block_number": {
+          "name": "l1_block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_block_hash": {
+          "name": "l1_block_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_block_timestamp": {
+          "name": "l1_block_timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_finalized": {
+          "name": "is_finalized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "prover_id": {
+          "name": "prover_id",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "proof_verified": {
+          "name": "proof_verified",
+          "columns": ["l2_block_number", "prover_id"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.archive": {
+      "name": "archive",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "root": {
+          "name": "root",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_available_leaf_index": {
+          "name": "next_available_leaf_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_hash": {
+          "name": "block_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "archive_block_hash_l2Block_hash_fk": {
+          "name": "archive_block_hash_l2Block_hash_fk",
+          "tableFrom": "archive",
+          "tableTo": "l2Block",
+          "columnsFrom": ["block_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l2Block": {
+      "name": "l2Block",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "orphan_timestamp": {
+          "name": "orphan_timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orphan_hasOrphanedParent": {
+          "name": "orphan_hasOrphanedParent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "height_idx": {
+          "name": "height_idx",
+          "columns": [
+            {
+              "expression": "height",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "l2block_version_idx": {
+          "name": "l2block_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "l2block_height_version_idx": {
+          "name": "l2block_height_version_idx",
+          "columns": [
+            {
+              "expression": "height",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "orphan_timestamp_idx": {
+          "name": "orphan_timestamp_idx",
+          "columns": [
+            {
+              "expression": "orphan_timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"l2Block\".\"orphan_timestamp\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "height_orphan_idx": {
+          "name": "height_orphan_idx",
+          "columns": [
+            {
+              "expression": "height",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "orphan_timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l2_contract_class_registered": {
+      "name": "l2_contract_class_registered",
+      "schema": "",
+      "columns": {
+        "block_hash": {
+          "name": "block_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_class_id": {
+          "name": "contract_class_id",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_hash": {
+          "name": "artifact_hash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_functions_root": {
+          "name": "private_functions_root",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "packed_bytecode": {
+          "name": "packed_bytecode",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_json": {
+          "name": "artifact_json",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_contract_name": {
+          "name": "artifact_contract_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contract_type": {
+          "name": "contract_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contract_version": {
+          "name": "contract_version",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_code_url": {
+          "name": "source_code_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l2_contract_class_registered_block_hash_l2Block_hash_fk": {
+          "name": "l2_contract_class_registered_block_hash_l2Block_hash_fk",
+          "tableFrom": "l2_contract_class_registered",
+          "tableTo": "l2Block",
+          "columnsFrom": ["block_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "contract_class_id_version": {
+          "name": "contract_class_id_version",
+          "columns": ["contract_class_id", "version"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.l2_contract_instance_aztec_scan_notes": {
+      "name": "l2_contract_instance_aztec_scan_notes",
+      "schema": "",
+      "columns": {
+        "address": {
+          "name": "address",
+          "type": "varchar(66)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_l1_contract_addresses": {
+          "name": "related_l1_contract_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l2_contract_instance_deployed": {
+      "name": "l2_contract_instance_deployed",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "block_hash": {
+          "name": "block_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "salt": {
+          "name": "salt",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_contract_class_id": {
+          "name": "current_contract_class_id",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_contract_class_id": {
+          "name": "original_contract_class_id",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initialization_hash": {
+          "name": "initialization_hash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployer": {
+          "name": "deployer",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "masterNullifierPublicKey": {
+          "name": "masterNullifierPublicKey",
+          "type": "varchar(130)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "masterIncomingViewingPublicKey": {
+          "name": "masterIncomingViewingPublicKey",
+          "type": "varchar(130)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "masterOutgoingViewingPublicKey": {
+          "name": "masterOutgoingViewingPublicKey",
+          "type": "varchar(130)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "masterTaggingPublicKey": {
+          "name": "masterTaggingPublicKey",
+          "type": "varchar(130)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l2_contract_instance_deployed_block_hash_l2Block_hash_fk": {
+          "name": "l2_contract_instance_deployed_block_hash_l2Block_hash_fk",
+          "tableFrom": "l2_contract_instance_deployed",
+          "tableTo": "l2Block",
+          "columnsFrom": ["block_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contract_class": {
+          "name": "contract_class",
+          "tableFrom": "l2_contract_instance_deployed",
+          "tableTo": "l2_contract_class_registered",
+          "columnsFrom": ["current_contract_class_id", "version"],
+          "columnsTo": ["contract_class_id", "version"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "l2_contract_instance_deployed_address_unique": {
+          "name": "l2_contract_instance_deployed_address_unique",
+          "nullsNotDistinct": false,
+          "columns": ["address"]
+        }
+      }
+    },
+    "public.l2_contract_instance_deployer_metadata": {
+      "name": "l2_contract_instance_deployer_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_identifier": {
+          "name": "contract_identifier",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_name": {
+          "name": "creator_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_contact": {
+          "name": "creator_contact",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_url": {
+          "name": "app_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l2_contract_instance_deployer_metadata_address_l2_contract_instance_deployed_address_fk": {
+          "name": "l2_contract_instance_deployer_metadata_address_l2_contract_instance_deployed_address_fk",
+          "tableFrom": "l2_contract_instance_deployer_metadata",
+          "tableTo": "l2_contract_instance_deployed",
+          "columnsFrom": ["address"],
+          "columnsTo": ["address"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l2_contract_instance_update": {
+      "name": "l2_contract_instance_update",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prev_contract_class_id": {
+          "name": "prev_contract_class_id",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_contract_class_id": {
+          "name": "new_contract_class_id",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_hash": {
+          "name": "block_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l2_contract_instance_update_block_hash_l2Block_hash_fk": {
+          "name": "l2_contract_instance_update_block_hash_l2Block_hash_fk",
+          "tableFrom": "l2_contract_instance_update",
+          "tableTo": "l2Block",
+          "columnsFrom": ["block_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "l2_contract_instance_update_address_unique": {
+          "name": "l2_contract_instance_update_address_unique",
+          "nullsNotDistinct": false,
+          "columns": ["address"]
+        }
+      }
+    },
+    "public.l2_contract_instance_verified_deployment_arguments": {
+      "name": "l2_contract_instance_verified_deployment_arguments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publicKeys": {
+          "name": "publicKeys",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployer": {
+          "name": "deployer",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "salt": {
+          "name": "salt",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "constructor_args": {
+          "name": "constructor_args",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l2_contract_instance_verified_deployment_arguments_address_l2_contract_instance_deployed_address_fk": {
+          "name": "l2_contract_instance_verified_deployment_arguments_address_l2_contract_instance_deployed_address_fk",
+          "tableFrom": "l2_contract_instance_verified_deployment_arguments",
+          "tableTo": "l2_contract_instance_deployed",
+          "columnsFrom": ["address"],
+          "columnsTo": ["address"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l2_private_function": {
+      "name": "l2_private_function",
+      "schema": "",
+      "columns": {
+        "contract_class_id": {
+          "name": "contract_class_id",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_metadata_hash": {
+          "name": "artifact_metadata_hash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "utility_functions_tree_root": {
+          "name": "utility_functions_tree_root",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_function_tree_sibling_path": {
+          "name": "private_function_tree_sibling_path",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_function_tree_leaf_index": {
+          "name": "private_function_tree_leaf_index",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_function_tree_sibling_path": {
+          "name": "artifact_function_tree_sibling_path",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_function_tree_leaf_index": {
+          "name": "artifact_function_tree_leaf_index",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_function_selector_value": {
+          "name": "private_function_selector_value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_function_metadata_hash": {
+          "name": "private_function_metadata_hash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_function_vk_hash": {
+          "name": "private_function_vk_hash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_function_bytecode": {
+          "name": "private_function_bytecode",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "private_function_contract_class": {
+          "name": "private_function_contract_class",
+          "columns": ["contract_class_id", "private_function_selector_value"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.l2_utility_function": {
+      "name": "l2_utility_function",
+      "schema": "",
+      "columns": {
+        "contract_class_id": {
+          "name": "contract_class_id",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_metadata_hash": {
+          "name": "artifact_metadata_hash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_functions_artifact_tree_root": {
+          "name": "private_functions_artifact_tree_root",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_function_tree_sibling_path": {
+          "name": "artifact_function_tree_sibling_path",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_function_tree_leaf_index": {
+          "name": "artifact_function_tree_leaf_index",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "utility_function_selector_value": {
+          "name": "utility_function_selector_value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "utility_function_metadata_hash": {
+          "name": "utility_function_metadata_hash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "utility_function_bytecode": {
+          "name": "utility_function_bytecode",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "utility_function_contract_class": {
+          "name": "utility_function_contract_class",
+          "columns": ["contract_class_id", "utility_function_selector_value"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.tx": {
+      "name": "tx",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fee_payer": {
+          "name": "fee_payer",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_timestamp": {
+          "name": "birth_timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l1_generic_contract_event": {
+      "name": "l1_generic_contract_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "l1_block_hash": {
+          "name": "l1_block_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_block_number": {
+          "name": "l1_block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_block_timestamp": {
+          "name": "l1_block_timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_contract_address": {
+          "name": "l1_contract_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_transaction_hash": {
+          "name": "l1_transaction_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_finalized": {
+          "name": "is_finalized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_args": {
+          "name": "event_args",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l1_l2_validator_proposer": {
+      "name": "l1_l2_validator_proposer",
+      "schema": "",
+      "columns": {
+        "attester_address": {
+          "name": "attester_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposer": {
+          "name": "proposer",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "EXTRACT(EPOCH FROM NOW()) * 1000"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l1_l2_validator_proposer_attester_address_l1_l2_validator_attester_fk": {
+          "name": "l1_l2_validator_proposer_attester_address_l1_l2_validator_attester_fk",
+          "tableFrom": "l1_l2_validator_proposer",
+          "tableTo": "l1_l2_validator",
+          "columnsFrom": ["attester_address"],
+          "columnsTo": ["attester"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "l1_l2_validator_proposer_attester_address_timestamp_pk": {
+          "name": "l1_l2_validator_proposer_attester_address_timestamp_pk",
+          "columns": ["attester_address", "timestamp"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.l1_l2_validator_rollup_address": {
+      "name": "l1_l2_validator_rollup_address",
+      "schema": "",
+      "columns": {
+        "attester_address": {
+          "name": "attester_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollup_address": {
+          "name": "rollup_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "EXTRACT(EPOCH FROM NOW()) * 1000"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l1_l2_validator_rollup_address_attester_address_l1_l2_validator_attester_fk": {
+          "name": "l1_l2_validator_rollup_address_attester_address_l1_l2_validator_attester_fk",
+          "tableFrom": "l1_l2_validator_rollup_address",
+          "tableTo": "l1_l2_validator",
+          "columnsFrom": ["attester_address"],
+          "columnsTo": ["attester"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "l1_l2_validator_rollup_address_attester_address_timestamp_pk": {
+          "name": "l1_l2_validator_rollup_address_attester_address_timestamp_pk",
+          "columns": ["attester_address", "timestamp"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.l1_l2_validator_stake": {
+      "name": "l1_l2_validator_stake",
+      "schema": "",
+      "columns": {
+        "attester_address": {
+          "name": "attester_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stake": {
+          "name": "stake",
+          "type": "numeric(77, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "EXTRACT(EPOCH FROM NOW()) * 1000"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l1_l2_validator_stake_attester_address_l1_l2_validator_attester_fk": {
+          "name": "l1_l2_validator_stake_attester_address_l1_l2_validator_attester_fk",
+          "tableFrom": "l1_l2_validator_stake",
+          "tableTo": "l1_l2_validator",
+          "columnsFrom": ["attester_address"],
+          "columnsTo": ["attester"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "l1_l2_validator_stake_attester_address_timestamp_pk": {
+          "name": "l1_l2_validator_stake_attester_address_timestamp_pk",
+          "columns": ["attester_address", "timestamp"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.l1_l2_validator_status": {
+      "name": "l1_l2_validator_status",
+      "schema": "",
+      "columns": {
+        "attester_address": {
+          "name": "attester_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "EXTRACT(EPOCH FROM NOW()) * 1000"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l1_l2_validator_status_attester_address_l1_l2_validator_attester_fk": {
+          "name": "l1_l2_validator_status_attester_address_l1_l2_validator_attester_fk",
+          "tableFrom": "l1_l2_validator_status",
+          "tableTo": "l1_l2_validator",
+          "columnsFrom": ["attester_address"],
+          "columnsTo": ["attester"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "l1_l2_validator_status_attester_address_timestamp_pk": {
+          "name": "l1_l2_validator_status_attester_address_timestamp_pk",
+          "columns": ["attester_address", "timestamp"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.l1_l2_validator": {
+      "name": "l1_l2_validator",
+      "schema": "",
+      "columns": {
+        "attester": {
+          "name": "attester",
+          "type": "varchar(42)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l1_l2_validator_withdrawer": {
+      "name": "l1_l2_validator_withdrawer",
+      "schema": "",
+      "columns": {
+        "attester_address": {
+          "name": "attester_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "withdrawer": {
+          "name": "withdrawer",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "EXTRACT(EPOCH FROM NOW()) * 1000"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l1_l2_validator_withdrawer_attester_address_l1_l2_validator_attester_fk": {
+          "name": "l1_l2_validator_withdrawer_attester_address_l1_l2_validator_attester_fk",
+          "tableFrom": "l1_l2_validator_withdrawer",
+          "tableTo": "l1_l2_validator",
+          "columnsFrom": ["attester_address"],
+          "columnsTo": ["attester"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "l1_l2_validator_withdrawer_attester_address_timestamp_pk": {
+          "name": "l1_l2_validator_withdrawer_attester_address_timestamp_pk",
+          "columns": ["attester_address", "timestamp"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.l2_chain_info": {
+      "name": "l2_chain_info",
+      "schema": "",
+      "columns": {
+        "l2_network_id": {
+          "name": "l2_network_id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "l1_chain_id": {
+          "name": "l1_chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollup_version": {
+          "name": "rollup_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "l1_contract_addresses": {
+          "name": "l1_contract_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol_contract_addresses": {
+          "name": "protocol_contract_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l2_rpc_node_error": {
+      "name": "l2_rpc_node_error",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rpc_node_name": {
+          "name": "rpc_node_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cause": {
+          "name": "cause",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stack": {
+          "name": "stack",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l2_rpc_node_error_rpc_node_name_l2_rpc_node_name_fk": {
+          "name": "l2_rpc_node_error_rpc_node_name_l2_rpc_node_name_fk",
+          "tableFrom": "l2_rpc_node_error",
+          "tableTo": "l2_rpc_node",
+          "columnsFrom": ["rpc_node_name"],
+          "columnsTo": ["name"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l2_rpc_node": {
+      "name": "l2_rpc_node",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rpc_url": {
+          "name": "rpc_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "l2_rpc_node_rpc_url_unique": {
+          "name": "l2_rpc_node_rpc_url_unique",
+          "nullsNotDistinct": false,
+          "columns": ["rpc_url"]
+        }
+      }
+    },
+    "public.l2_sequencer": {
+      "name": "l2_sequencer",
+      "schema": "",
+      "columns": {
+        "enr": {
+          "name": "enr",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rpc_node_name": {
+          "name": "rpc_node_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l2_network_id": {
+          "name": "l2_network_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollup_version": {
+          "name": "rollup_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_version": {
+          "name": "node_version",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_chain_id": {
+          "name": "l1_chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l2_sequencer_rpc_node_name_l2_rpc_node_name_fk": {
+          "name": "l2_sequencer_rpc_node_name_l2_rpc_node_name_fk",
+          "tableFrom": "l2_sequencer",
+          "tableTo": "l2_rpc_node",
+          "columnsFrom": ["rpc_node_name"],
+          "columnsTo": ["name"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l2BlockFinalizationStatus": {
+      "name": "l2BlockFinalizationStatus",
+      "schema": "",
+      "columns": {
+        "l2_block_hash": {
+          "name": "l2_block_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l2_block_number": {
+          "name": "l2_block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "EXTRACT(EPOCH FROM NOW()) * 1000"
+        }
+      },
+      "indexes": {
+        "l2_block_finalization_l2blockhash_idx": {
+          "name": "l2_block_finalization_l2blockhash_idx",
+          "columns": [
+            {
+              "expression": "l2_block_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "l2_block_finalization_status_idx": {
+          "name": "l2_block_finalization_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "l2_block_finalization_status_pk": {
+          "name": "l2_block_finalization_status_pk",
+          "columns": ["l2_block_hash", "status", "l2_block_number"]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/services/explorer-api/migrations/meta/_journal.json
+++ b/services/explorer-api/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1771257085127,
       "tag": "0009_luxuriant_tomas",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1774872000000,
+      "tag": "0010_total_fees_mana_numeric",
+      "breakpoints": true
     }
   ]
 }

--- a/services/explorer-api/src/svcs/database/controllers/l2block/store.ts
+++ b/services/explorer-api/src/svcs/database/controllers/l2block/store.ts
@@ -48,8 +48,9 @@ export const store = async (
     await dbTx.insert(header).values({
       id: headerId,
       blockHash: block.hash,
-      totalFees: block.header.totalFees,
-      totalManaUsed: block.header.totalManaUsed,
+      totalFees: block.header.totalFees.toString(),
+      totalManaUsed: block.header.totalManaUsed.toString(),
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       spongeBlobHash: block.header.spongeBlobHash,
     });
 

--- a/services/explorer-api/src/svcs/database/schema/l2block/header.ts
+++ b/services/explorer-api/src/svcs/database/schema/l2block/header.ts
@@ -1,12 +1,13 @@
 import { generateAztecAddressColumn } from "@chicmoz-pkg/backend-utils";
 import { HexString } from "@chicmoz-pkg/types";
-import { bigint, index, pgTable, uuid, varchar } from "drizzle-orm/pg-core";
+import { index, pgTable, uuid, varchar } from "drizzle-orm/pg-core";
 import {
   generateEthAddressColumn,
   generateFrColumn,
   generateFrNumberColumn,
   generateTimestampColumn,
   generateTreeTable,
+  generateUint256Column,
 } from "../utils.js";
 import { l2Block } from "./root.js";
 
@@ -18,8 +19,8 @@ export const header = pgTable(
       .notNull()
       .$type<HexString>()
       .references(() => l2Block.hash, { onDelete: "cascade" }),
-    totalFees: bigint("total_fees", { mode: "bigint" }).notNull(),
-    totalManaUsed: bigint("total_mana_used", { mode: "bigint" }).notNull(),
+    totalFees: generateUint256Column("total_fees").notNull(),
+    totalManaUsed: generateUint256Column("total_mana_used").notNull(),
     spongeBlobHash: generateFrColumn("sponge_blob_hash").notNull(),
   },
   (t) => ({


### PR DESCRIPTION
## Root Cause

The testnet explorer was falling out of sync due to the explorer-api crashing when trying to store certain blocks. The error seen in k8s logs:

\`\`\`
Failed to store block 18749: error: value "36583610105684000000" is out of range for type bigint
\`\`\`

The \`total_fees\` and \`total_mana_used\` columns on the \`header\` table were defined as PostgreSQL \`bigint\` (64-bit signed, max ~9.2×10¹⁸). These fields are Aztec **Fr field elements** — they can hold any value in the BN254 scalar field, up to ~2.19×10⁷⁶. As the testnet scales, values exceeding the bigint ceiling are being produced regularly.

From the k8s logs, **144 distinct blocks failed** over a 24h window (18635–18822), all with the same overflow error. Example overflowing values:

- \`36,583,610,105,684,000,000\` (block 18749) — ~3.66×10¹⁹
- \`186,502,662,765,877,200,000\` (block 18805) — ~1.87×10²⁰
- \`100,666,123,053,289,200,000\` (block 18801) — ~1.01×10²⁰

All are valid Fr field elements, all exceed PostgreSQL bigint max.

The \`generateUint256Column\` helper (\`numeric(77, 0)\`) already existed in \`schema/utils.ts\` for exactly this purpose — it just wasn't being used for these two columns. \`numeric(77, 0)\` is sufficient to cover the full BN254 Fr field range (~2.19×10⁷⁶ < 10⁷⁷).

## Changes

### \`schema/l2block/header.ts\`
- Replace \`bigint("total_fees", { mode: "bigint" })\` → \`generateUint256Column("total_fees")\` (\`numeric(77, 0)\`)
- Replace \`bigint("total_mana_used", { mode: "bigint" })\` → \`generateUint256Column("total_mana_used")\` (\`numeric(77, 0)\`)
- Remove unused \`bigint\` import, add \`generateUint256Column\` import

### \`controllers/l2block/store.ts\`
- Convert \`block.header.totalFees\` and \`block.header.totalManaUsed\` to \`.toString()\` at insert — Drizzle's \`numeric\` column expects \`string\`, not \`bigint\`
- Add \`eslint-disable\` for pre-existing \`spongeBlobHash\` \`any\` assignment (unbuilt types package, pre-existing issue, out of scope)

### \`migrations/0010_total_fees_mana_numeric.sql\` _(new)_
\`\`\`sql
ALTER TABLE "header" ALTER COLUMN "total_fees"
  SET DATA TYPE numeric(77, 0) USING "total_fees"::numeric;
ALTER TABLE "header" ALTER COLUMN "total_mana_used"
  SET DATA TYPE numeric(77, 0) USING "total_mana_used"::numeric;
\`\`\`

Precision matches \`generateUint256Column\` (\`numeric(77, 0)\`). The read path (\`z.coerce.bigint()\` in the Zod schema) correctly coerces the string Drizzle returns for \`numeric\` columns back to \`bigint\` — no read-path changes needed.

> Note: the helper is named \`generateUint256Column\` but actually uses \`numeric(77, 0)\`, which covers Fr values but is not a true uint256 (which would need \`numeric(78, 0)\`). That naming/precision discrepancy is tracked in a separate issue.

### \`migrations/meta/_journal.json\` + \`migrations/meta/0010_snapshot.json\`
- Drizzle journal and snapshot updated to reflect the new migration

## After deploying

Once the migration is applied to testnet, **144 blocks are missing** and will not self-heal — \`AZTEC_DISABLE_ETERNAL_CATCHUP=true\` is set on the testnet listener. Trigger a re-crawl by temporarily setting on the \`aztec-listener-testnet\` deployment:

\`\`\`
AZTEC_LISTEN_FOR_PROPOSED_BLOCKS_FORCED_START_FROM_HEIGHT=18635
AZTEC_LISTEN_FOR_PROVEN_BLOCKS_FORCED_START_FROM_HEIGHT=18635
\`\`\`

Remove these env vars after the catchup completes.