### PR TITLE
fix: cherry-pick Kafka consumer offset replay loop fix onto production-testnet

### DIFF
--- a/packages/message-bus/src/class.ts
+++ b/packages/message-bus/src/class.ts
@@ -178,10 +178,18 @@ export class MessageBus {
     this.nonRetriableWrapper(groupId);
 
     await this.#consumers[groupId]!.consumer.run({
-      eachMessage: async ({ topic, message }) => {
+      // TODO: https://kafka.js.org/docs/consuming; probably need to look into manually committing instead in future
+      eachMessage: async ({ topic, message, heartbeat }) => {
         // this.logger.info(
         //   `Kafka: received message from topic ${topic} in group ${groupId}`
         // );
+        // Yield the event loop between messages so that other consumers sharing
+        // this Node.js process get a chance to fetch and process their messages.
+        // Without this, a consumer with a large backlog (e.g. catchup) can
+        // starve other consumers (e.g. tip-of-chain block handler) by
+        // monopolizing the event loop with back-to-back await chains.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         // Convert Buffer to Uint8Array before deserializing
         const messageValue = message.value!;
@@ -201,6 +209,12 @@ export class MessageBus {
         const data = deserializedObj.data as object;
         const cb = this.#consumers[groupId]?.topicCallbacks[topic];
         if (cb) {
+          // Send a heartbeat before invoking the handler so the broker knows
+          // the consumer is still alive during long-running DB operations.
+          // Without this, the broker may consider the consumer dead after the
+          // session timeout, trigger a group rebalance, and reset the offset —
+          // causing the same messages to be replayed indefinitely.
+          await heartbeat();
           try {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
             await cb(data);

--- a/services/aztec-listener/tests/mocks/index.ts
+++ b/services/aztec-listener/tests/mocks/index.ts
@@ -59,6 +59,7 @@ export const createMockL2Block = (
   hash: vi
     .fn()
     .mockResolvedValue({ toString: () => `block-${blockNumber}-hash` }),
+  toBuffer: vi.fn().mockReturnValue(Buffer.alloc(0)),
   toString: vi.fn().mockReturnValue(`mock-block-${blockNumber}`),
 });
 

--- a/services/explorer-api/src/events/received/on-block/index.ts
+++ b/services/explorer-api/src/events/received/on-block/index.ts
@@ -133,14 +133,10 @@ const storeBlock = async (parsedBlock: ChicmozL2Block, haveRetried = false) => {
 
       if (shouldRetry) {
         return storeBlock(parsedBlock, true);
-      } else {
-        await ensureFinalizationStatusStored(
-          // NOTE: this is currently assuming that the error is a duplicate error
-          parsedBlock.hash,
-          parsedBlock.height,
-          parsedBlock.finalizationStatus,
-        );
       }
+      // When shouldRetry is false and the un-orphan path was taken,
+      // ensureFinalizationStatusStored was already called inside unOrphanCallback.
+      // No additional call needed here.
     });
 
   await emit.l2BlockFinalizationUpdate(storeRes?.finalizationUpdate ?? null);

--- a/services/explorer-api/src/svcs/database/controllers/l2block/store.ts
+++ b/services/explorer-api/src/svcs/database/controllers/l2block/store.ts
@@ -275,18 +275,23 @@ const ensureParentBlocksFinalizationStatusStored = async (
       `Ensuring finalization status ${ChicmozL2BlockFinalizationStatus[status]} for ${blocksWithMissingStatus.length} blocks before block ${l2BlockNumber}`,
     );
 
-    // Bulk INSERT all missing finalization status rows in a single statement
-    // instead of a serial loop, to avoid stalling the Kafka consumer heartbeat
-    // when there are tens of thousands of ancestor blocks to backfill.
-    await tx
-      .insert(l2BlockFinalizationStatusTable)
-      .values(
-        blocksWithMissingStatus.map((block) => ({
-          l2BlockHash: block.hash,
-          l2BlockNumber: block.blockNumber,
-          status,
-        })),
-      )
-      .onConflictDoNothing();
+    const rowsToInsert = blocksWithMissingStatus.map((block) => ({
+      l2BlockHash: block.hash,
+      l2BlockNumber: block.blockNumber,
+      status,
+    }));
+
+    // Batch the INSERTs so each statement stays below PostgreSQL's
+    // 65,535 bind-parameter limit. We insert 3 columns per row.
+    const insertedColumnCount = 3;
+    const maxBindParameters = 65_535;
+    const batchSize = Math.floor(maxBindParameters / insertedColumnCount);
+
+    for (let i = 0; i < rowsToInsert.length; i += batchSize) {
+      await tx
+        .insert(l2BlockFinalizationStatusTable)
+        .values(rowsToInsert.slice(i, i + batchSize))
+        .onConflictDoNothing();
+    }
   });
 };

--- a/services/explorer-api/src/svcs/database/controllers/l2block/store.ts
+++ b/services/explorer-api/src/svcs/database/controllers/l2block/store.ts
@@ -266,27 +266,27 @@ const ensureParentBlocksFinalizationStatusStored = async (
     const blocksWithMissingStatus = await blocksOnOtherStatus
       .except(allBlocksOnSameStatus)
       .orderBy(asc(l2BlockFinalizationStatusTable.l2BlockNumber));
-    let counter = 0;
-    if (blocksWithMissingStatus.length > 0) {
-      logger.info(
-        `Ensuring finalization status ${ChicmozL2BlockFinalizationStatus[status]} for ${blocksWithMissingStatus.length} blocks before block ${l2BlockNumber}`,
-      );
+
+    if (blocksWithMissingStatus.length === 0) {
+      return;
     }
-    for (const block of blocksWithMissingStatus) {
-      if (blocksWithMissingStatus.length < 25) {
-        logger.info(
-          `Ensuring status ${ChicmozL2BlockFinalizationStatus[status]} for block ${block.blockNumber} (${block.hash})`,
-        );
-      } else if (counter++ % 100 === 0) {
-        logger.info(
-          `Ensuring status ${ChicmozL2BlockFinalizationStatus[status]} for block ${block.blockNumber} (${counter} of ${blocksWithMissingStatus.length} processed)`,
-        );
-      }
-      await _ensureFinalizationStatusStored(
-        block.hash,
-        block.blockNumber,
-        status,
-      );
-    }
+
+    logger.info(
+      `Ensuring finalization status ${ChicmozL2BlockFinalizationStatus[status]} for ${blocksWithMissingStatus.length} blocks before block ${l2BlockNumber}`,
+    );
+
+    // Bulk INSERT all missing finalization status rows in a single statement
+    // instead of a serial loop, to avoid stalling the Kafka consumer heartbeat
+    // when there are tens of thousands of ancestor blocks to backfill.
+    await tx
+      .insert(l2BlockFinalizationStatusTable)
+      .values(
+        blocksWithMissingStatus.map((block) => ({
+          l2BlockHash: block.hash,
+          l2BlockNumber: block.blockNumber,
+          status,
+        })),
+      )
+      .onConflictDoNothing();
   });
 };


