### PR TITLE
chore: merge main into production

### DIFF
--- a/k8s/production/common/skaffold.infra.yaml
+++ b/k8s/production/common/skaffold.infra.yaml
@@ -8,6 +8,15 @@ manifests:
     - k8s/production/postgres/postgres.yaml
     - k8s/production/redis/redis.yaml
     - k8s/production/kafka/kafka.yaml
+    - k8s/production/monitoring/prometheus-rbac.yaml
+    - k8s/production/monitoring/kube-state-metrics.yaml
+    - k8s/production/monitoring/prometheus-config.yaml
+    - k8s/production/monitoring/prometheus-pvc.yaml
+    - k8s/production/monitoring/prometheus-deployment.yaml
+    - k8s/production/monitoring/prometheus-service.yaml
+    - k8s/production/monitoring/otel-collector-config.yaml
+    - k8s/production/monitoring/otel-collector-deployment.yaml
+    - k8s/production/monitoring/otel-collector-service.yaml
   helm:
     releases:
       - name: envoy-gateway

--- a/k8s/production/monitoring/kube-state-metrics.yaml
+++ b/k8s/production/monitoring/kube-state-metrics.yaml
@@ -1,0 +1,136 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-state-metrics
+  namespace: chicmoz-prod
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-state-metrics
+rules:
+  - apiGroups: [""]
+    resources:
+      - configmaps
+      - secrets
+      - nodes
+      - pods
+      - services
+      - resourcequotas
+      - replicationcontrollers
+      - persistentvolumeclaims
+      - persistentvolumes
+      - namespaces
+      - endpoints
+      - limitranges
+    verbs: ["list", "watch"]
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+      - statefulsets
+    verbs: ["list", "watch"]
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs: ["list", "watch"]
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs: ["list", "watch"]
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+      - networkpolicies
+    verbs: ["list", "watch"]
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs: ["list", "watch"]
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+      - volumeattachments
+    verbs: ["list", "watch"]
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs: ["list", "watch"]
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs: ["list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics
+subjects:
+  - kind: ServiceAccount
+    name: kube-state-metrics
+    namespace: chicmoz-prod
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-state-metrics
+  namespace: chicmoz-prod
+  labels:
+    app: kube-state-metrics
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kube-state-metrics
+  template:
+    metadata:
+      labels:
+        app: kube-state-metrics
+    spec:
+      serviceAccountName: kube-state-metrics
+      containers:
+        - name: kube-state-metrics
+          image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 300m
+              memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-state-metrics
+  namespace: chicmoz-prod
+  labels:
+    app: kube-state-metrics
+spec:
+  type: ClusterIP
+  selector:
+    app: kube-state-metrics
+  ports:
+    - name: http-metrics
+      port: 8080
+      targetPort: http-metrics
+      protocol: TCP

--- a/k8s/production/monitoring/otel-collector-config.yaml
+++ b/k8s/production/monitoring/otel-collector-config.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+  namespace: chicmoz-prod
+data:
+  config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+
+    processors:
+      batch: {}
+
+    exporters:
+      prometheus:
+        endpoint: 0.0.0.0:8889
+        metric_expiration: 5m
+
+    service:
+      pipelines:
+        metrics:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [prometheus]

--- a/k8s/production/monitoring/otel-collector-deployment.yaml
+++ b/k8s/production/monitoring/otel-collector-deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+  namespace: chicmoz-prod
+  labels:
+    app: otel-collector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: otel-collector
+  template:
+    metadata:
+      labels:
+        app: otel-collector
+    spec:
+      containers:
+        - name: otel-collector
+          image: otel/opentelemetry-collector:0.148.0
+          args:
+            - --config=/etc/otel/config.yaml
+          ports:
+            - name: otlp-grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+            - name: prom-metrics
+              containerPort: 8889
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/otel
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: otel-collector-config
+            items:
+              - key: config.yaml
+                path: config.yaml

--- a/k8s/production/monitoring/otel-collector-service.yaml
+++ b/k8s/production/monitoring/otel-collector-service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector
+  namespace: chicmoz-prod
+  labels:
+    app: otel-collector
+spec:
+  type: ClusterIP
+  selector:
+    app: otel-collector
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      targetPort: otlp-grpc
+      protocol: TCP
+    - name: otlp-http
+      port: 4318
+      targetPort: otlp-http
+      protocol: TCP
+    - name: prom-metrics
+      port: 8889
+      targetPort: prom-metrics
+      protocol: TCP

--- a/k8s/production/monitoring/prometheus-config.yaml
+++ b/k8s/production/monitoring/prometheus-config.yaml
@@ -1,0 +1,177 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config-template
+  namespace: chicmoz-prod
+data:
+  prometheus.yml.tmpl: |
+    global:
+      scrape_interval: 30s
+      evaluation_interval: 30s
+      external_labels:
+        cluster: aztecscan-prod
+        source: k8s
+
+    scrape_configs:
+      - job_name: prometheus
+        static_configs:
+          - targets: ["localhost:9090"]
+
+      - job_name: otel-collector
+        static_configs:
+          - targets: ["otel-collector.chicmoz-prod.svc.cluster.local:8889"]
+
+      - job_name: kube-state-metrics
+        static_configs:
+          - targets: ["kube-state-metrics.chicmoz-prod.svc.cluster.local:8080"]
+
+      - job_name: kubernetes-services
+        kubernetes_sd_configs:
+          - role: service
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+            action: keep
+            regex: true
+          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+            action: replace
+            target_label: __scheme__
+            regex: (https?)
+          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+            action: replace
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+            target_label: __address__
+          - action: labelmap
+            regex: __meta_kubernetes_service_label_(.+)
+          - source_labels: [__meta_kubernetes_namespace]
+            action: replace
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_service_name]
+            action: replace
+            target_label: service
+          - source_labels: [__meta_kubernetes_service_name]
+            action: replace
+            target_label: network
+            regex: .*(mainnet).*
+            replacement: $1
+          - source_labels: [__meta_kubernetes_service_name]
+            action: replace
+            target_label: network
+            regex: .*(testnet).*
+            replacement: $1
+          - source_labels: [__meta_kubernetes_service_name]
+            action: replace
+            target_label: network
+            regex: .*(devnet).*
+            replacement: $1
+          - source_labels: [network]
+            action: replace
+            target_label: network
+            regex: ^$
+            replacement: infra
+
+      - job_name: kubernetes-pods
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+            action: keep
+            regex: true
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+            action: replace
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+            target_label: __address__
+          - action: labelmap
+            regex: __meta_kubernetes_pod_label_(.+)
+          - source_labels: [__meta_kubernetes_namespace]
+            action: replace
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            action: replace
+            target_label: pod
+          - source_labels: [__meta_kubernetes_pod_label_app]
+            action: replace
+            target_label: network
+            regex: .*(mainnet).*
+            replacement: $1
+          - source_labels: [__meta_kubernetes_pod_label_app]
+            action: replace
+            target_label: network
+            regex: .*(testnet).*
+            replacement: $1
+          - source_labels: [__meta_kubernetes_pod_label_app]
+            action: replace
+            target_label: network
+            regex: .*(devnet).*
+            replacement: $1
+          - source_labels: [__meta_kubernetes_pod_name]
+            action: replace
+            target_label: network
+            regex: .*(mainnet).*
+            replacement: $1
+          - source_labels: [__meta_kubernetes_pod_name]
+            action: replace
+            target_label: network
+            regex: .*(testnet).*
+            replacement: $1
+          - source_labels: [__meta_kubernetes_pod_name]
+            action: replace
+            target_label: network
+            regex: .*(devnet).*
+            replacement: $1
+          - source_labels: [network]
+            action: replace
+            target_label: network
+            regex: ^$
+            replacement: infra
+
+      - job_name: kubernetes-nodes
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        kubernetes_sd_configs:
+          - role: node
+        relabel_configs:
+          - action: labelmap
+            regex: __meta_kubernetes_node_label_(.+)
+          - target_label: __address__
+            replacement: kubernetes.default.svc:443
+          - source_labels: [__meta_kubernetes_node_name]
+            target_label: __metrics_path__
+            replacement: /api/v1/nodes/$1/proxy/metrics
+          - target_label: network
+            replacement: infra
+
+      - job_name: kubernetes-nodes-cadvisor
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        kubernetes_sd_configs:
+          - role: node
+        relabel_configs:
+          - action: labelmap
+            regex: __meta_kubernetes_node_label_(.+)
+          - target_label: __address__
+            replacement: kubernetes.default.svc:443
+          - source_labels: [__meta_kubernetes_node_name]
+            target_label: __metrics_path__
+            replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+          - target_label: network
+            replacement: infra
+
+    remote_write:
+      - url: __REMOTE_WRITE_URL__
+        authorization:
+          type: Bearer
+          credentials_file: /etc/prometheus/remote-write/REMOTE_WRITE_TOKEN

