### PR TITLE
chore: improve local developtment (deployed on separate machine)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,37 @@ yarn build
 yarn dev
 ```
 
+You can also keep the backend stack on another machine and tunnel the sandbox gateway over SSH.
+
+Run the backend machine as usual:
+
+```sh
+skaffold run --filename k8s/local/skaffold.sandbox_no_ui.yaml
+./scripts/miscellaneous.sh
+```
+
+Then, on the UI machine, forward a local port to the backend machine's current gateway NodePort and keep using the existing sandbox hostname locally:
+
+```sh
+ssh -N -L 8080:<remote-minikube-ip>:<remote-gateway-nodeport> <remote-host>
+```
+
+You can discover those values on the backend machine with:
+
+```sh
+minikube ip
+kubectl get svc -n envoy-gateway-system -o wide
+```
+
+```sh
+VITE_L2_NETWORK_ID=SANDBOX \
+VITE_API_KEY=dev-api-key \
+VITE_API_URL=http://api.sandbox.chicmoz.localhost:8080/v1 \
+yarn dev
+```
+
+If websocket forwarding is not set up yet, leave `VITE_WS_URL` unset.
+
 ## Code Overview
 
 ### services/aztec-listener

--- a/k8s/local/anvil-ethereum-node/deployment.yaml
+++ b/k8s/local/anvil-ethereum-node/deployment.yaml
@@ -10,7 +10,8 @@ spec:
   selector:
     matchLabels:
       app: anvil-ethereum-node
-  strategy: {}
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
@@ -20,6 +21,9 @@ spec:
         - image: aztecprotocol/foundry
           name: anvil-ethereum-node
           resources:
+            requests:
+              memory: 300Mi
+              cpu: 100m
             limits:
               memory: 300Mi
               cpu: 250m

--- a/k8s/local/auth/deployment.yaml
+++ b/k8s/local/auth/deployment.yaml
@@ -10,7 +10,8 @@ spec:
   selector:
     matchLabels:
       app: auth-label
-  strategy: {}
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
@@ -19,6 +20,9 @@ spec:
       containers:
         - image: auth:latest
           resources:
+            requests:
+              memory: 1000Mi
+              cpu: 100m
             limits:
               memory: 1000Mi
               cpu: 500m

--- a/k8s/local/aztec-listener/sandbox/deployment.yaml
+++ b/k8s/local/aztec-listener/sandbox/deployment.yaml
@@ -10,6 +10,8 @@ spec:
   selector:
     matchLabels:
       app: aztec-listener-sandbox-label
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
@@ -27,6 +29,9 @@ spec:
       containers:
         - image: aztec-listener:latest
           resources:
+            requests:
+              memory: 750Mi
+              cpu: 100m
             limits:
               memory: 750Mi
               cpu: 500m

--- a/k8s/local/aztec-sandbox-node/deployment.yaml
+++ b/k8s/local/aztec-sandbox-node/deployment.yaml
@@ -10,7 +10,8 @@ spec:
   selector:
     matchLabels:
       app: aztec-sandbox-node
-  strategy: {}
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
@@ -29,6 +30,9 @@ spec:
         - image: aztecprotocol/aztec:4.1.1
           name: aztec-sandbox-node
           resources:
+            requests:
+              memory: 2Gi
+              cpu: 500m
             limits:
               memory: 4Gi
               cpu: 2000m

--- a/k8s/local/common/skaffold.aztec_sanbox_nodes.yaml
+++ b/k8s/local/common/skaffold.aztec_sanbox_nodes.yaml
@@ -10,11 +10,8 @@ deploy:
 manifests:
   rawYaml:
     - ../aztec-sandbox-node/httproute.yaml
-    - ../aztec-sandbox-node/clienttrafficpolicy.yaml
     - ../aztec-sandbox-node/deployment.yaml
     - ../aztec-sandbox-node/service.yaml
-    - ../aztec-sandbox-node/config.yaml
-    - ../anvil-ethereum-node/config.yaml
     - ../anvil-ethereum-node/httproute.yaml
     - ../anvil-ethereum-node/deployment.yaml
     - ../anvil-ethereum-node/service.yaml

--- a/k8s/local/ethereum-listener/sandbox/deployment.yaml
+++ b/k8s/local/ethereum-listener/sandbox/deployment.yaml
@@ -10,7 +10,8 @@ spec:
   selector:
     matchLabels:
       app: ethereum-listener-sandbox-label
-  strategy: {}
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
@@ -31,6 +32,9 @@ spec:
       containers:
         - image: ethereum-listener:latest
           resources:
+            requests:
+              memory: 300Mi
+              cpu: 100m
             limits:
               memory: 300Mi
               cpu: 500m

--- a/k8s/local/event-cannon/deployment.yaml
+++ b/k8s/local/event-cannon/deployment.yaml
@@ -10,7 +10,8 @@ spec:
   selector:
     matchLabels:
       app: event-cannon-label
-  strategy: {}
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
@@ -19,6 +20,9 @@ spec:
       containers:
         - image: event-cannon:latest
           resources:
+            requests:
+              memory: 2Gi
+              cpu: 100m
             limits:
               memory: 2Gi
               cpu: 500m

--- a/k8s/local/explorer-api/sandbox/deployment.yaml
+++ b/k8s/local/explorer-api/sandbox/deployment.yaml
@@ -10,6 +10,8 @@ spec:
   selector:
     matchLabels:
       app: explorer-api-sandbox-label
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
@@ -30,6 +32,9 @@ spec:
       containers:
         - image: explorer-api:latest
           resources:
+            requests:
+              memory: 600Mi
+              cpu: 100m
             limits:
               memory: 600Mi
               cpu: 500m

--- a/k8s/local/websocket-event-publisher/sandbox/deployment.yaml
+++ b/k8s/local/websocket-event-publisher/sandbox/deployment.yaml
@@ -10,6 +10,8 @@ spec:
   selector:
     matchLabels:
       app: websocket-event-publisher-sandbox-label
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
@@ -23,6 +25,9 @@ spec:
               containerPort: 3000
               protocol: TCP
           resources:
+            requests:
+              memory: 300Mi
+              cpu: 100m
             limits:
               memory: 300Mi
               cpu: 500m

--- a/scripts/miscellaneous.sh
+++ b/scripts/miscellaneous.sh
@@ -1,14 +1,19 @@
 #!/bin/bash
 
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)"
+PROJECT_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+TUNNEL_BIND_ADDRESS="${CHICMOZ_MINIKUBE_TUNNEL_BIND_ADDRESS:-127.0.0.1}"
 
 # Create the namespace
 kubectl create namespace chicmoz --dry-run=client -o yaml | kubectl apply -f -
 
 # Apply gateway CRDs
-kubectl kustomize k8s/common/gateway-crds | kubectl apply -f -
+kubectl kustomize "$PROJECT_ROOT/k8s/common/gateway-crds" | kubectl apply -f -
 
 if bash "$(dirname "$0")/create_local_secrets.sh"; then
-    minikube tunnel --bind-address 127.0.0.1
+    minikube tunnel --bind-address "$TUNNEL_BIND_ADDRESS"
 else
     echo "Error: Failed to create secrets. Minikube tunnel will not be started."
     exit 1

--- a/services/explorer-ui/src/hooks/websocket/index.ts
+++ b/services/explorer-ui/src/hooks/websocket/index.ts
@@ -91,6 +91,11 @@ export const useWebSocketConnection = (): WsReadyStateText => {
 
   // Handle WebSocket connection based on tab visibility
   useEffect(() => {
+    if (!WS_URL) {
+      setReadyState(WebSocket.CLOSED);
+      return;
+    }
+
     // Function to initialize or reconnect WebSocket
     const initializeWebSocket = () => {
       if (!isTabActive) {
@@ -118,7 +123,11 @@ export const useWebSocketConnection = (): WsReadyStateText => {
         !websocketInstance ||
         websocketInstance.readyState === WebSocket.CLOSED
       ) {
-        websocketInstance = createWebSocket(queryClient, setReadyState, isTabActive);
+        websocketInstance = createWebSocket(
+          queryClient,
+          setReadyState,
+          isTabActive,
+        );
       } else {
         // Update readyState to match existing connection
         // If it's open, make sure UI reflects that


### PR DESCRIPTION
Make the sandbox no-ui stack easier to run on another machine and tunnel into from a local frontend. This removes broken node manifest references, makes the helper and UI more tolerant of remote API-only workflows, and tunes the local sandbox deployments for single-node minikube.