### PR DESCRIPTION
## Summary

Cherry-pick of the Kafka consumer offset replay loop fix (merged in #603) onto `production-testnet`.

### Commits included
- `7e7afba` — fix: prevent Kafka consumer offset replay loop on un-orphan path
- `2280895` — Update services/explorer-api/src/svcs/database/controllers/l2block/store.ts
- `3bafd8e` — fix: add toBuffer mock to createMockL2Block to fix failing tests

### What this fixes
Three compounding issues caused the explorer-api Kafka consumer to enter an infinite message-replay loop when processing `NEW_BLOCK_EVENT` during an un-orphan path with a large ancestor chain (~30k blocks on TESTNET):

1. `ensureParentBlocksFinalizationStatusStored` ran an O(N) serial INSERT loop (one DB round-trip per ancestor), stalling the consumer thread for longer than KafkaJS's session timeout.
2. KafkaJS `eachMessage` lacked a `heartbeat()` call — the broker declared the consumer dead, rebalanced the group, and reset offsets, causing the same messages to replay indefinitely.
3. `ensureFinalizationStatusStored` was called twice per un-orphan cycle.

### Changes
- `packages/message-bus/src/class.ts`: Add `heartbeat` to `eachMessage` signature, call `await heartbeat()` before handler dispatch, add `setTimeout(0)` yield to avoid event-loop starvation.
- `services/explorer-api/src/svcs/database/controllers/l2block/store.ts`: Replace O(N) serial INSERT loop with a single bulk INSERT in `ensureParentBlocksFinalizationStatusStored`.
- `services/explorer-api/src/events/received/on-block/index.ts`: Remove duplicate `ensureFinalizationStatusStored` call.

> **Note**: This is a targeted cherry-pick onto `production-testnet`. It does NOT merge `main` into the production branch — the production branch has unique commits that are not in `main`.