--- a/k8s/production/monitoring/prometheus-config.yaml
+++ b/k8s/production/monitoring/prometheus-config.yaml
@@ -24,6 +24,27 @@ data:
       - job_name: kube-state-metrics
         static_configs:
           - targets: ["kube-state-metrics.chicmoz-prod.svc.cluster.local:8080"]
+        metric_relabel_configs:
+          - source_labels: [pod]
+            action: replace
+            target_label: network
+            regex: .*(mainnet).*
+            replacement: $1
+          - source_labels: [pod]
+            action: replace
+            target_label: network
+            regex: .*(testnet).*
+            replacement: $1
+          - source_labels: [pod]
+            action: replace
+            target_label: network
+            regex: .*(devnet).*
+            replacement: $1
+          - source_labels: [network]
+            action: replace
+            target_label: network
+            regex: ^$
+            replacement: infra
 
       - job_name: kubernetes-services
         kubernetes_sd_configs:
@@ -169,6 +190,22 @@ data:
             replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
           - target_label: network
             replacement: infra
+        metric_relabel_configs:
+          - source_labels: [pod]
+            action: replace
+            target_label: network
+            regex: .*(mainnet).*
+            replacement: $1
+          - source_labels: [pod]
+            action: replace
+            target_label: network
+            regex: .*(testnet).*
+            replacement: $1
+          - source_labels: [pod]
+            action: replace
+            target_label: network
+            regex: .*(devnet).*
+            replacement: $1
 
     remote_write:
       - url: __REMOTE_WRITE_URL__

--- a/k8s/production/monitoring/prometheus-deployment.yaml
+++ b/k8s/production/monitoring/prometheus-deployment.yaml
@@ -1,0 +1,92 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: chicmoz-prod
+  labels:
+    app: prometheus
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      serviceAccountName: prometheus
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+      initContainers:
+        - name: render-config
+          image: alpine:3.20
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              REMOTE_WRITE_URL_ESCAPED=$(printf '%s\n' "$REMOTE_WRITE_URL" | sed 's/[&]/\\&/g')
+              sed "s|__REMOTE_WRITE_URL__|${REMOTE_WRITE_URL_ESCAPED}|g" /etc/prometheus/template/prometheus.yml.tmpl > /etc/prometheus/config/prometheus.yml
+          env:
+            - name: REMOTE_WRITE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: prom-remote-write
+                  key: REMOTE_WRITE_URL
+          volumeMounts:
+            - name: config-template
+              mountPath: /etc/prometheus/template
+              readOnly: true
+            - name: generated-config
+              mountPath: /etc/prometheus/config
+      containers:
+        - name: prometheus
+          image: prom/prometheus:v2.53.5
+          args:
+            - --config.file=/etc/prometheus/config/prometheus.yml
+            - --storage.tsdb.path=/prometheus
+            - --storage.tsdb.retention.time=15d
+            - --web.enable-lifecycle
+          ports:
+            - name: http
+              containerPort: 9090
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 2Gi
+          volumeMounts:
+            - name: generated-config
+              mountPath: /etc/prometheus/config
+              readOnly: true
+            - name: storage
+              mountPath: /prometheus
+            - name: remote-write
+              mountPath: /etc/prometheus/remote-write
+              readOnly: true
+      volumes:
+        - name: config-template
+          configMap:
+            name: prometheus-config-template
+            items:
+              - key: prometheus.yml.tmpl
+                path: prometheus.yml.tmpl
+        - name: generated-config
+          emptyDir: {}
+        - name: storage
+          persistentVolumeClaim:
+            claimName: prometheus-storage
+        - name: remote-write
+          secret:
+            secretName: prom-remote-write
+            items:
+              - key: REMOTE_WRITE_TOKEN
+                path: REMOTE_WRITE_TOKEN

--- a/k8s/production/monitoring/prometheus-pvc.yaml
+++ b/k8s/production/monitoring/prometheus-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: prometheus-storage
+  namespace: chicmoz-prod
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi

--- a/k8s/production/monitoring/prometheus-rbac.yaml
+++ b/k8s/production/monitoring/prometheus-rbac.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: chicmoz-prod
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-chicmoz-prod
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - services
+      - endpoints
+      - pods
+      - namespaces
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources:
+      - endpointslices
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-chicmoz-prod
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-chicmoz-prod
+subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: chicmoz-prod

--- a/k8s/production/monitoring/prometheus-service.yaml
+++ b/k8s/production/monitoring/prometheus-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: chicmoz-prod
+  labels:
+    app: prometheus
+spec:
+  type: ClusterIP
+  selector:
+    app: prometheus
+  ports:
+    - name: http
+      port: 9090
+      targetPort: http
+      protocol: TCP

--- a/k8s/production/skaffold.only_monitoring.yaml
+++ b/k8s/production/skaffold.only_monitoring.yaml
@@ -1,0 +1,19 @@
+apiVersion: skaffold/v4beta6
+kind: Config
+metadata:
+  name: only-monitoring-prod
+deploy:
+  kubectl:
+    flags:
+      apply: ["--force"]
+manifests:
+  rawYaml:
+    - k8s/production/monitoring/prometheus-rbac.yaml
+    - k8s/production/monitoring/kube-state-metrics.yaml
+    - k8s/production/monitoring/prometheus-config.yaml
+    - k8s/production/monitoring/prometheus-pvc.yaml
+    - k8s/production/monitoring/prometheus-deployment.yaml
+    - k8s/production/monitoring/prometheus-service.yaml
+    - k8s/production/monitoring/otel-collector-config.yaml
+    - k8s/production/monitoring/otel-collector-deployment.yaml
+    - k8s/production/monitoring/otel-collector-service.yaml

--- a/packages/message-bus/src/class.ts
+++ b/packages/message-bus/src/class.ts
@@ -178,7 +178,7 @@ export class MessageBus {
 
     await this.#consumers[groupId]!.consumer.run({
       // TODO: https://kafka.js.org/docs/consuming; probably need to look into manually committing instead in future
-      eachMessage: async ({ topic, message }) => {
+      eachMessage: async ({ topic, message, heartbeat }) => {
         // Yield the event loop between messages so that other consumers sharing
         // this Node.js process get a chance to fetch and process their messages.
         // Without this, a consumer with a large backlog (e.g. catchup) can
@@ -202,6 +202,12 @@ export class MessageBus {
         const data = deserializedObj.data as object;
         const cb = this.#consumers[groupId]?.topicCallbacks[topic];
         if (cb) {
+          // Send a heartbeat before invoking the handler so the broker knows
+          // the consumer is still alive during long-running DB operations.
+          // Without this, the broker may consider the consumer dead after the
+          // session timeout, trigger a group rebalance, and reset the offset —
+          // causing the same messages to be replayed indefinitely.
+          await heartbeat();
           try {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
             await cb(data);

--- a/services/aztec-listener/tests/mocks/index.ts
+++ b/services/aztec-listener/tests/mocks/index.ts
@@ -59,6 +59,7 @@ export const createMockL2Block = (
   hash: vi
     .fn()
     .mockResolvedValue({ toString: () => `block-${blockNumber}-hash` }),
+  toBuffer: vi.fn().mockReturnValue(Buffer.alloc(0)),
   toString: vi.fn().mockReturnValue(`mock-block-${blockNumber}`),
 });
 

--- a/services/explorer-api/src/events/received/on-block/index.ts
+++ b/services/explorer-api/src/events/received/on-block/index.ts
@@ -133,14 +133,10 @@ const storeBlock = async (parsedBlock: ChicmozL2Block, haveRetried = false) => {
 
       if (shouldRetry) {
         return storeBlock(parsedBlock, true);
-      } else {
-        await ensureFinalizationStatusStored(
-          // NOTE: this is currently assuming that the error is a duplicate error
-          parsedBlock.hash,
-          parsedBlock.height,
-          parsedBlock.finalizationStatus,
-        );
       }
+      // When shouldRetry is false and the un-orphan path was taken,
+      // ensureFinalizationStatusStored was already called inside unOrphanCallback.
+      // No additional call needed here.
     });
 
   await emit.l2BlockFinalizationUpdate(storeRes?.finalizationUpdate ?? null);

--- a/services/explorer-api/src/svcs/database/controllers/l2block/store.ts
+++ b/services/explorer-api/src/svcs/database/controllers/l2block/store.ts
@@ -266,27 +266,32 @@ const ensureParentBlocksFinalizationStatusStored = async (
     const blocksWithMissingStatus = await blocksOnOtherStatus
       .except(allBlocksOnSameStatus)
       .orderBy(asc(l2BlockFinalizationStatusTable.l2BlockNumber));
-    let counter = 0;
-    if (blocksWithMissingStatus.length > 0) {
-      logger.info(
-        `Ensuring finalization status ${ChicmozL2BlockFinalizationStatus[status]} for ${blocksWithMissingStatus.length} blocks before block ${l2BlockNumber}`,
-      );
+
+    if (blocksWithMissingStatus.length === 0) {
+      return;
     }
-    for (const block of blocksWithMissingStatus) {
-      if (blocksWithMissingStatus.length < 25) {
-        logger.info(
-          `Ensuring status ${ChicmozL2BlockFinalizationStatus[status]} for block ${block.blockNumber} (${block.hash})`,
-        );
-      } else if (counter++ % 100 === 0) {
-        logger.info(
-          `Ensuring status ${ChicmozL2BlockFinalizationStatus[status]} for block ${block.blockNumber} (${counter} of ${blocksWithMissingStatus.length} processed)`,
-        );
-      }
-      await _ensureFinalizationStatusStored(
-        block.hash,
-        block.blockNumber,
-        status,
-      );
+
+    logger.info(
+      `Ensuring finalization status ${ChicmozL2BlockFinalizationStatus[status]} for ${blocksWithMissingStatus.length} blocks before block ${l2BlockNumber}`,
+    );
+
+    const rowsToInsert = blocksWithMissingStatus.map((block) => ({
+      l2BlockHash: block.hash,
+      l2BlockNumber: block.blockNumber,
+      status,
+    }));
+
+    // Batch the INSERTs so each statement stays below PostgreSQL's
+    // 65,535 bind-parameter limit. We insert 3 columns per row.
+    const insertedColumnCount = 3;
+    const maxBindParameters = 65_535;
+    const batchSize = Math.floor(maxBindParameters / insertedColumnCount);
+
+    for (let i = 0; i < rowsToInsert.length; i += batchSize) {
+      await tx
+        .insert(l2BlockFinalizationStatusTable)
+        .values(rowsToInsert.slice(i, i + batchSize))
+        .onConflictDoNothing();
     }
   });
 };


### PR DESCRIPTION
## Summary

Merges `main` into `production` (mainnet).

### Key fix included

- **fix: prevent Kafka consumer offset replay loop on un-orphan path** (#603)
  - Adds `heartbeat()` call in KafkaJS `eachMessage` handler to prevent broker rebalance during long DB operations
  - Replaces O(N) serial INSERT loop in `ensureParentBlocksFinalizationStatusStored` with a single bulk INSERT
  - Removes duplicate `ensureFinalizationStatusStored` call in the un-orphan code path