### PR TITLE
feat: add dynamic fee juice token metadata and token-aware formatting

### DIFF
--- a/packages/types/src/aztec/general.ts
+++ b/packages/types/src/aztec/general.ts
@@ -33,6 +33,8 @@ export const chicmozChainInfoSchema = z.object({
   protocolContractAddresses: ProtocolContractAddressesSchema,
   stakingAssetSymbol: z.string().optional(),
   stakingAssetDecimals: z.number().int().nonnegative().optional(),
+  feeJuiceSymbol: z.string().optional(),
+  feeJuiceDecimals: z.number().int().nonnegative().optional(),
   createdAt: z.coerce.date().optional(),
   latestUpdateAt: z.coerce.date().optional(),
 });

--- a/services/ethereum-listener/src/events/emitted/index.ts
+++ b/services/ethereum-listener/src/events/emitted/index.ts
@@ -11,6 +11,8 @@ type StakingAssetInfoEvent = {
   chainInfo: ChicmozChainInfo & {
     stakingAssetSymbol?: string;
     stakingAssetDecimals?: number;
+    feeJuiceSymbol?: string;
+    feeJuiceDecimals?: number;
   };
 };
 

--- a/services/ethereum-listener/src/events/received/index.ts
+++ b/services/ethereum-listener/src/events/received/index.ts
@@ -31,36 +31,75 @@ const erc20MetadataAbi = [
   },
 ] as const;
 
-const publishStakingAssetInfo = async (
-  chainInfo: ChicmozChainInfo,
-): Promise<void> => {
-  const { stakingAssetAddress } = chainInfo.l1ContractAddresses;
+type TokenMetadata = {
+  symbol?: string;
+  decimals?: number;
+};
 
-  if (!stakingAssetAddress || !isAddress(stakingAssetAddress)) {
+const getTokenMetadata = async ({
+  address,
+  tokenName,
+}: {
+  address: string;
+  tokenName: string;
+}): Promise<TokenMetadata> => {
+  if (!address || !isAddress(address)) {
     logger.warn(
-      `Skipping staking asset metadata publish due to invalid address: ${stakingAssetAddress}`,
+      `Skipping ${tokenName} metadata publish due to invalid address: ${address}`,
     );
-    return;
+    return {};
   }
 
-  const [stakingAssetSymbol, stakingAssetDecimals] = await Promise.all([
-    getPublicHttpClient().readContract({
+  try {
+    const [symbol, decimals] = await Promise.all([
+      getPublicHttpClient().readContract({
+        address: address ,
+        abi: erc20MetadataAbi,
+        functionName: "symbol",
+      }),
+      getPublicHttpClient().readContract({
+        address: address ,
+        abi: erc20MetadataAbi,
+        functionName: "decimals",
+      }),
+    ]);
+
+    return {
+      symbol,
+      decimals,
+    };
+  } catch (error) {
+    logger.error(
+      `Failed to fetch ${tokenName} metadata for ${address}: ${(error as Error).stack}`,
+    );
+    return {};
+  }
+};
+
+const publishChainInfoTokenMetadata = async (
+  chainInfo: ChicmozChainInfo,
+): Promise<void> => {
+  const { stakingAssetAddress, feeJuiceAddress } =
+    chainInfo.l1ContractAddresses;
+
+  const [stakingAssetMetadata, feeJuiceMetadata] = await Promise.all([
+    getTokenMetadata({
       address: stakingAssetAddress,
-      abi: erc20MetadataAbi,
-      functionName: "symbol",
+      tokenName: "staking asset",
     }),
-    getPublicHttpClient().readContract({
-      address: stakingAssetAddress,
-      abi: erc20MetadataAbi,
-      functionName: "decimals",
+    getTokenMetadata({
+      address: feeJuiceAddress,
+      tokenName: "fee juice",
     }),
   ]);
 
   await emit.stakingAssetInfo({
     chainInfo: {
       ...chainInfo,
-      stakingAssetSymbol,
-      stakingAssetDecimals,
+      stakingAssetSymbol: stakingAssetMetadata.symbol,
+      stakingAssetDecimals: stakingAssetMetadata.decimals,
+      feeJuiceSymbol: feeJuiceMetadata.symbol,
+      feeJuiceDecimals: feeJuiceMetadata.decimals,
     },
   });
 };
@@ -70,9 +109,11 @@ export const onChainInfo = async (event: ChicmozChainInfoEvent) => {
   await storeL1ContractAddresses(event.chainInfo.l1ContractAddresses);
 
   try {
-    await publishStakingAssetInfo(event.chainInfo);
+    await publishChainInfoTokenMetadata(event.chainInfo);
   } catch (e) {
-    logger.error(`Failed to publish staking asset info: ${(e as Error).stack}`);
+    logger.error(
+      `Failed to publish chain info token metadata: ${(e as Error).stack}`,
+    );
   }
 
   await ensureStarted();

--- a/services/ethereum-listener/src/events/received/index.ts
+++ b/services/ethereum-listener/src/events/received/index.ts
@@ -53,20 +53,26 @@ const getTokenMetadata = async ({
   try {
     const [symbol, decimals] = await Promise.all([
       getPublicHttpClient().readContract({
-        address: address ,
+        address: address,
         abi: erc20MetadataAbi,
         functionName: "symbol",
       }),
       getPublicHttpClient().readContract({
-        address: address ,
+        address: address,
         abi: erc20MetadataAbi,
         functionName: "decimals",
       }),
     ]);
 
+    if (decimals > 255n) {
+      throw new Error(
+        `Invalid ${tokenName} decimals for ${address}: ${decimals}`,
+      );
+    }
+
     return {
       symbol,
-      decimals,
+      decimals: Number(decimals),
     };
   } catch (error) {
     logger.error(

--- a/services/explorer-api/Dockerfile
+++ b/services/explorer-api/Dockerfile
@@ -10,6 +10,7 @@ ENV VERSION_STRING $VERSION_STRING
 RUN yarn workspaces focus @chicmoz/explorer-api
 COPY . .
 RUN yarn build
+RUN yarn workspaces focus @chicmoz/explorer-api --production
 
 FROM node:22-trixie-slim
 WORKDIR /usr/main/services/explorer-api
@@ -18,6 +19,12 @@ WORKDIR /usr/main/services/explorer-api
 ARG VERSION_STRING
 ENV VERSION_STRING $VERSION_STRING
 
-COPY --from=BUILD /usr/main /usr/main
+COPY --from=BUILD /usr/main/.yarn /usr/main/.yarn
+COPY --from=BUILD /usr/main/.yarnrc.yml /usr/main/.yarnrc.yml
+COPY --from=BUILD /usr/main/package.json /usr/main/package.json
+COPY --from=BUILD /usr/main/yarn.lock /usr/main/yarn.lock
+COPY --from=BUILD /usr/main/node_modules /usr/main/node_modules
+COPY --from=BUILD /usr/main/packages /usr/main/packages
+COPY --from=BUILD /usr/main/services/explorer-api /usr/main/services/explorer-api
 
 CMD ["yarn", "run", "start"]

--- a/services/explorer-api/migrations/0015_old_madame_hydra.sql
+++ b/services/explorer-api/migrations/0015_old_madame_hydra.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "l2_chain_info" ADD COLUMN "fee_juice_symbol" varchar;--> statement-breakpoint
+ALTER TABLE "l2_chain_info" ADD COLUMN "fee_juice_decimals" integer;

--- a/services/explorer-api/migrations/meta/0015_snapshot.json
+++ b/services/explorer-api/migrations/meta/0015_snapshot.json
@@ -1,0 +1,2710 @@
+{
+  "id": "d335544a-c63e-448f-88c5-cadf469afefd",
+  "prevId": "8fdd931a-557d-4eac-ae24-d70ea4d9f8a4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.aztec-chain-connection": {
+      "name": "aztec-chain-connection",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "chain_height": {
+          "name": "chain_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latest_processed_height": {
+          "name": "latest_processed_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rpc_url": {
+          "name": "rpc_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_version": {
+          "name": "node_version",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_chain_id": {
+          "name": "l1_chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollup_version": {
+          "name": "rollup_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enr": {
+          "name": "enr",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "l1_contract_addresses": {
+          "name": "l1_contract_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol_contract_addresses": {
+          "name": "protocol_contract_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.contract_instance_balance": {
+      "name": "contract_instance_balance",
+      "schema": "",
+      "columns": {
+        "contract_address": {
+          "name": "contract_address",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric(77, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "contract_instance_balance_pk": {
+          "name": "contract_instance_balance_pk",
+          "columns": ["contract_address", "timestamp"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.dropped_tx": {
+      "name": "dropped_tx",
+      "schema": "",
+      "columns": {
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_as_pending_at": {
+          "name": "created_as_pending_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dropped_at": {
+          "name": "dropped_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l2_chain_info": {
+      "name": "l2_chain_info",
+      "schema": "",
+      "columns": {
+        "l2_network_id": {
+          "name": "l2_network_id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "l1_chain_id": {
+          "name": "l1_chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollup_version": {
+          "name": "rollup_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staking_asset_symbol": {
+          "name": "staking_asset_symbol",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "staking_asset_decimals": {
+          "name": "staking_asset_decimals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_juice_symbol": {
+          "name": "fee_juice_symbol",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_juice_decimals": {
+          "name": "fee_juice_decimals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "l1_contract_addresses": {
+          "name": "l1_contract_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol_contract_addresses": {
+          "name": "protocol_contract_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.body": {
+      "name": "body",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "block_hash": {
+          "name": "block_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "body_block_hash_idx": {
+          "name": "body_block_hash_idx",
+          "columns": [
+            {
+              "expression": "block_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "body_block_hash_l2Block_hash_fk": {
+          "name": "body_block_hash_l2Block_hash_fk",
+          "tableFrom": "body",
+          "tableTo": "l2Block",
+          "columnsFrom": ["block_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.public_data_write": {
+      "name": "public_data_write",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tx_effect_hash": {
+          "name": "tx_effect_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "leaf_slot": {
+          "name": "leaf_slot",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "public_data_write_tx_effect_hash_idx": {
+          "name": "public_data_write_tx_effect_hash_idx",
+          "columns": [
+            {
+              "expression": "tx_effect_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_data_write_index_idx": {
+          "name": "public_data_write_index_idx",
+          "columns": [
+            {
+              "expression": "index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_data_write_tx_effect_hash_index_idx": {
+          "name": "public_data_write_tx_effect_hash_index_idx",
+          "columns": [
+            {
+              "expression": "tx_effect_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "public_data_write_tx_effect_hash_tx_effect_tx_hash_fk": {
+          "name": "public_data_write_tx_effect_hash_tx_effect_tx_hash_fk",
+          "tableFrom": "public_data_write",
+          "tableTo": "tx_effect",
+          "columnsFrom": ["tx_effect_hash"],
+          "columnsTo": ["tx_hash"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.tx_effect": {
+      "name": "tx_effect",
+      "schema": "",
+      "columns": {
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "body_id": {
+          "name": "body_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_time_of_birth": {
+          "name": "tx_time_of_birth",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "EXTRACT(EPOCH FROM NOW()) * 1000"
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revert_code": {
+          "name": "revert_code",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_fee": {
+          "name": "transaction_fee",
+          "type": "numeric(77, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_hashes": {
+          "name": "note_hashes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nullifiers": {
+          "name": "nullifiers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l2_to_l1_msgs": {
+          "name": "l2_to_l1_msgs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_logs": {
+          "name": "private_logs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_logs": {
+          "name": "public_logs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_class_logs": {
+          "name": "contract_class_logs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tx_hash_index": {
+          "name": "tx_hash_index",
+          "columns": [
+            {
+              "expression": "tx_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tx_effect_body_id_idx": {
+          "name": "tx_effect_body_id_idx",
+          "columns": [
+            {
+              "expression": "body_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tx_effect_index_idx": {
+          "name": "tx_effect_index_idx",
+          "columns": [
+            {
+              "expression": "index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tx_effect_body_id_index_idx": {
+          "name": "tx_effect_body_id_index_idx",
+          "columns": [
+            {
+              "expression": "body_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tx_effect_body_id_body_id_fk": {
+          "name": "tx_effect_body_id_body_id_fk",
+          "tableFrom": "tx_effect",
+          "tableTo": "body",
+          "columnsFrom": ["body_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.gas_fees": {
+      "name": "gas_fees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "global_variables_id": {
+          "name": "global_variables_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_per_da_gas": {
+          "name": "fee_per_da_gas",
+          "type": "numeric(77, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_per_l2_gas": {
+          "name": "fee_per_l2_gas",
+          "type": "numeric(77, 0)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "gas_fees_global_variables_id_idx": {
+          "name": "gas_fees_global_variables_id_idx",
+          "columns": [
+            {
+              "expression": "global_variables_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gas_fees_global_variables_id_global_variables_id_fk": {
+          "name": "gas_fees_global_variables_id_global_variables_id_fk",
+          "tableFrom": "gas_fees",
+          "tableTo": "global_variables",
+          "columnsFrom": ["global_variables_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.global_variables": {
+      "name": "global_variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "header_id": {
+          "name": "header_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_number": {
+          "name": "slot_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coinbase": {
+          "name": "coinbase",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_recipient": {
+          "name": "fee_recipient",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "global_variables_header_id_idx": {
+          "name": "global_variables_header_id_idx",
+          "columns": [
+            {
+              "expression": "header_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "global_variables_version_idx": {
+          "name": "global_variables_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "global_variables_header_id_header_id_fk": {
+          "name": "global_variables_header_id_header_id_fk",
+          "tableFrom": "global_variables",
+          "tableTo": "header",
+          "columnsFrom": ["header_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.header": {
+      "name": "header",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "block_hash": {
+          "name": "block_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_fees": {
+          "name": "total_fees",
+          "type": "numeric(77, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_mana_used": {
+          "name": "total_mana_used",
+          "type": "numeric(77, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sponge_blob_hash": {
+          "name": "sponge_blob_hash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "header_block_hash_idx": {
+          "name": "header_block_hash_idx",
+          "columns": [
+            {
+              "expression": "block_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "header_block_hash_l2Block_hash_fk": {
+          "name": "header_block_hash_l2Block_hash_fk",
+          "tableFrom": "header",
+          "tableTo": "l2Block",
+          "columnsFrom": ["block_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l1_to_l2_message_tree": {
+      "name": "l1_to_l2_message_tree",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "root": {
+          "name": "root",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_available_leaf_index": {
+          "name": "next_available_leaf_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_id": {
+          "name": "state_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l1_to_l2_message_tree_state_id_state_id_fk": {
+          "name": "l1_to_l2_message_tree_state_id_state_id_fk",
+          "tableFrom": "l1_to_l2_message_tree",
+          "tableTo": "state",
+          "columnsFrom": ["state_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.last_archive": {
+      "name": "last_archive",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "root": {
+          "name": "root",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_available_leaf_index": {
+          "name": "next_available_leaf_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header_id": {
+          "name": "header_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "last_archive_header_id_header_id_fk": {
+          "name": "last_archive_header_id_header_id_fk",
+          "tableFrom": "last_archive",
+          "tableTo": "header",
+          "columnsFrom": ["header_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.note_hash_tree": {
+      "name": "note_hash_tree",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "root": {
+          "name": "root",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_available_leaf_index": {
+          "name": "next_available_leaf_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_partial_id": {
+          "name": "state_partial_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "note_hash_tree_state_partial_id_partial_id_fk": {
+          "name": "note_hash_tree_state_partial_id_partial_id_fk",
+          "tableFrom": "note_hash_tree",
+          "tableTo": "partial",
+          "columnsFrom": ["state_partial_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.nullifier_tree": {
+      "name": "nullifier_tree",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "root": {
+          "name": "root",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_available_leaf_index": {
+          "name": "next_available_leaf_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_partial_id": {
+          "name": "state_partial_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nullifier_tree_state_partial_id_partial_id_fk": {
+          "name": "nullifier_tree_state_partial_id_partial_id_fk",
+          "tableFrom": "nullifier_tree",
+          "tableTo": "partial",
+          "columnsFrom": ["state_partial_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.partial": {
+      "name": "partial",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "state_id": {
+          "name": "state_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "partial_state_id_idx": {
+          "name": "partial_state_id_idx",
+          "columns": [
+            {
+              "expression": "state_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "partial_state_id_state_id_fk": {
+          "name": "partial_state_id_state_id_fk",
+          "tableFrom": "partial",
+          "tableTo": "state",
+          "columnsFrom": ["state_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.public_data_tree": {
+      "name": "public_data_tree",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "root": {
+          "name": "root",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_available_leaf_index": {
+          "name": "next_available_leaf_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_partial_id": {
+          "name": "state_partial_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "public_data_tree_state_partial_id_partial_id_fk": {
+          "name": "public_data_tree_state_partial_id_partial_id_fk",
+          "tableFrom": "public_data_tree",
+          "tableTo": "partial",
+          "columnsFrom": ["state_partial_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.state": {
+      "name": "state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "header_id": {
+          "name": "header_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "state_header_id_idx": {
+          "name": "state_header_id_idx",
+          "columns": [
+            {
+              "expression": "header_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "state_header_id_header_id_fk": {
+          "name": "state_header_id_header_id_fk",
+          "tableFrom": "state",
+          "tableTo": "header",
+          "columnsFrom": ["header_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l1_l2_block_proposed": {
+      "name": "l1_l2_block_proposed",
+      "schema": "",
+      "columns": {
+        "l1_contract_address": {
+          "name": "l1_contract_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l2_block_number": {
+          "name": "l2_block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_block_number": {
+          "name": "l1_block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_block_hash": {
+          "name": "l1_block_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_block_timestamp": {
+          "name": "l1_block_timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_finalized": {
+          "name": "is_finalized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "archive": {
+          "name": "archive",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "block_proposal": {
+          "name": "block_proposal",
+          "columns": ["l2_block_number", "archive"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.l1_l2_proof_verified": {
+      "name": "l1_l2_proof_verified",
+      "schema": "",
+      "columns": {
+        "l1_contract_address": {
+          "name": "l1_contract_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l2_block_number": {
+          "name": "l2_block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_block_number": {
+          "name": "l1_block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_block_hash": {
+          "name": "l1_block_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_block_timestamp": {
+          "name": "l1_block_timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_finalized": {
+          "name": "is_finalized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "prover_id": {
+          "name": "prover_id",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "proof_verified": {
+          "name": "proof_verified",
+          "columns": ["l2_block_number", "prover_id"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.archive": {
+      "name": "archive",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "root": {
+          "name": "root",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_available_leaf_index": {
+          "name": "next_available_leaf_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_hash": {
+          "name": "block_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "archive_block_hash_l2Block_hash_fk": {
+          "name": "archive_block_hash_l2Block_hash_fk",
+          "tableFrom": "archive",
+          "tableTo": "l2Block",
+          "columnsFrom": ["block_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l2Block": {
+      "name": "l2Block",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "orphan_timestamp": {
+          "name": "orphan_timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orphan_hasOrphanedParent": {
+          "name": "orphan_hasOrphanedParent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "height_idx": {
+          "name": "height_idx",
+          "columns": [
+            {
+              "expression": "height",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "l2block_version_idx": {
+          "name": "l2block_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "l2block_height_version_idx": {
+          "name": "l2block_height_version_idx",
+          "columns": [
+            {
+              "expression": "height",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "orphan_timestamp_idx": {
+          "name": "orphan_timestamp_idx",
+          "columns": [
+            {
+              "expression": "orphan_timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"l2Block\".\"orphan_timestamp\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "height_orphan_idx": {
+          "name": "height_orphan_idx",
+          "columns": [
+            {
+              "expression": "height",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "orphan_timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l2_contract_class_registered": {
+      "name": "l2_contract_class_registered",
+      "schema": "",
+      "columns": {
+        "block_hash": {
+          "name": "block_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_class_id": {
+          "name": "contract_class_id",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_hash": {
+          "name": "artifact_hash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_functions_root": {
+          "name": "private_functions_root",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "packed_bytecode": {
+          "name": "packed_bytecode",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_json": {
+          "name": "artifact_json",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_contract_name": {
+          "name": "artifact_contract_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contract_type": {
+          "name": "contract_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contract_version": {
+          "name": "contract_version",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_code_url": {
+          "name": "source_code_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_code_commit_hash": {
+          "name": "source_code_commit_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_code": {
+          "name": "source_code",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l2_contract_class_registered_block_hash_l2Block_hash_fk": {
+          "name": "l2_contract_class_registered_block_hash_l2Block_hash_fk",
+          "tableFrom": "l2_contract_class_registered",
+          "tableTo": "l2Block",
+          "columnsFrom": ["block_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "contract_class_id_version": {
+          "name": "contract_class_id_version",
+          "columns": ["contract_class_id", "version"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.l2_contract_instance_aztec_scan_notes": {
+      "name": "l2_contract_instance_aztec_scan_notes",
+      "schema": "",
+      "columns": {
+        "address": {
+          "name": "address",
+          "type": "varchar(66)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_l1_contract_addresses": {
+          "name": "related_l1_contract_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l2_contract_instance_deployed": {
+      "name": "l2_contract_instance_deployed",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "block_hash": {
+          "name": "block_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "salt": {
+          "name": "salt",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_contract_class_id": {
+          "name": "current_contract_class_id",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_contract_class_id": {
+          "name": "original_contract_class_id",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initialization_hash": {
+          "name": "initialization_hash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployer": {
+          "name": "deployer",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "masterNullifierPublicKey": {
+          "name": "masterNullifierPublicKey",
+          "type": "varchar(130)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "masterIncomingViewingPublicKey": {
+          "name": "masterIncomingViewingPublicKey",
+          "type": "varchar(130)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "masterOutgoingViewingPublicKey": {
+          "name": "masterOutgoingViewingPublicKey",
+          "type": "varchar(130)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "masterTaggingPublicKey": {
+          "name": "masterTaggingPublicKey",
+          "type": "varchar(130)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l2_contract_instance_deployed_block_hash_l2Block_hash_fk": {
+          "name": "l2_contract_instance_deployed_block_hash_l2Block_hash_fk",
+          "tableFrom": "l2_contract_instance_deployed",
+          "tableTo": "l2Block",
+          "columnsFrom": ["block_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contract_class": {
+          "name": "contract_class",
+          "tableFrom": "l2_contract_instance_deployed",
+          "tableTo": "l2_contract_class_registered",
+          "columnsFrom": ["current_contract_class_id", "version"],
+          "columnsTo": ["contract_class_id", "version"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "l2_contract_instance_deployed_address_unique": {
+          "name": "l2_contract_instance_deployed_address_unique",
+          "nullsNotDistinct": false,
+          "columns": ["address"]
+        }
+      }
+    },
+    "public.l2_contract_instance_deployer_metadata": {
+      "name": "l2_contract_instance_deployer_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_identifier": {
+          "name": "contract_identifier",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_name": {
+          "name": "creator_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_contact": {
+          "name": "creator_contact",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_url": {
+          "name": "app_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l2_contract_instance_deployer_metadata_address_l2_contract_instance_deployed_address_fk": {
+          "name": "l2_contract_instance_deployer_metadata_address_l2_contract_instance_deployed_address_fk",
+          "tableFrom": "l2_contract_instance_deployer_metadata",
+          "tableTo": "l2_contract_instance_deployed",
+          "columnsFrom": ["address"],
+          "columnsTo": ["address"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l2_contract_instance_update": {
+      "name": "l2_contract_instance_update",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prev_contract_class_id": {
+          "name": "prev_contract_class_id",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_contract_class_id": {
+          "name": "new_contract_class_id",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_hash": {
+          "name": "block_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l2_contract_instance_update_block_hash_l2Block_hash_fk": {
+          "name": "l2_contract_instance_update_block_hash_l2Block_hash_fk",
+          "tableFrom": "l2_contract_instance_update",
+          "tableTo": "l2Block",
+          "columnsFrom": ["block_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "l2_contract_instance_update_address_unique": {
+          "name": "l2_contract_instance_update_address_unique",
+          "nullsNotDistinct": false,
+          "columns": ["address"]
+        }
+      }
+    },
+    "public.l2_contract_instance_verified_deployment_arguments": {
+      "name": "l2_contract_instance_verified_deployment_arguments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publicKeys": {
+          "name": "publicKeys",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployer": {
+          "name": "deployer",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "salt": {
+          "name": "salt",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "constructor_args": {
+          "name": "constructor_args",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l2_contract_instance_verified_deployment_arguments_address_l2_contract_instance_deployed_address_fk": {
+          "name": "l2_contract_instance_verified_deployment_arguments_address_l2_contract_instance_deployed_address_fk",
+          "tableFrom": "l2_contract_instance_verified_deployment_arguments",
+          "tableTo": "l2_contract_instance_deployed",
+          "columnsFrom": ["address"],
+          "columnsTo": ["address"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l2_private_function": {
+      "name": "l2_private_function",
+      "schema": "",
+      "columns": {
+        "contract_class_id": {
+          "name": "contract_class_id",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_metadata_hash": {
+          "name": "artifact_metadata_hash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "utility_functions_tree_root": {
+          "name": "utility_functions_tree_root",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_function_tree_sibling_path": {
+          "name": "private_function_tree_sibling_path",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_function_tree_leaf_index": {
+          "name": "private_function_tree_leaf_index",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_function_tree_sibling_path": {
+          "name": "artifact_function_tree_sibling_path",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_function_tree_leaf_index": {
+          "name": "artifact_function_tree_leaf_index",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_function_selector_value": {
+          "name": "private_function_selector_value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_function_metadata_hash": {
+          "name": "private_function_metadata_hash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_function_vk_hash": {
+          "name": "private_function_vk_hash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_function_bytecode": {
+          "name": "private_function_bytecode",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "private_function_contract_class": {
+          "name": "private_function_contract_class",
+          "columns": ["contract_class_id", "private_function_selector_value"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.l2_utility_function": {
+      "name": "l2_utility_function",
+      "schema": "",
+      "columns": {
+        "contract_class_id": {
+          "name": "contract_class_id",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_metadata_hash": {
+          "name": "artifact_metadata_hash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_functions_artifact_tree_root": {
+          "name": "private_functions_artifact_tree_root",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_function_tree_sibling_path": {
+          "name": "artifact_function_tree_sibling_path",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_function_tree_leaf_index": {
+          "name": "artifact_function_tree_leaf_index",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "utility_function_selector_value": {
+          "name": "utility_function_selector_value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "utility_function_metadata_hash": {
+          "name": "utility_function_metadata_hash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "utility_function_bytecode": {
+          "name": "utility_function_bytecode",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "utility_function_contract_class": {
+          "name": "utility_function_contract_class",
+          "columns": ["contract_class_id", "utility_function_selector_value"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.source_verification_jobs": {
+      "name": "source_verification_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "contract_class_id": {
+          "name": "contract_class_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "git_ref": {
+          "name": "git_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sub_path": {
+          "name": "sub_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aztec_version": {
+          "name": "aztec_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_hash": {
+          "name": "commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_ip": {
+          "name": "client_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "source_verification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.tx": {
+      "name": "tx",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fee_payer": {
+          "name": "fee_payer",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_timestamp": {
+          "name": "birth_timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l1_generic_contract_event": {
+      "name": "l1_generic_contract_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "l1_block_hash": {
+          "name": "l1_block_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_block_number": {
+          "name": "l1_block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_block_timestamp": {
+          "name": "l1_block_timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_contract_address": {
+          "name": "l1_contract_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_transaction_hash": {
+          "name": "l1_transaction_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_finalized": {
+          "name": "is_finalized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_args": {
+          "name": "event_args",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l1_l2_validator_proposer": {
+      "name": "l1_l2_validator_proposer",
+      "schema": "",
+      "columns": {
+        "attester_address": {
+          "name": "attester_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposer": {
+          "name": "proposer",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "EXTRACT(EPOCH FROM NOW()) * 1000"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l1_l2_validator_proposer_attester_address_l1_l2_validator_attester_fk": {
+          "name": "l1_l2_validator_proposer_attester_address_l1_l2_validator_attester_fk",
+          "tableFrom": "l1_l2_validator_proposer",
+          "tableTo": "l1_l2_validator",
+          "columnsFrom": ["attester_address"],
+          "columnsTo": ["attester"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "l1_l2_validator_proposer_attester_address_timestamp_pk": {
+          "name": "l1_l2_validator_proposer_attester_address_timestamp_pk",
+          "columns": ["attester_address", "timestamp"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.l1_l2_validator_rollup_address": {
+      "name": "l1_l2_validator_rollup_address",
+      "schema": "",
+      "columns": {
+        "attester_address": {
+          "name": "attester_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollup_address": {
+          "name": "rollup_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "EXTRACT(EPOCH FROM NOW()) * 1000"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l1_l2_validator_rollup_address_attester_address_l1_l2_validator_attester_fk": {
+          "name": "l1_l2_validator_rollup_address_attester_address_l1_l2_validator_attester_fk",
+          "tableFrom": "l1_l2_validator_rollup_address",
+          "tableTo": "l1_l2_validator",
+          "columnsFrom": ["attester_address"],
+          "columnsTo": ["attester"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "l1_l2_validator_rollup_address_attester_address_timestamp_pk": {
+          "name": "l1_l2_validator_rollup_address_attester_address_timestamp_pk",
+          "columns": ["attester_address", "timestamp"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.l1_l2_validator_stake": {
+      "name": "l1_l2_validator_stake",
+      "schema": "",
+      "columns": {
+        "attester_address": {
+          "name": "attester_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stake": {
+          "name": "stake",
+          "type": "numeric(77, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "EXTRACT(EPOCH FROM NOW()) * 1000"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l1_l2_validator_stake_attester_address_l1_l2_validator_attester_fk": {
+          "name": "l1_l2_validator_stake_attester_address_l1_l2_validator_attester_fk",
+          "tableFrom": "l1_l2_validator_stake",
+          "tableTo": "l1_l2_validator",
+          "columnsFrom": ["attester_address"],
+          "columnsTo": ["attester"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "l1_l2_validator_stake_attester_address_timestamp_pk": {
+          "name": "l1_l2_validator_stake_attester_address_timestamp_pk",
+          "columns": ["attester_address", "timestamp"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.l1_l2_validator_status": {
+      "name": "l1_l2_validator_status",
+      "schema": "",
+      "columns": {
+        "attester_address": {
+          "name": "attester_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "EXTRACT(EPOCH FROM NOW()) * 1000"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l1_l2_validator_status_attester_address_l1_l2_validator_attester_fk": {
+          "name": "l1_l2_validator_status_attester_address_l1_l2_validator_attester_fk",
+          "tableFrom": "l1_l2_validator_status",
+          "tableTo": "l1_l2_validator",
+          "columnsFrom": ["attester_address"],
+          "columnsTo": ["attester"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "l1_l2_validator_status_attester_address_timestamp_pk": {
+          "name": "l1_l2_validator_status_attester_address_timestamp_pk",
+          "columns": ["attester_address", "timestamp"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.l1_l2_validator": {
+      "name": "l1_l2_validator",
+      "schema": "",
+      "columns": {
+        "attester": {
+          "name": "attester",
+          "type": "varchar(42)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l1_l2_validator_withdrawer": {
+      "name": "l1_l2_validator_withdrawer",
+      "schema": "",
+      "columns": {
+        "attester_address": {
+          "name": "attester_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "withdrawer": {
+          "name": "withdrawer",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "EXTRACT(EPOCH FROM NOW()) * 1000"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l1_l2_validator_withdrawer_attester_address_l1_l2_validator_attester_fk": {
+          "name": "l1_l2_validator_withdrawer_attester_address_l1_l2_validator_attester_fk",
+          "tableFrom": "l1_l2_validator_withdrawer",
+          "tableTo": "l1_l2_validator",
+          "columnsFrom": ["attester_address"],
+          "columnsTo": ["attester"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "l1_l2_validator_withdrawer_attester_address_timestamp_pk": {
+          "name": "l1_l2_validator_withdrawer_attester_address_timestamp_pk",
+          "columns": ["attester_address", "timestamp"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.l2_rpc_node_error": {
+      "name": "l2_rpc_node_error",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rpc_node_name": {
+          "name": "rpc_node_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cause": {
+          "name": "cause",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stack": {
+          "name": "stack",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l2_rpc_node_error_rpc_node_name_l2_rpc_node_name_fk": {
+          "name": "l2_rpc_node_error_rpc_node_name_l2_rpc_node_name_fk",
+          "tableFrom": "l2_rpc_node_error",
+          "tableTo": "l2_rpc_node",
+          "columnsFrom": ["rpc_node_name"],
+          "columnsTo": ["name"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l2_rpc_node": {
+      "name": "l2_rpc_node",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rpc_url": {
+          "name": "rpc_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "l2_rpc_node_rpc_url_unique": {
+          "name": "l2_rpc_node_rpc_url_unique",
+          "nullsNotDistinct": false,
+          "columns": ["rpc_url"]
+        }
+      }
+    },
+    "public.l2_sequencer": {
+      "name": "l2_sequencer",
+      "schema": "",
+      "columns": {
+        "enr": {
+          "name": "enr",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rpc_node_name": {
+          "name": "rpc_node_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l2_network_id": {
+          "name": "l2_network_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollup_version": {
+          "name": "rollup_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_version": {
+          "name": "node_version",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l1_chain_id": {
+          "name": "l1_chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "l2_sequencer_rpc_node_name_l2_rpc_node_name_fk": {
+          "name": "l2_sequencer_rpc_node_name_l2_rpc_node_name_fk",
+          "tableFrom": "l2_sequencer",
+          "tableTo": "l2_rpc_node",
+          "columnsFrom": ["rpc_node_name"],
+          "columnsTo": ["name"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.l2BlockFinalizationStatus": {
+      "name": "l2BlockFinalizationStatus",
+      "schema": "",
+      "columns": {
+        "l2_block_hash": {
+          "name": "l2_block_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "l2_block_number": {
+          "name": "l2_block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "EXTRACT(EPOCH FROM NOW()) * 1000"
+        }
+      },
+      "indexes": {
+        "l2_block_finalization_l2blockhash_idx": {
+          "name": "l2_block_finalization_l2blockhash_idx",
+          "columns": [
+            {
+              "expression": "l2_block_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "l2_block_finalization_status_idx": {
+          "name": "l2_block_finalization_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "l2_block_finalization_status_pk": {
+          "name": "l2_block_finalization_status_pk",
+          "columns": ["l2_block_hash", "status", "l2_block_number"]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.source_verification_status": {
+      "name": "source_verification_status",
+      "schema": "public",
+      "values": ["PENDING", "COMPILING", "VERIFYING", "VERIFIED", "FAILED"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/services/explorer-api/migrations/meta/_journal.json
+++ b/services/explorer-api/migrations/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1776335842441,
       "tag": "0014_classy_xavin",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1776414885225,
+      "tag": "0015_old_madame_hydra",
+      "breakpoints": true
     }
   ]
 }

--- a/services/explorer-api/src/events/received/on-staking-asset-info.ts
+++ b/services/explorer-api/src/events/received/on-staking-asset-info.ts
@@ -13,12 +13,14 @@ type StakingAssetInfoEvent = {
   chainInfo: ChicmozChainInfo & {
     stakingAssetSymbol?: string;
     stakingAssetDecimals?: number;
+    feeJuiceSymbol?: string;
+    feeJuiceDecimals?: number;
   };
 };
 
 const onStakingAssetInfo = async (event: StakingAssetInfoEvent) => {
   logger.info(
-    `🪙 staking asset info event ${event.chainInfo.l1ContractAddresses.stakingAssetAddress} ${event.chainInfo.stakingAssetSymbol}`,
+    `🪙 token metadata event staking=${event.chainInfo.l1ContractAddresses.stakingAssetAddress}:${event.chainInfo.stakingAssetSymbol} feeJuice=${event.chainInfo.l1ContractAddresses.feeJuiceAddress}:${event.chainInfo.feeJuiceSymbol}`,
   );
   await l2.storeChainInfo(event.chainInfo);
 };

--- a/services/explorer-api/src/svcs/database/controllers/l2/chain-info/get.ts
+++ b/services/explorer-api/src/svcs/database/controllers/l2/chain-info/get.ts
@@ -10,9 +10,11 @@ import { and, desc, eq } from "drizzle-orm";
 import { CURRENT_ROLLUP_VERSION_BIGINT } from "../../../../../constants/versions.js";
 import { l2ChainInfoTable } from "../../../schema/l2/chain-info.js";
 
-type ChicmozChainInfoWithStakingAsset = ChicmozChainInfo & {
+type ChicmozChainInfoWithTokenMetadata = ChicmozChainInfo & {
   stakingAssetSymbol?: string;
   stakingAssetDecimals?: number;
+  feeJuiceSymbol?: string;
+  feeJuiceDecimals?: number;
 };
 
 export async function getL2ChainInfo(
@@ -34,6 +36,8 @@ export async function getL2ChainInfo(
     const chainInfo = result[0] as (typeof result)[number] & {
       stakingAssetSymbol?: string | null;
       stakingAssetDecimals?: number | null;
+      feeJuiceSymbol?: string | null;
+      feeJuiceDecimals?: number | null;
     };
 
     return chicmozChainInfoSchema.parse({
@@ -44,7 +48,9 @@ export async function getL2ChainInfo(
       protocolContractAddresses: chainInfo.protocolContractAddresses,
       stakingAssetSymbol: chainInfo.stakingAssetSymbol ?? undefined,
       stakingAssetDecimals: chainInfo.stakingAssetDecimals ?? undefined,
-    }) as ChicmozChainInfoWithStakingAsset;
+      feeJuiceSymbol: chainInfo.feeJuiceSymbol ?? undefined,
+      feeJuiceDecimals: chainInfo.feeJuiceDecimals ?? undefined,
+    }) as ChicmozChainInfoWithTokenMetadata;
   }
 
   if (result.length === 0 && NODE_ENV === NodeEnv.DEV) {
@@ -59,6 +65,8 @@ export async function getL2ChainInfo(
       const chainInfo = anyResult[0] as (typeof anyResult)[number] & {
         stakingAssetSymbol?: string | null;
         stakingAssetDecimals?: number | null;
+        feeJuiceSymbol?: string | null;
+        feeJuiceDecimals?: number | null;
       };
 
       return chicmozChainInfoSchema.parse({
@@ -69,7 +77,9 @@ export async function getL2ChainInfo(
         protocolContractAddresses: chainInfo.protocolContractAddresses,
         stakingAssetSymbol: chainInfo.stakingAssetSymbol ?? undefined,
         stakingAssetDecimals: chainInfo.stakingAssetDecimals ?? undefined,
-      }) as ChicmozChainInfoWithStakingAsset;
+        feeJuiceSymbol: chainInfo.feeJuiceSymbol ?? undefined,
+        feeJuiceDecimals: chainInfo.feeJuiceDecimals ?? undefined,
+      }) as ChicmozChainInfoWithTokenMetadata;
     }
   }
   return null;

--- a/services/explorer-api/src/svcs/database/controllers/l2/chain-info/store.ts
+++ b/services/explorer-api/src/svcs/database/controllers/l2/chain-info/store.ts
@@ -3,16 +3,18 @@ import { type ChicmozChainInfo } from "@chicmoz-pkg/types";
 import { l2ChainInfoTable } from "../../../schema/l2/chain-info.js";
 import { onRollupVersion } from "./rollup-version-cache.js";
 
-type ChicmozChainInfoWithStakingAsset = ChicmozChainInfo & {
+type ChicmozChainInfoWithTokenMetadata = ChicmozChainInfo & {
   stakingAssetSymbol?: string;
   stakingAssetDecimals?: number;
+  feeJuiceSymbol?: string;
+  feeJuiceDecimals?: number;
 };
 
 export async function storeChainInfo(
   chainInfo: ChicmozChainInfo,
 ): Promise<void> {
-  const chainInfoWithStakingAsset =
-    chainInfo as ChicmozChainInfoWithStakingAsset;
+  const chainInfoWithTokenMetadata =
+    chainInfo as ChicmozChainInfoWithTokenMetadata;
   const {
     l2NetworkId,
     l1ChainId,
@@ -30,11 +32,19 @@ export async function storeChainInfo(
   };
 
   const optionalValues = {
-    ...(chainInfoWithStakingAsset.stakingAssetSymbol !== undefined
-      ? { stakingAssetSymbol: chainInfoWithStakingAsset.stakingAssetSymbol }
+    ...(chainInfoWithTokenMetadata.stakingAssetSymbol !== undefined
+      ? { stakingAssetSymbol: chainInfoWithTokenMetadata.stakingAssetSymbol }
       : {}),
-    ...(chainInfoWithStakingAsset.stakingAssetDecimals !== undefined
-      ? { stakingAssetDecimals: chainInfoWithStakingAsset.stakingAssetDecimals }
+    ...(chainInfoWithTokenMetadata.stakingAssetDecimals !== undefined
+      ? {
+          stakingAssetDecimals: chainInfoWithTokenMetadata.stakingAssetDecimals,
+        }
+      : {}),
+    ...(chainInfoWithTokenMetadata.feeJuiceSymbol !== undefined
+      ? { feeJuiceSymbol: chainInfoWithTokenMetadata.feeJuiceSymbol }
+      : {}),
+    ...(chainInfoWithTokenMetadata.feeJuiceDecimals !== undefined
+      ? { feeJuiceDecimals: chainInfoWithTokenMetadata.feeJuiceDecimals }
       : {}),
   };
 

--- a/services/explorer-api/src/svcs/database/schema/l2/chain-info.ts
+++ b/services/explorer-api/src/svcs/database/schema/l2/chain-info.ts
@@ -16,6 +16,8 @@ export const l2ChainInfoTable = pgTable("l2_chain_info", {
   }).notNull(),
   stakingAssetSymbol: varchar("staking_asset_symbol"),
   stakingAssetDecimals: integer("staking_asset_decimals"),
+  feeJuiceSymbol: varchar("fee_juice_symbol"),
+  feeJuiceDecimals: integer("fee_juice_decimals"),
   createdAt: timestamp("created_at").notNull().defaultNow(),
   updatedAt: timestamp("updated_at").notNull().defaultNow(),
   l1ContractAddresses: jsonb("l1_contract_addresses").notNull(),

--- a/services/explorer-ui/src/components/copyable-amount.tsx
+++ b/services/explorer-ui/src/components/copyable-amount.tsx
@@ -1,0 +1,39 @@
+import { type FC } from "react";
+import { toast } from "sonner";
+import { CustomTooltip } from "~/components/custom-tooltip";
+import { cn } from "~/lib/utils";
+
+type Props = {
+  displayAmount: string;
+  rawAmount: string;
+  className?: string;
+};
+
+export const CopyableAmount: FC<Props> = ({
+  displayAmount,
+  rawAmount,
+  className,
+}) => {
+  const handleCopy = async (): Promise<void> => {
+    try {
+      await navigator.clipboard.writeText(rawAmount);
+      toast.success("Copied to clipboard");
+    } catch {
+      toast.error("Failed to copy to clipboard");
+    }
+  };
+
+  return (
+    <CustomTooltip content="Copy full amount">
+      <button
+        type="button"
+        className={cn("cursor-pointer hover:opacity-80", className)}
+        onClick={() => {
+          void handleCopy();
+        }}
+      >
+        {displayAmount}
+      </button>
+    </CustomTooltip>
+  );
+};

--- a/services/explorer-ui/src/components/data-table/data-table-column-header.tsx
+++ b/services/explorer-ui/src/components/data-table/data-table-column-header.tsx
@@ -16,22 +16,31 @@ import {
 import { cn } from "~/lib/utils";
 
 interface DataTableColumnHeaderProps<TData, TValue>
-  extends React.HTMLAttributes<HTMLDivElement> {
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, "title"> {
   column: Column<TData, TValue>;
-  title: string;
+  title: React.ReactNode;
+  supplement?: React.ReactNode;
 }
 
 export function DataTableColumnHeader<TData, TValue>({
   column,
   title,
+  supplement,
   className,
 }: DataTableColumnHeaderProps<TData, TValue>) {
-  if (!column.getCanSort()) return <div className={cn(className)}>{title}</div>;
+  if (!column.getCanSort()) {
+    return (
+      <div className={cn("flex items-center justify-start gap-1", className)}>
+        <div>{title}</div>
+        {supplement ? <div>{supplement}</div> : null}
+      </div>
+    );
+  }
 
   return (
     <div className={cn("flex items-center justify-start w-full", className)}>
       <DropdownMenu>
-        <DropdownMenuTrigger className="flex flex-row w-full !p-0">
+        <DropdownMenuTrigger className="flex flex-row items-center !p-0">
           <span className="text-left">{title}</span>
           {column.getIsSorted() === "desc" ? (
             <ArrowDownIcon className="ml-2 h-4 w-4" />
@@ -57,6 +66,7 @@ export function DataTableColumnHeader<TData, TValue>({
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
+      {supplement ? <div className="ml-1">{supplement}</div> : null}
     </div>
   );
 }

--- a/services/explorer-ui/src/components/fee-recipient/fee-recipient-columns.tsx
+++ b/services/explorer-ui/src/components/fee-recipient/fee-recipient-columns.tsx
@@ -1,11 +1,23 @@
 import { type ColumnDef } from "@tanstack/react-table";
-import { truncateHashString } from "~/lib/create-hash-string";
-import { DataTableColumnHeader } from "../data-table";
 import { type ChicmozFeeRecipient } from "@chicmoz-pkg/types";
+import { truncateHashString } from "~/lib/create-hash-string";
+import { formatFees, getFeeJuiceSymbol } from "~/lib/utils";
+import { DataTableColumnHeader } from "../data-table";
 import { CustomTooltip } from "../custom-tooltip";
 import { CopyableText } from "../copy-text";
+import { EtherscanAddressLink } from "../etherscan-address-link";
 
-export const FeeRecipientColums: ColumnDef<ChicmozFeeRecipient>[] = [
+type CreateFeeRecipientColumnsArgs = {
+  feeJuiceAddress?: string;
+  feeJuiceDecimals?: number;
+  feeJuiceSymbol?: string;
+};
+
+export const createFeeRecipientColumns = ({
+  feeJuiceAddress,
+  feeJuiceDecimals,
+  feeJuiceSymbol,
+}: CreateFeeRecipientColumnsArgs): ColumnDef<ChicmozFeeRecipient>[] => [
   {
     accessorKey: "l2Address",
     header: ({ column }) => (
@@ -30,12 +42,29 @@ export const FeeRecipientColums: ColumnDef<ChicmozFeeRecipient>[] = [
       />
     ),
     cell: ({ row }) => {
+      const symbol = getFeeJuiceSymbol(feeJuiceSymbol);
+      const formattedFees = formatFees(
+        String(row.getValue("feesReceived")),
+        feeJuiceDecimals,
+      );
+      const formattedValue = `${formattedFees.value}${formattedFees.denomination}`;
+
       return (
-        <CustomTooltip content="The amount of FJ received">
-          <div className="font-mono">
-            {String(row.getValue("feesReceived"))}
-          </div>
-        </CustomTooltip>
+        <div className="font-mono flex items-center gap-1">
+          <CustomTooltip content={`The amount of ${symbol} received`}>
+            <span>{formattedValue}</span>
+          </CustomTooltip>
+          {feeJuiceAddress ? (
+            <EtherscanAddressLink
+              content={symbol}
+              endpoint={`/token/${feeJuiceAddress}`}
+              showExternalLinkIcon={false}
+              tooltipContent="View token address on Etherscan"
+            />
+          ) : (
+            <span>{symbol}</span>
+          )}
+        </div>
       );
     },
   },
@@ -50,7 +79,9 @@ export const FeeRecipientColums: ColumnDef<ChicmozFeeRecipient>[] = [
     ),
     cell: ({ row }) => {
       return (
-        <CustomTooltip content="The amount of FJ received">
+        <CustomTooltip
+          content={`The number of blocks with ${getFeeJuiceSymbol(feeJuiceSymbol)} rewards received`}
+        >
           <div className="font-mono">{row.getValue("nbrOfBlocks")}</div>
         </CustomTooltip>
       );

--- a/services/explorer-ui/src/components/fee-recipient/fee-recipient-columns.tsx
+++ b/services/explorer-ui/src/components/fee-recipient/fee-recipient-columns.tsx
@@ -1,5 +1,6 @@
 import { type ColumnDef } from "@tanstack/react-table";
 import { type ChicmozFeeRecipient } from "@chicmoz-pkg/types";
+import { CopyableAmount } from "~/components/copyable-amount";
 import { truncateHashString } from "~/lib/create-hash-string";
 import { formatFees, getFeeJuiceSymbol } from "~/lib/utils";
 import { DataTableColumnHeader } from "../data-table";
@@ -51,9 +52,10 @@ export const createFeeRecipientColumns = ({
 
       return (
         <div className="font-mono flex items-center gap-1">
-          <CustomTooltip content={`The amount of ${symbol} received`}>
-            <span>{formattedValue}</span>
-          </CustomTooltip>
+          <CopyableAmount
+            displayAmount={formattedValue}
+            rawAmount={String(row.getValue("feesReceived"))}
+          />
           {feeJuiceAddress ? (
             <EtherscanAddressLink
               content={symbol}

--- a/services/explorer-ui/src/components/fee-recipient/fee-recipient-table.tsx
+++ b/services/explorer-ui/src/components/fee-recipient/fee-recipient-table.tsx
@@ -1,7 +1,7 @@
-import { type FC } from "react";
+import { type FC, useMemo } from "react";
 import { DataTable } from "~/components/data-table";
 import { type ChicmozFeeRecipient } from "@chicmoz-pkg/types";
-import { FeeRecipientColums } from "./fee-recipient-columns";
+import { createFeeRecipientColumns } from "./fee-recipient-columns";
 
 interface Props {
   title?: string;
@@ -11,6 +11,9 @@ interface Props {
   disableSizeSelector?: boolean;
   disablePagination?: boolean;
   maxEntries?: number;
+  feeJuiceAddress?: string;
+  feeJuiceDecimals?: number;
+  feeJuiceSymbol?: string;
 }
 
 export const FeeReceipientsTable: FC<Props> = ({
@@ -21,7 +24,20 @@ export const FeeReceipientsTable: FC<Props> = ({
   disableSizeSelector,
   disablePagination,
   maxEntries = 10,
+  feeJuiceAddress,
+  feeJuiceDecimals,
+  feeJuiceSymbol,
 }) => {
+  const columns = useMemo(
+    () =>
+      createFeeRecipientColumns({
+        feeJuiceAddress,
+        feeJuiceDecimals,
+        feeJuiceSymbol,
+      }),
+    [feeJuiceAddress, feeJuiceDecimals, feeJuiceSymbol],
+  );
+
   if (error) {
     return <p className="text-red-500">{error.message}</p>;
   }
@@ -36,7 +52,7 @@ export const FeeReceipientsTable: FC<Props> = ({
         <DataTable
           isLoading={isLoading}
           data={feeRecipients ?? []}
-          columns={FeeRecipientColums}
+          columns={columns}
           disableSizeSelector={disableSizeSelector}
           disablePagination={disablePagination}
           maxEntries={maxEntries}

--- a/services/explorer-ui/src/components/loading/util.ts
+++ b/services/explorer-ui/src/components/loading/util.ts
@@ -1,4 +1,4 @@
-import { formatTimeSince } from "~/lib/utils";
+import { formatTimeSince, getFeeJuiceSymbol } from "~/lib/utils";
 
 export const getEmptyTxEffectData = (hash?: string, date?: Date) => [
   {
@@ -10,7 +10,7 @@ export const getEmptyTxEffectData = (hash?: string, date?: Date) => [
     value: date ? `${formatTimeSince(date.getTime())} ago` : undefined,
   },
   {
-    label: "TRANSACTION FEE (FJ)",
+    label: "TRANSACTION FEE",
     value: undefined,
   },
   {
@@ -23,7 +23,11 @@ export const getEmptyTxEffectData = (hash?: string, date?: Date) => [
     value: undefined,
   },
 ];
-export const getEmptyBlockData = (hash?: string, timestamp?: number) => [
+export const getEmptyBlockData = (
+  feeJuiceSymbol?: string,
+  hash?: string,
+  timestamp?: number,
+) => [
   {
     label: "Block Hash",
     value: hash,
@@ -46,7 +50,7 @@ export const getEmptyBlockData = (hash?: string, timestamp?: number) => [
     value: undefined,
   },
   {
-    label: "totalFees (FJ)",
+    label: `totalFees (${getFeeJuiceSymbol(feeJuiceSymbol)})`,
     value: undefined,
   },
   {
@@ -90,7 +94,7 @@ export const getEmptyContractInstanceData = () => [
   { label: "VERSION", value: undefined },
   { label: "DEPLOYER", value: undefined },
   {
-    label: "FEE JUICE BALANCE",
+    label: "TOKEN BALANCE",
     value: undefined,
   },
   {

--- a/services/explorer-ui/src/components/tx-effects/tx-effects-columns.tsx
+++ b/services/explorer-ui/src/components/tx-effects/tx-effects-columns.tsx
@@ -3,13 +3,15 @@ import { type ColumnDef } from "@tanstack/react-table";
 import { type UiTxEffectTable } from "@chicmoz-pkg/types";
 import { DataTableColumnHeader } from "~/components/data-table";
 import { truncateHashString } from "~/lib/create-hash-string";
+import { formatFees, getFeeJuiceSymbol } from "~/lib/utils";
 import { routes } from "~/routes/__root";
 import { CustomTooltip } from "../custom-tooltip";
+import { EtherscanAddressLink } from "../etherscan-address-link";
 import { TimeAgoCell } from "../formated-time-cell";
 
 const text = {
   txHash: "HASH",
-  transactionFee: "FEE (FJ)",
+  transactionFee: "FEE",
   blockHeight: "HEIGHT",
   timeSince: "AGE",
 };
@@ -25,7 +27,17 @@ const compareDecimalStrings = (left: string, right: string): number => {
   return leftValue > rightValue ? 1 : -1;
 };
 
-export const TxEffectsTableColumns: ColumnDef<UiTxEffectTable>[] = [
+type CreateTxEffectsTableColumnsArgs = {
+  feeJuiceAddress?: string;
+  feeJuiceDecimals?: number;
+  feeJuiceSymbol?: string;
+};
+
+export const createTxEffectsTableColumns = ({
+  feeJuiceAddress,
+  feeJuiceDecimals,
+  feeJuiceSymbol,
+}: CreateTxEffectsTableColumnsArgs): ColumnDef<UiTxEffectTable>[] => [
   {
     accessorKey: "txHash",
     header: ({ column }) => (
@@ -74,11 +86,34 @@ export const TxEffectsTableColumns: ColumnDef<UiTxEffectTable>[] = [
         title={text.transactionFee}
       />
     ),
-    cell: ({ row }) => (
-      <CustomTooltip content="The amount of FJ paid for this transaction">
-        <div className="font-mono">{row.getValue("transactionFee")}</div>
-      </CustomTooltip>
-    ),
+    cell: ({ row }) => {
+      const symbol = getFeeJuiceSymbol(feeJuiceSymbol);
+      const formattedFee = formatFees(
+        String(row.getValue("transactionFee")),
+        feeJuiceDecimals,
+      );
+      const formattedValue = `${formattedFee.value}${formattedFee.denomination}`;
+
+      return (
+        <div className="font-mono flex items-center gap-1">
+          <CustomTooltip
+            content={`The amount of ${symbol} paid for this transaction`}
+          >
+            <span>{formattedValue}</span>
+          </CustomTooltip>
+          {feeJuiceAddress ? (
+            <EtherscanAddressLink
+              content={symbol}
+              endpoint={`/token/${feeJuiceAddress}`}
+              showExternalLinkIcon={false}
+              tooltipContent="View token address on Etherscan"
+            />
+          ) : (
+            <span>{symbol}</span>
+          )}
+        </div>
+      );
+    },
     sortingFn: (rowA, rowB, columnId) => {
       const left = rowA.getValue(columnId);
       const right = rowB.getValue(columnId);

--- a/services/explorer-ui/src/components/tx-effects/tx-effects-columns.tsx
+++ b/services/explorer-ui/src/components/tx-effects/tx-effects-columns.tsx
@@ -1,11 +1,11 @@
 import { Link } from "@tanstack/react-router";
 import { type ColumnDef } from "@tanstack/react-table";
 import { type UiTxEffectTable } from "@chicmoz-pkg/types";
+import { CopyableAmount } from "~/components/copyable-amount";
 import { DataTableColumnHeader } from "~/components/data-table";
 import { truncateHashString } from "~/lib/create-hash-string";
 import { formatFees, getFeeJuiceSymbol } from "~/lib/utils";
 import { routes } from "~/routes/__root";
-import { CustomTooltip } from "../custom-tooltip";
 import { EtherscanAddressLink } from "../etherscan-address-link";
 import { TimeAgoCell } from "../formated-time-cell";
 
@@ -96,11 +96,10 @@ export const createTxEffectsTableColumns = ({
 
       return (
         <div className="font-mono flex items-center gap-1">
-          <CustomTooltip
-            content={`The amount of ${symbol} paid for this transaction`}
-          >
-            <span>{formattedValue}</span>
-          </CustomTooltip>
+          <CopyableAmount
+            displayAmount={formattedValue}
+            rawAmount={String(row.getValue("transactionFee"))}
+          />
           {feeJuiceAddress ? (
             <EtherscanAddressLink
               content={symbol}

--- a/services/explorer-ui/src/components/tx-effects/tx-effects-table.tsx
+++ b/services/explorer-ui/src/components/tx-effects/tx-effects-table.tsx
@@ -1,7 +1,7 @@
-import { type FC } from "react";
+import { type FC, useMemo } from "react";
 import { DataTable } from "~/components/data-table";
-import { TxEffectsTableColumns } from "./tx-effects-columns";
 import { type UiTxEffectTable } from "@chicmoz-pkg/types";
+import { createTxEffectsTableColumns } from "./tx-effects-columns";
 
 interface Props {
   title?: string;
@@ -11,6 +11,9 @@ interface Props {
   disableSizeSelector?: boolean;
   disablePagination?: boolean;
   maxEntries?: number;
+  feeJuiceAddress?: string;
+  feeJuiceDecimals?: number;
+  feeJuiceSymbol?: string;
 }
 
 export const TxEffectsTable: FC<Props> = ({
@@ -21,7 +24,20 @@ export const TxEffectsTable: FC<Props> = ({
   disableSizeSelector,
   disablePagination = false,
   maxEntries = 10,
+  feeJuiceAddress,
+  feeJuiceDecimals,
+  feeJuiceSymbol,
 }) => {
+  const columns = useMemo(
+    () =>
+      createTxEffectsTableColumns({
+        feeJuiceAddress,
+        feeJuiceDecimals,
+        feeJuiceSymbol,
+      }),
+    [feeJuiceAddress, feeJuiceDecimals, feeJuiceSymbol],
+  );
+
   if (error) {
     return <p className="text-red-500">{error.message}</p>;
   }
@@ -36,7 +52,7 @@ export const TxEffectsTable: FC<Props> = ({
         <DataTable
           isLoading={isLoading}
           data={txEffects ?? []}
-          columns={TxEffectsTableColumns}
+          columns={columns}
           disableSizeSelector={disableSizeSelector}
           disablePagination={disablePagination}
           maxEntries={maxEntries}

--- a/services/explorer-ui/src/components/validators/validators-columns.tsx
+++ b/services/explorer-ui/src/components/validators/validators-columns.tsx
@@ -1,5 +1,6 @@
 import { Link } from "@tanstack/react-router";
 import { type ColumnDef } from "@tanstack/react-table";
+import { CopyableAmount } from "~/components/copyable-amount";
 import { DataTableColumnHeader } from "~/components/data-table";
 import { truncateHashString } from "~/lib/create-hash-string";
 import { formatCompactUnits } from "~/lib/utils";
@@ -38,155 +39,158 @@ export const createValidatorsTableColumns = ({
   stakingAssetDecimals,
   stakingAssetSymbol,
 }: CreateValidatorsTableColumnsArgs): ColumnDef<ValidatorTableSchema>[] => [
-    {
-      accessorKey: "attester",
-      header: ({ column }) => (
-        <DataTableColumnHeader
-          className="text-purple-dark text-sm"
-          column={column}
-          title={text.attester}
-        />
-      ),
-      cell: ({ row }) => {
-        const attester = row.getValue("attester");
-        if (typeof attester !== "string") {
-          return null;
-        }
-        return (
-          <Link to={`${routes.l1.route}/${routes.validators.route}/${attester}`}>
-            <div className="text-purple-light font-mono">
-              {truncateHashString(attester)}
-            </div>
-          </Link>
-        );
-      },
-      enableSorting: true,
-      enableHiding: false,
-    },
-    {
-      accessorKey: "withdrawer",
-      header: ({ column }) => (
-        <DataTableColumnHeader
-          className="text-purple-dark text-sm"
-          column={column}
-          title={text.withdrawer}
-        />
-      ),
-      cell: ({ row }) => {
-        const withdrawer = row.getValue("withdrawer");
-        if (typeof withdrawer !== "string") {
-          return null;
-        }
-        return getLinkCell(withdrawer, `/address/${withdrawer}`);
-      },
-      enableSorting: true,
-      enableHiding: true,
-    },
-    {
-      accessorKey: "proposer",
-      header: ({ column }) => (
-        <DataTableColumnHeader
-          className="text-purple-dark text-sm"
-          column={column}
-          title={text.proposer}
-        />
-      ),
-      cell: ({ row }) => {
-        const proposer = row.getValue("proposer");
-        if (typeof proposer !== "string") {
-          return null;
-        }
-        return getLinkCell(proposer, `/address/${proposer}`);
-      },
-      enableSorting: true,
-      enableHiding: true,
-    },
-    {
-      accessorKey: "stake",
-      header: ({ column }) => (
-        <DataTableColumnHeader
-          className="text-purple-dark text-sm"
-          column={column}
-          title={text.stake}
-        />
-      ),
-      cell: ({ row }) => {
-        const rawStake = row.getValue("stake");
-        if (typeof rawStake !== "bigint") {
-          return null;
-        }
-
-        const stake = formatCompactUnits(rawStake, stakingAssetDecimals);
-        const symbol = stakingAssetSymbol ?? "AZTEC";
-
-        return (
-          <div className="font-mono flex items-center gap-1">
-            <span>{stake}</span>
-            {stakingAssetAddress ? (
-              <EtherscanAddressLink
-                content={symbol}
-                endpoint={`/token/${stakingAssetAddress}`}
-                showExternalLinkIcon={false}
-                tooltipContent="View token address on Etherscan"
-              />
-            ) : (
-              <span>{symbol}</span>
-            )}
+  {
+    accessorKey: "attester",
+    header: ({ column }) => (
+      <DataTableColumnHeader
+        className="text-purple-dark text-sm"
+        column={column}
+        title={text.attester}
+      />
+    ),
+    cell: ({ row }) => {
+      const attester = row.getValue("attester");
+      if (typeof attester !== "string") {
+        return null;
+      }
+      return (
+        <Link to={`${routes.l1.route}/${routes.validators.route}/${attester}`}>
+          <div className="text-purple-light font-mono">
+            {truncateHashString(attester)}
           </div>
-        );
-      },
-      enableSorting: true,
-      enableHiding: false,
+        </Link>
+      );
     },
-    {
-      accessorKey: "status",
-      header: ({ column }) => (
-        <DataTableColumnHeader
-          className="text-purple-dark text-sm"
-          column={column}
-          title={text.status}
-        />
-      ),
-      cell: ({ row }) => {
-        const status = row.getValue("status");
-        if (typeof status !== "number") {
-          return null;
-        }
-        return <ValidatorStatusBadge status={status} />;
-      },
-      enableSorting: true,
-      enableHiding: false,
+    enableSorting: true,
+    enableHiding: false,
+  },
+  {
+    accessorKey: "withdrawer",
+    header: ({ column }) => (
+      <DataTableColumnHeader
+        className="text-purple-dark text-sm"
+        column={column}
+        title={text.withdrawer}
+      />
+    ),
+    cell: ({ row }) => {
+      const withdrawer = row.getValue("withdrawer");
+      if (typeof withdrawer !== "string") {
+        return null;
+      }
+      return getLinkCell(withdrawer, `/address/${withdrawer}`);
     },
-    {
-      accessorKey: "firstSeenAt",
-      header: ({ column }) => (
-        <DataTableColumnHeader
-          className="text-purple-dark text-sm"
-          column={column}
-          title={text.firstSeenAt}
-        />
-      ),
-      cell: ({ row }) => {
-        const date = Number(row.getValue("firstSeenAt"));
-        return <TimeAgoCell timestamp={date} />;
-      },
-      enableSorting: true,
-      enableHiding: true,
+    enableSorting: true,
+    enableHiding: true,
+  },
+  {
+    accessorKey: "proposer",
+    header: ({ column }) => (
+      <DataTableColumnHeader
+        className="text-purple-dark text-sm"
+        column={column}
+        title={text.proposer}
+      />
+    ),
+    cell: ({ row }) => {
+      const proposer = row.getValue("proposer");
+      if (typeof proposer !== "string") {
+        return null;
+      }
+      return getLinkCell(proposer, `/address/${proposer}`);
     },
-    {
-      accessorKey: "latestSeenChangeAt",
-      header: ({ column }) => (
-        <DataTableColumnHeader
-          className="text-purple-dark text-sm"
-          column={column}
-          title={text.latestSeenChangeAt}
-        />
-      ),
-      cell: ({ row }) => {
-        const date = Number(row.getValue("latestSeenChangeAt"));
-        return <TimeAgoCell timestamp={date} />;
-      },
-      enableSorting: true,
-      enableHiding: true,
+    enableSorting: true,
+    enableHiding: true,
+  },
+  {
+    accessorKey: "stake",
+    header: ({ column }) => (
+      <DataTableColumnHeader
+        className="text-purple-dark text-sm"
+        column={column}
+        title={text.stake}
+      />
+    ),
+    cell: ({ row }) => {
+      const rawStake = row.getValue("stake");
+      if (typeof rawStake !== "bigint") {
+        return null;
+      }
+
+      const stake = formatCompactUnits(rawStake, stakingAssetDecimals);
+      const symbol = stakingAssetSymbol ?? "AZTEC";
+
+      return (
+        <div className="font-mono flex items-center gap-1">
+          <CopyableAmount
+            displayAmount={stake}
+            rawAmount={rawStake.toString()}
+          />
+          {stakingAssetAddress ? (
+            <EtherscanAddressLink
+              content={symbol}
+              endpoint={`/token/${stakingAssetAddress}`}
+              showExternalLinkIcon={false}
+              tooltipContent="View token address on Etherscan"
+            />
+          ) : (
+            <span>{symbol}</span>
+          )}
+        </div>
+      );
     },
-  ];
+    enableSorting: true,
+    enableHiding: false,
+  },
+  {
+    accessorKey: "status",
+    header: ({ column }) => (
+      <DataTableColumnHeader
+        className="text-purple-dark text-sm"
+        column={column}
+        title={text.status}
+      />
+    ),
+    cell: ({ row }) => {
+      const status = row.getValue("status");
+      if (typeof status !== "number") {
+        return null;
+      }
+      return <ValidatorStatusBadge status={status} />;
+    },
+    enableSorting: true,
+    enableHiding: false,
+  },
+  {
+    accessorKey: "firstSeenAt",
+    header: ({ column }) => (
+      <DataTableColumnHeader
+        className="text-purple-dark text-sm"
+        column={column}
+        title={text.firstSeenAt}
+      />
+    ),
+    cell: ({ row }) => {
+      const date = Number(row.getValue("firstSeenAt"));
+      return <TimeAgoCell timestamp={date} />;
+    },
+    enableSorting: true,
+    enableHiding: true,
+  },
+  {
+    accessorKey: "latestSeenChangeAt",
+    header: ({ column }) => (
+      <DataTableColumnHeader
+        className="text-purple-dark text-sm"
+        column={column}
+        title={text.latestSeenChangeAt}
+      />
+    ),
+    cell: ({ row }) => {
+      const date = Number(row.getValue("latestSeenChangeAt"));
+      return <TimeAgoCell timestamp={date} />;
+    },
+    enableSorting: true,
+    enableHiding: true,
+  },
+];

--- a/services/explorer-ui/src/components/validators/validators-columns.tsx
+++ b/services/explorer-ui/src/components/validators/validators-columns.tsx
@@ -38,155 +38,155 @@ export const createValidatorsTableColumns = ({
   stakingAssetDecimals,
   stakingAssetSymbol,
 }: CreateValidatorsTableColumnsArgs): ColumnDef<ValidatorTableSchema>[] => [
-  {
-    accessorKey: "attester",
-    header: ({ column }) => (
-      <DataTableColumnHeader
-        className="text-purple-dark text-sm"
-        column={column}
-        title={text.attester}
-      />
-    ),
-    cell: ({ row }) => {
-      const attester = row.getValue("attester");
-      if (typeof attester !== "string") {
-        return null;
-      }
-      return (
-        <Link to={`${routes.l1.route}/${routes.validators.route}/${attester}`}>
-          <div className="text-purple-light font-mono">
-            {truncateHashString(attester)}
+    {
+      accessorKey: "attester",
+      header: ({ column }) => (
+        <DataTableColumnHeader
+          className="text-purple-dark text-sm"
+          column={column}
+          title={text.attester}
+        />
+      ),
+      cell: ({ row }) => {
+        const attester = row.getValue("attester");
+        if (typeof attester !== "string") {
+          return null;
+        }
+        return (
+          <Link to={`${routes.l1.route}/${routes.validators.route}/${attester}`}>
+            <div className="text-purple-light font-mono">
+              {truncateHashString(attester)}
+            </div>
+          </Link>
+        );
+      },
+      enableSorting: true,
+      enableHiding: false,
+    },
+    {
+      accessorKey: "withdrawer",
+      header: ({ column }) => (
+        <DataTableColumnHeader
+          className="text-purple-dark text-sm"
+          column={column}
+          title={text.withdrawer}
+        />
+      ),
+      cell: ({ row }) => {
+        const withdrawer = row.getValue("withdrawer");
+        if (typeof withdrawer !== "string") {
+          return null;
+        }
+        return getLinkCell(withdrawer, `/address/${withdrawer}`);
+      },
+      enableSorting: true,
+      enableHiding: true,
+    },
+    {
+      accessorKey: "proposer",
+      header: ({ column }) => (
+        <DataTableColumnHeader
+          className="text-purple-dark text-sm"
+          column={column}
+          title={text.proposer}
+        />
+      ),
+      cell: ({ row }) => {
+        const proposer = row.getValue("proposer");
+        if (typeof proposer !== "string") {
+          return null;
+        }
+        return getLinkCell(proposer, `/address/${proposer}`);
+      },
+      enableSorting: true,
+      enableHiding: true,
+    },
+    {
+      accessorKey: "stake",
+      header: ({ column }) => (
+        <DataTableColumnHeader
+          className="text-purple-dark text-sm"
+          column={column}
+          title={text.stake}
+        />
+      ),
+      cell: ({ row }) => {
+        const rawStake = row.getValue("stake");
+        if (typeof rawStake !== "bigint") {
+          return null;
+        }
+
+        const stake = formatCompactUnits(rawStake, stakingAssetDecimals);
+        const symbol = stakingAssetSymbol ?? "AZTEC";
+
+        return (
+          <div className="font-mono flex items-center gap-1">
+            <span>{stake}</span>
+            {stakingAssetAddress ? (
+              <EtherscanAddressLink
+                content={symbol}
+                endpoint={`/token/${stakingAssetAddress}`}
+                showExternalLinkIcon={false}
+                tooltipContent="View token address on Etherscan"
+              />
+            ) : (
+              <span>{symbol}</span>
+            )}
           </div>
-        </Link>
-      );
+        );
+      },
+      enableSorting: true,
+      enableHiding: false,
     },
-    enableSorting: true,
-    enableHiding: false,
-  },
-  {
-    accessorKey: "withdrawer",
-    header: ({ column }) => (
-      <DataTableColumnHeader
-        className="text-purple-dark text-sm"
-        column={column}
-        title={text.withdrawer}
-      />
-    ),
-    cell: ({ row }) => {
-      const withdrawer = row.getValue("withdrawer");
-      if (typeof withdrawer !== "string") {
-        return null;
-      }
-      return getLinkCell(withdrawer, `/address/${withdrawer}`);
+    {
+      accessorKey: "status",
+      header: ({ column }) => (
+        <DataTableColumnHeader
+          className="text-purple-dark text-sm"
+          column={column}
+          title={text.status}
+        />
+      ),
+      cell: ({ row }) => {
+        const status = row.getValue("status");
+        if (typeof status !== "number") {
+          return null;
+        }
+        return <ValidatorStatusBadge status={status} />;
+      },
+      enableSorting: true,
+      enableHiding: false,
     },
-    enableSorting: true,
-    enableHiding: true,
-  },
-  {
-    accessorKey: "proposer",
-    header: ({ column }) => (
-      <DataTableColumnHeader
-        className="text-purple-dark text-sm"
-        column={column}
-        title={text.proposer}
-      />
-    ),
-    cell: ({ row }) => {
-      const proposer = row.getValue("proposer");
-      if (typeof proposer !== "string") {
-        return null;
-      }
-      return getLinkCell(proposer, `/address/${proposer}`);
+    {
+      accessorKey: "firstSeenAt",
+      header: ({ column }) => (
+        <DataTableColumnHeader
+          className="text-purple-dark text-sm"
+          column={column}
+          title={text.firstSeenAt}
+        />
+      ),
+      cell: ({ row }) => {
+        const date = Number(row.getValue("firstSeenAt"));
+        return <TimeAgoCell timestamp={date} />;
+      },
+      enableSorting: true,
+      enableHiding: true,
     },
-    enableSorting: true,
-    enableHiding: true,
-  },
-  {
-    accessorKey: "stake",
-    header: ({ column }) => (
-      <DataTableColumnHeader
-        className="text-purple-dark text-sm"
-        column={column}
-        title={text.stake}
-      />
-    ),
-    cell: ({ row }) => {
-      const rawStake = row.getValue("stake");
-      if (typeof rawStake !== "bigint") {
-        return null;
-      }
-
-      const stake = formatCompactUnits(rawStake, stakingAssetDecimals);
-      const symbol = stakingAssetSymbol ?? "STK";
-
-      return (
-        <div className="font-mono flex items-center gap-1">
-          <span>{stake}</span>
-          {stakingAssetAddress ? (
-            <EtherscanAddressLink
-              content={symbol}
-              endpoint={`/token/${stakingAssetAddress}`}
-              showExternalLinkIcon={false}
-              tooltipContent="View token address on Etherscan"
-            />
-          ) : (
-            <span>{symbol}</span>
-          )}
-        </div>
-      );
+    {
+      accessorKey: "latestSeenChangeAt",
+      header: ({ column }) => (
+        <DataTableColumnHeader
+          className="text-purple-dark text-sm"
+          column={column}
+          title={text.latestSeenChangeAt}
+        />
+      ),
+      cell: ({ row }) => {
+        const date = Number(row.getValue("latestSeenChangeAt"));
+        return <TimeAgoCell timestamp={date} />;
+      },
+      enableSorting: true,
+      enableHiding: true,
     },
-    enableSorting: true,
-    enableHiding: false,
-  },
-  {
-    accessorKey: "status",
-    header: ({ column }) => (
-      <DataTableColumnHeader
-        className="text-purple-dark text-sm"
-        column={column}
-        title={text.status}
-      />
-    ),
-    cell: ({ row }) => {
-      const status = row.getValue("status");
-      if (typeof status !== "number") {
-        return null;
-      }
-      return <ValidatorStatusBadge status={status} />;
-    },
-    enableSorting: true,
-    enableHiding: false,
-  },
-  {
-    accessorKey: "firstSeenAt",
-    header: ({ column }) => (
-      <DataTableColumnHeader
-        className="text-purple-dark text-sm"
-        column={column}
-        title={text.firstSeenAt}
-      />
-    ),
-    cell: ({ row }) => {
-      const date = Number(row.getValue("firstSeenAt"));
-      return <TimeAgoCell timestamp={date} />;
-    },
-    enableSorting: true,
-    enableHiding: true,
-  },
-  {
-    accessorKey: "latestSeenChangeAt",
-    header: ({ column }) => (
-      <DataTableColumnHeader
-        className="text-purple-dark text-sm"
-        column={column}
-        title={text.latestSeenChangeAt}
-      />
-    ),
-    cell: ({ row }) => {
-      const date = Number(row.getValue("latestSeenChangeAt"));
-      return <TimeAgoCell timestamp={date} />;
-    },
-    enableSorting: true,
-    enableHiding: true,
-  },
-];
+  ];

--- a/services/explorer-ui/src/lib/utils.ts
+++ b/services/explorer-ui/src/lib/utils.ts
@@ -104,50 +104,66 @@ export const formatTimeSince = (
   return `${duration}`;
 };
 
-const feesPrefix = [
-  { label: "", value: 1 },
-  { label: "k", value: 1_000 },
-  { label: "M", value: 1_000_000 },
-  { label: "G", value: 1_000_000_000 },
-];
-
-export const formatFees = (fees: string | undefined) => {
-  if (fees === undefined) {
-    return { denomination: "", value: "No data" };
-  }
-  const feesNumber = Number(fees);
-  for (let i = feesPrefix.length - 1; i >= 0; i--) {
-    const prefix = feesPrefix[i];
-    if (feesNumber >= prefix.value) {
-      return {
-        denomination: prefix.label,
-        value: (feesNumber / prefix.value).toFixed(2),
-      };
-    }
-  }
-  return {
-    denomination: "",
-    value: feesNumber.toFixed(2),
-  };
+export const getFeeJuiceSymbol = (symbol?: string): string => {
+  return symbol ?? "AZTEC";
 };
 
-const formatRoundedUnits = (
+const formatWithSignificantDigits = (
   value: bigint,
   decimals: number,
-  displayDecimals: number,
-) => {
-  const base = 10n ** BigInt(decimals);
-  const scale = 10n ** BigInt(displayDecimals);
-  const roundedScaledValue = (value * scale + base / 2n) / base;
-  const integerPart = roundedScaledValue / scale;
-
-  if (displayDecimals === 0) {
-    return integerPart.toString();
+  significantDigits = 4,
+): string => {
+  if (value === 0n) {
+    return "0";
   }
 
-  const fractionalPart = (roundedScaledValue % scale)
+  const rawDigits = value.toString();
+  const integerPartRaw =
+    rawDigits.length > decimals
+      ? rawDigits.slice(0, rawDigits.length - decimals)
+      : "0";
+  const fractionPartRaw =
+    rawDigits.length > decimals
+      ? rawDigits.slice(rawDigits.length - decimals)
+      : rawDigits.padStart(decimals, "0");
+  const integerPartNormalized = integerPartRaw.replace(/^0+/, "") || "0";
+  const hasIntegerPart = integerPartNormalized !== "0";
+
+  let fractionDigits: number;
+
+  if (hasIntegerPart) {
+    fractionDigits = Math.max(
+      significantDigits - integerPartNormalized.length,
+      0,
+    );
+  } else {
+    const firstNonZeroIndex = fractionPartRaw.search(/[1-9]/);
+
+    if (firstNonZeroIndex === -1) {
+      return "0";
+    }
+
+    fractionDigits = firstNonZeroIndex + significantDigits;
+  }
+
+  let roundedValue: bigint;
+
+  if (fractionDigits >= decimals) {
+    roundedValue = value * 10n ** BigInt(fractionDigits - decimals);
+  } else {
+    const divisor = 10n ** BigInt(decimals - fractionDigits);
+    roundedValue = (value + divisor / 2n) / divisor;
+  }
+
+  if (fractionDigits === 0) {
+    return roundedValue.toString();
+  }
+
+  const scale = 10n ** BigInt(fractionDigits);
+  const integerPart = roundedValue / scale;
+  const fractionalPart = (roundedValue % scale)
     .toString()
-    .padStart(displayDecimals, "0");
+    .padStart(fractionDigits, "0");
 
   return `${integerPart.toString()}.${fractionalPart}`;
 };
@@ -161,12 +177,30 @@ export const formatCompactUnits = (value: bigint, decimals = 18): string => {
   let formattedValue: string;
 
   if (absoluteValue < oneThousand) {
-    formattedValue = formatRoundedUnits(absoluteValue, decimals, 0);
+    formattedValue = formatWithSignificantDigits(absoluteValue, decimals);
   } else if (absoluteValue <= 999_999n * base) {
-    formattedValue = `${formatRoundedUnits(absoluteValue, decimals + 3, 0)}K`;
+    formattedValue = `${formatWithSignificantDigits(absoluteValue, decimals + 3)}k`;
   } else {
-    formattedValue = `${formatRoundedUnits(absoluteValue, decimals + 6, 2)}M`;
+    formattedValue = `${formatWithSignificantDigits(absoluteValue, decimals + 6)}M`;
   }
 
   return isNegative ? `-${formattedValue}` : formattedValue;
+};
+
+export const formatFees = (
+  fees: string | undefined,
+  decimals = 18,
+): { denomination: string; value: string } => {
+  if (fees === undefined) {
+    return { denomination: "", value: "No data" };
+  }
+
+  try {
+    return {
+      denomination: "",
+      value: formatCompactUnits(BigInt(fees), decimals),
+    };
+  } catch {
+    return { denomination: "", value: "No data" };
+  }
 };

--- a/services/explorer-ui/src/pages/block-details/index.tsx
+++ b/services/explorer-ui/src/pages/block-details/index.tsx
@@ -68,6 +68,9 @@ export const BlockDetails: FC = () => {
             txEffects={blockTxEffects}
             isLoading={txEffectsLoading}
             error={txEffectsError}
+            feeJuiceAddress={chainInfo?.l1ContractAddresses.feeJuiceAddress}
+            feeJuiceDecimals={chainInfo?.feeJuiceDecimals}
+            feeJuiceSymbol={chainInfo?.feeJuiceSymbol}
           />
         );
       case "contracts":
@@ -111,7 +114,9 @@ export const BlockDetails: FC = () => {
             <AdjecentBlockButtons blockNumber={block.height} />
           )}
           <div className="bg-white rounded-lg shadow-md p-4">
-            <KeyValueDisplay data={getBlockDetails(block)} />
+            <KeyValueDisplay
+              data={getBlockDetails(block, chainInfo?.feeJuiceSymbol)}
+            />
           </div>
         </div>
         <OptionButtons

--- a/services/explorer-ui/src/pages/block-details/util.ts
+++ b/services/explorer-ui/src/pages/block-details/util.ts
@@ -5,10 +5,12 @@ import {
   type UiTxEffectTable,
 } from "@chicmoz-pkg/types";
 import { type DetailItem } from "~/components/info-display/key-value-display";
+import { getFeeJuiceSymbol } from "~/lib/utils";
 import { API_URL, aztecExplorer } from "~/service/constants";
 
 export const getBlockDetails = (
   latestBlock: ChicmozL2BlockLight,
+  feeJuiceSymbol?: string,
 ): DetailItem[] => {
   const l2BlockTimestamp = latestBlock.header.globalVariables.timestamp;
 
@@ -42,7 +44,7 @@ export const getBlockDetails = (
       tooltip: "L2 address that receives the transaction fees for this block.",
     },
     {
-      label: "totalFees (FJ)",
+      label: `totalFees (${getFeeJuiceSymbol(feeJuiceSymbol)})`,
       value: "" + latestBlock.header.totalFees,
     },
     {
@@ -52,13 +54,16 @@ export const getBlockDetails = (
     {
       label: "feePerDaGas",
       value: "" + latestBlock.header.globalVariables.gasFees.feePerDaGas,
-      tooltip:
-        "FJ paid for the data usage by the transaction, e.g. creating/spending notes, emitting logs, etc.",
+      tooltip: `${getFeeJuiceSymbol(
+        feeJuiceSymbol,
+      )} paid for the data usage by the transaction, e.g. creating/spending notes, emitting logs, etc.`,
     },
     {
       label: "feePerL2Gas",
       value: "" + latestBlock.header.globalVariables.gasFees.feePerL2Gas,
-      tooltip: "FJ paid for the computation usage of the public VM.",
+      tooltip: `${getFeeJuiceSymbol(
+        feeJuiceSymbol,
+      )} paid for the computation usage of the public VM.`,
     },
     {
       label: " Block status",
@@ -67,8 +72,7 @@ export const getBlockDetails = (
     {
       label: "Proposed on L1",
       value: "Not yet proposed",
-      timestamp:
-        Math.floor((proposedOnL1Date?? 0)) ?? undefined,
+      timestamp: Math.floor(proposedOnL1Date ?? 0) ?? undefined,
     },
     // NOTE: not all blocks have this
     //{

--- a/services/explorer-ui/src/pages/block/index.tsx
+++ b/services/explorer-ui/src/pages/block/index.tsx
@@ -5,18 +5,20 @@ import { BaseLayout } from "~/layout/base-layout";
 import {
   useAvarageBlockTime,
   useAvarageFees,
+  useChainInfo,
   useSubTitle,
   usePaginatedTableBlocks,
   useLatestTableBlocks,
   useLatestTableBlocksByHeightRange,
 } from "~/hooks";
-import { formatDuration } from "~/lib/utils";
+import { formatDuration, getFeeJuiceSymbol } from "~/lib/utils";
 import { routes } from "~/routes/__root";
 
 export const Blocks: FC = () => {
   useSubTitle(routes.blocks.children.index.title);
 
   const { data: latestBlocksData } = useLatestTableBlocks();
+  const { data: chainInfo } = useChainInfo();
 
   // State for block range (for range selector)
   const [startBlock, setStartBlock] = useState<number | undefined>(undefined);
@@ -113,7 +115,7 @@ export const Blocks: FC = () => {
       </div>
       <div className="grid grid-cols-2 gap-3 my-10 md:gap-5">
         <InfoBadge
-          title="Average fees (FJ)"
+          title={`Average fees (${getFeeJuiceSymbol(chainInfo?.feeJuiceSymbol)})`}
           isLoading={loadingAvarageFees}
           error={errorAvarageFees}
           data={avarageFees}

--- a/services/explorer-ui/src/pages/contract-instance-details/components/balance-header.tsx
+++ b/services/explorer-ui/src/pages/contract-instance-details/components/balance-header.tsx
@@ -1,19 +1,22 @@
 import { type FC } from "react";
+import { getFeeJuiceSymbol } from "~/lib/utils";
 
 interface BalanceHeaderProps {
   currentBalance: number;
   lastUpdated: string;
+  feeJuiceSymbol?: string;
 }
 
 export const BalanceHeader: FC<BalanceHeaderProps> = ({
   currentBalance,
   lastUpdated,
+  feeJuiceSymbol,
 }) => {
   return (
     <div className="bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20 rounded-lg p-4 md:p-6 border border-blue-100 dark:border-blue-800">
       <div className="text-center">
         <h3 className="text-sm md:text-lg font-semibold text-gray-700 dark:text-gray-200 mb-2">
-          Current Fee Juice Balance
+          Current {getFeeJuiceSymbol(feeJuiceSymbol)} Balance
         </h3>
         <div className="text-sm md:text-3xl font-bold text-primary">
           {currentBalance.toLocaleString()}
@@ -25,4 +28,3 @@ export const BalanceHeader: FC<BalanceHeaderProps> = ({
     </div>
   );
 };
-

--- a/services/explorer-ui/src/pages/contract-instance-details/components/balance-header.tsx
+++ b/services/explorer-ui/src/pages/contract-instance-details/components/balance-header.tsx
@@ -1,14 +1,16 @@
 import { type FC } from "react";
-import { getFeeJuiceSymbol } from "~/lib/utils";
+import { formatCompactUnits, getFeeJuiceSymbol } from "~/lib/utils";
 
 interface BalanceHeaderProps {
-  currentBalance: number;
+  currentBalance: bigint;
+  feeJuiceDecimals?: number;
   lastUpdated: string;
   feeJuiceSymbol?: string;
 }
 
 export const BalanceHeader: FC<BalanceHeaderProps> = ({
   currentBalance,
+  feeJuiceDecimals,
   lastUpdated,
   feeJuiceSymbol,
 }) => {
@@ -19,7 +21,7 @@ export const BalanceHeader: FC<BalanceHeaderProps> = ({
           Current {getFeeJuiceSymbol(feeJuiceSymbol)} Balance
         </h3>
         <div className="text-sm md:text-3xl font-bold text-primary">
-          {currentBalance.toLocaleString()}
+          {formatCompactUnits(currentBalance, feeJuiceDecimals)}
         </div>
         <div className="text-xs md:text-sm text-gray-500 dark:text-gray-400 mt-1">
           Last updated: {new Date(lastUpdated).toLocaleString()}

--- a/services/explorer-ui/src/pages/contract-instance-details/feejuice-balance.tsx
+++ b/services/explorer-ui/src/pages/contract-instance-details/feejuice-balance.tsx
@@ -9,11 +9,13 @@ import { useBalanceChartData } from "./hooks/use-balance-chart-data";
 
 interface FeeJuiceBalanceProps {
   historyData: ChicmozContractInstanceBalance[];
+  feeJuiceDecimals?: number;
   feeJuiceSymbol?: string;
 }
 
 export const FeeJuiceBalance: FC<FeeJuiceBalanceProps> = ({
   historyData,
+  feeJuiceDecimals,
   feeJuiceSymbol,
 }) => {
   // State for date filtering and UI
@@ -61,7 +63,8 @@ export const FeeJuiceBalance: FC<FeeJuiceBalanceProps> = ({
     <div className="space-y-4 md:space-y-6">
       {/* Current Balance Display */}
       <BalanceHeader
-        currentBalance={Number(latestBalance.balance)}
+        currentBalance={latestBalance.balance}
+        feeJuiceDecimals={feeJuiceDecimals}
         lastUpdated={latestBalance.timestamp.toString()}
         feeJuiceSymbol={feeJuiceSymbol}
       />

--- a/services/explorer-ui/src/pages/contract-instance-details/feejuice-balance.tsx
+++ b/services/explorer-ui/src/pages/contract-instance-details/feejuice-balance.tsx
@@ -1,4 +1,4 @@
-import { ChicmozContractInstanceBalance } from "@chicmoz-pkg/types";
+import { type ChicmozContractInstanceBalance } from "@chicmoz-pkg/types";
 import { type FC, useState } from "react";
 import { BalanceAreaChart } from "~/components/charts/balance-area-chart";
 import { BalanceHeader } from "./components/balance-header";
@@ -9,9 +9,13 @@ import { useBalanceChartData } from "./hooks/use-balance-chart-data";
 
 interface FeeJuiceBalanceProps {
   historyData: ChicmozContractInstanceBalance[];
+  feeJuiceSymbol?: string;
 }
 
-export const FeeJuiceBalance: FC<FeeJuiceBalanceProps> = ({ historyData }) => {
+export const FeeJuiceBalance: FC<FeeJuiceBalanceProps> = ({
+  historyData,
+  feeJuiceSymbol,
+}) => {
   // State for date filtering and UI
   const [startDate, setStartDate] = useState<string>("");
   const [endDate, setEndDate] = useState<string>("");
@@ -32,7 +36,7 @@ export const FeeJuiceBalance: FC<FeeJuiceBalanceProps> = ({ historyData }) => {
     formatTooltipLabel,
     minDateForInput,
     maxDateForInput,
-  } = useBalanceChartData(historyData, startDate, endDate);
+  } = useBalanceChartData(historyData, startDate, endDate, feeJuiceSymbol);
 
   // Event handlers
   const clearDateRange = () => {
@@ -59,6 +63,7 @@ export const FeeJuiceBalance: FC<FeeJuiceBalanceProps> = ({ historyData }) => {
       <BalanceHeader
         currentBalance={Number(latestBalance.balance)}
         lastUpdated={latestBalance.timestamp.toString()}
+        feeJuiceSymbol={feeJuiceSymbol}
       />
 
       {/* Chart */}

--- a/services/explorer-ui/src/pages/contract-instance-details/hooks/use-balance-chart-data.ts
+++ b/services/explorer-ui/src/pages/contract-instance-details/hooks/use-balance-chart-data.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
-import { ChicmozContractInstanceBalance } from "@chicmoz-pkg/types";
+import { type ChicmozContractInstanceBalance } from "@chicmoz-pkg/types";
+import { getFeeJuiceSymbol } from "~/lib/utils";
 
 interface ChartDataPoint {
   timestamp: number;
@@ -11,6 +12,7 @@ export const useBalanceChartData = (
   historyData: ChicmozContractInstanceBalance[],
   startDate: string,
   endDate: string,
+  feeJuiceSymbol?: string,
 ) => {
   return useMemo(() => {
     // Sort data by timestamp to ensure chronological order
@@ -20,15 +22,21 @@ export const useBalanceChartData = (
 
     // Filter data based on date range
     const filteredData = (() => {
-      if (!startDate && !endDate) return sortedData;
+      if (!startDate && !endDate) {
+        return sortedData;
+      }
 
       return sortedData.filter((item) => {
         const itemDate = new Date(item.timestamp);
         const start = startDate ? new Date(startDate) : null;
         const end = endDate ? new Date(endDate + "T23:59:59") : null; // Include end of day
 
-        if (start && itemDate < start) return false;
-        if (end && itemDate > end) return false;
+        if (start && itemDate < start) {
+          return false;
+        }
+        if (end && itemDate > end) {
+          return false;
+        }
         return true;
       });
     })();
@@ -103,7 +111,10 @@ export const useBalanceChartData = (
     const timeFormatter = getTimeFormatter();
 
     const formatTooltipValue = (value: number) => {
-      return [`${value.toLocaleString()} Fee Juice`, "Balance"];
+      return [
+        `${value.toLocaleString()} ${getFeeJuiceSymbol(feeJuiceSymbol)}`,
+        "Balance",
+      ];
     };
 
     const formatTooltipLabel = (timestamp: number) => {
@@ -137,5 +148,5 @@ export const useBalanceChartData = (
       minDateForInput,
       maxDateForInput,
     };
-  }, [historyData, startDate, endDate]);
+  }, [historyData, startDate, endDate, feeJuiceSymbol]);
 };

--- a/services/explorer-ui/src/pages/contract-instance-details/tabs-section.tsx
+++ b/services/explorer-ui/src/pages/contract-instance-details/tabs-section.tsx
@@ -3,7 +3,11 @@ import { useState, type FC } from "react";
 import { KeyValueDisplay } from "~/components/info-display/key-value-display";
 import { Loader } from "~/components/loader";
 import { OptionButtons } from "~/components/option-buttons";
-import { useContractClass, useContractInstanceBalanceHistory } from "~/hooks";
+import {
+  useChainInfo,
+  useContractClass,
+  useContractInstanceBalanceHistory,
+} from "~/hooks";
 import { type SimpleArtifactData } from "../contract-class-details/artifact-parser";
 import { ArtifactExplorerTab } from "../contract-class-details/tabs/artifact-explorer-tab";
 import { ArtifactJsonTab } from "../contract-class-details/tabs/artifact-json-tab";
@@ -17,6 +21,7 @@ interface PillSectionProps {
 export const TabsSection: FC<PillSectionProps> = ({
   contractInstanceDetails,
 }) => {
+  const { data: chainInfo } = useChainInfo();
   const { verifiedDeploymentArguments, deployerMetadata, aztecScanNotes } =
     getVerifiedContractInstanceDeploymentData(contractInstanceDetails);
 
@@ -55,7 +60,10 @@ export const TabsSection: FC<PillSectionProps> = ({
         return balanceHistoryRes.isLoading ? (
           <Loader amount={1} />
         ) : (
-          <FeeJuiceBalance historyData={balanceHistoryRes.data ?? []} />
+          <FeeJuiceBalance
+            historyData={balanceHistoryRes.data ?? []}
+            feeJuiceSymbol={chainInfo?.feeJuiceSymbol}
+          />
         );
       case "contactDetails":
         return <KeyValueDisplay data={deployerMetadata ?? []} />;

--- a/services/explorer-ui/src/pages/contract-instance-details/tabs-section.tsx
+++ b/services/explorer-ui/src/pages/contract-instance-details/tabs-section.tsx
@@ -62,6 +62,7 @@ export const TabsSection: FC<PillSectionProps> = ({
         ) : (
           <FeeJuiceBalance
             historyData={balanceHistoryRes.data ?? []}
+            feeJuiceDecimals={chainInfo?.feeJuiceDecimals}
             feeJuiceSymbol={chainInfo?.feeJuiceSymbol}
           />
         );

--- a/services/explorer-ui/src/pages/contract-instance-details/types.ts
+++ b/services/explorer-ui/src/pages/contract-instance-details/types.ts
@@ -22,7 +22,7 @@ export const tabSchema = z.object({
 export type Tab = z.infer<typeof tabSchema>;
 
 export const verifiedDeploymentTabs: Tab[] = [
-  { id: "feeJuiceBalance", label: "Feejuice Balance" },
+  { id: "feeJuiceBalance", label: "Token Balance" },
   { id: "verifiedDeployment", label: "Verified deployment" },
   { id: "contactDetails", label: "Contact details" },
   { id: "aztecScanNotes", label: "Aztec Scan notes" },

--- a/services/explorer-ui/src/pages/fee-recipients.tsx
+++ b/services/explorer-ui/src/pages/fee-recipients.tsx
@@ -5,7 +5,7 @@ import { useSubTitle } from "~/hooks";
 import { useChainInfo } from "~/hooks/api";
 import { useFeeRecipients } from "~/hooks/api/fee-recipient";
 import { BaseLayout } from "~/layout/base-layout";
-import { getFeeJuiceSymbol } from "~/lib/utils";
+import { formatCompactUnits, getFeeJuiceSymbol } from "~/lib/utils";
 import { routes } from "~/routes/__root";
 
 export const FeeRecipientPage: FC = () => {
@@ -13,11 +13,17 @@ export const FeeRecipientPage: FC = () => {
   const { data, isLoading, error } = useFeeRecipients();
   const { data: chainInfo } = useChainInfo();
 
-  const getTotalReceived = data
+  const totalReceived = data
     ? data.reduce((acc, cur) => {
-        return acc + Number(cur.feesReceived);
-      }, 0)
-    : 0;
+        return acc + cur.feesReceived;
+      }, 0n)
+    : 0n;
+
+  const formattedTotalReceived = formatCompactUnits(
+    totalReceived,
+    chainInfo?.feeJuiceDecimals,
+  );
+
   return (
     <BaseLayout>
       <div className="flex flex-wrap m-5">
@@ -41,7 +47,7 @@ export const FeeRecipientPage: FC = () => {
           )})`}
           isLoading={isLoading}
           error={error}
-          data={getTotalReceived.toString()}
+          data={formattedTotalReceived}
         />
       </div>
       <div className="rounded-lg shadow-lg">

--- a/services/explorer-ui/src/pages/fee-recipients.tsx
+++ b/services/explorer-ui/src/pages/fee-recipients.tsx
@@ -2,13 +2,16 @@ import { type FC } from "react";
 import { FeeReceipientsTable } from "~/components/fee-recipient/fee-recipient-table";
 import { InfoBadge } from "~/components/info-badge";
 import { useSubTitle } from "~/hooks";
+import { useChainInfo } from "~/hooks/api";
 import { useFeeRecipients } from "~/hooks/api/fee-recipient";
 import { BaseLayout } from "~/layout/base-layout";
+import { getFeeJuiceSymbol } from "~/lib/utils";
 import { routes } from "~/routes/__root";
 
 export const FeeRecipientPage: FC = () => {
   useSubTitle(routes.feeRecipients.title);
   const { data, isLoading, error } = useFeeRecipients();
+  const { data: chainInfo } = useChainInfo();
 
   const getTotalReceived = data
     ? data.reduce((acc, cur) => {
@@ -33,14 +36,22 @@ export const FeeRecipientPage: FC = () => {
           data={data ? data.length.toString() : ""}
         />
         <InfoBadge
-          title="Total amount fees received"
+          title={`Total amount fees received (${getFeeJuiceSymbol(
+            chainInfo?.feeJuiceSymbol,
+          )})`}
           isLoading={isLoading}
           error={error}
           data={getTotalReceived.toString()}
         />
       </div>
       <div className="rounded-lg shadow-lg">
-        <FeeReceipientsTable feeRecipients={data} isLoading={isLoading} />
+        <FeeReceipientsTable
+          feeRecipients={data}
+          isLoading={isLoading}
+          feeJuiceAddress={chainInfo?.l1ContractAddresses.feeJuiceAddress}
+          feeJuiceDecimals={chainInfo?.feeJuiceDecimals}
+          feeJuiceSymbol={chainInfo?.feeJuiceSymbol}
+        />
       </div>
     </BaseLayout>
   );

--- a/services/explorer-ui/src/pages/l1/validator-details.tsx
+++ b/services/explorer-ui/src/pages/l1/validator-details.tsx
@@ -33,7 +33,7 @@ const getValidatorData = (
     validator.stake,
     stakingAssetInfo.stakingAssetDecimals,
   );
-  const stakingAssetSymbol = stakingAssetInfo.stakingAssetSymbol ?? "STK";
+  const stakingAssetSymbol = stakingAssetInfo.stakingAssetSymbol ?? "AZTEC";
 
   return [
     {

--- a/services/explorer-ui/src/pages/l1/validator-details.tsx
+++ b/services/explorer-ui/src/pages/l1/validator-details.tsx
@@ -1,6 +1,7 @@
 import { type ChicmozL1L2Validator } from "@chicmoz-pkg/types";
 import { useParams } from "@tanstack/react-router";
 import { type FC } from "react";
+import { CopyableAmount } from "~/components/copyable-amount";
 import { EtherscanAddressLink } from "~/components/etherscan-address-link";
 import {
   KeyValueDisplay,
@@ -46,7 +47,10 @@ const getValidatorData = (
       value: "CUSTOM",
       customValue: (
         <span className="inline-flex w-full items-center justify-end gap-1 font-mono">
-          <span>{stakeValue}</span>
+          <CopyableAmount
+            displayAmount={stakeValue}
+            rawAmount={validator.stake.toString()}
+          />
           {stakingAssetInfo.stakingAssetAddress ? (
             <EtherscanAddressLink
               content={stakingAssetSymbol}

--- a/services/explorer-ui/src/pages/landing/index.tsx
+++ b/services/explorer-ui/src/pages/landing/index.tsx
@@ -150,7 +150,7 @@ export const Landing: FC = () => {
               data={totalAmountOfContracts}
             />
             <InfoBadge
-              title={`Average fees (${formattedFees.denomination} ${getFeeJuiceSymbol(
+              title={`Average fees (${getFeeJuiceSymbol(
                 chainInfo?.feeJuiceSymbol,
               )})`}
               isLoading={loadingAvarageFees}

--- a/services/explorer-ui/src/pages/landing/index.tsx
+++ b/services/explorer-ui/src/pages/landing/index.tsx
@@ -10,6 +10,7 @@ import {
   HealthStatus,
   useAvarageBlockTime,
   useAvarageFees,
+  useChainInfo,
   useLatestTableBlocks,
   useLatestTableTxEffects,
   usePendingTxs,
@@ -20,7 +21,7 @@ import {
   useTotalTxEffects,
   useTotalTxEffectsLast24h,
 } from "~/hooks";
-import { formatDuration, formatFees } from "~/lib/utils";
+import { formatDuration, formatFees, getFeeJuiceSymbol } from "~/lib/utils";
 import { routes } from "~/routes/__root";
 
 export const Landing: FC = () => {
@@ -63,6 +64,7 @@ export const Landing: FC = () => {
     isLoading: isLoadingTxEffects,
     error: txEffectsError,
   } = useLatestTableTxEffects();
+  const { data: chainInfo } = useChainInfo();
 
   // For pending transactions
   const {
@@ -148,7 +150,9 @@ export const Landing: FC = () => {
               data={totalAmountOfContracts}
             />
             <InfoBadge
-              title={`Average fees (${formattedFees.denomination} FJ)`}
+              title={`Average fees (${formattedFees.denomination} ${getFeeJuiceSymbol(
+                chainInfo?.feeJuiceSymbol,
+              )})`}
               isLoading={loadingAvarageFees}
               error={errorAvarageFees}
               data={formattedFees.value}
@@ -230,6 +234,11 @@ export const Landing: FC = () => {
                   disableSizeSelector={true}
                   disablePagination={true}
                   maxEntries={8}
+                  feeJuiceAddress={
+                    chainInfo?.l1ContractAddresses.feeJuiceAddress
+                  }
+                  feeJuiceDecimals={chainInfo?.feeJuiceDecimals}
+                  feeJuiceSymbol={chainInfo?.feeJuiceSymbol}
                 />
                 <Link
                   to={routes.txEffects.route}

--- a/services/explorer-ui/src/pages/tx-effect-details/index.tsx
+++ b/services/explorer-ui/src/pages/tx-effect-details/index.tsx
@@ -6,6 +6,7 @@ import { LoadingDetails } from "~/components/loading/loading-details";
 import { getEmptyTxEffectData } from "~/components/loading/util";
 import { OrphanedBanner } from "~/components/orphaned-banner";
 import {
+  useChainInfo,
   useGetDroppedTxByHash,
   useGetTxEffectByHash,
   usePendingTxsByHash,
@@ -28,6 +29,7 @@ export const TxEffectDetails: FC = () => {
     error: txEffectsError,
   } = useGetTxEffectByHash(hash);
   const tick = useTimeTick();
+  const { data: chainInfo } = useChainInfo();
 
   const { data: pendingTx, isLoading: isPendingTxLoading } =
     usePendingTxsByHash(hash);
@@ -106,7 +108,15 @@ export const TxEffectDetails: FC = () => {
             <OrphanedBanner type="tx-effect" />
           ) : null}
           <div className="bg-white rounded-lg shadow-md p-4">
-            <KeyValueDisplay key={tick} data={getTxEffectData(txEffects)} />
+            <KeyValueDisplay
+              key={tick}
+              data={getTxEffectData(
+                txEffects,
+                chainInfo?.l1ContractAddresses.feeJuiceAddress,
+                chainInfo?.feeJuiceDecimals,
+                chainInfo?.feeJuiceSymbol,
+              )}
+            />
           </div>
           <TabsSection txEffects={txEffects} />
         </div>

--- a/services/explorer-ui/src/pages/tx-effect-details/utils.ts
+++ b/services/explorer-ui/src/pages/tx-effect-details/utils.ts
@@ -3,6 +3,7 @@ import {
   type ChicmozL2TxEffectDeluxe,
 } from "@chicmoz-pkg/types";
 import { createElement } from "react";
+import { CopyableAmount } from "~/components/copyable-amount";
 import { EtherscanAddressLink } from "~/components/etherscan-address-link";
 import { formatFees, getFeeJuiceSymbol } from "~/lib/utils";
 import { API_URL, aztecExplorer } from "~/service/constants";
@@ -47,11 +48,10 @@ export const getTxEffectData = (
           className:
             "inline-flex w-full items-center justify-end gap-1 font-mono",
         },
-        createElement(
-          "span",
-          undefined,
-          `${formattedFee.value}${formattedFee.denomination}`,
-        ),
+        createElement(CopyableAmount, {
+          displayAmount: `${formattedFee.value}${formattedFee.denomination}`,
+          rawAmount: data.transactionFee.toString(),
+        }),
         feeJuiceAddress
           ? createElement(EtherscanAddressLink, {
               content: symbol,

--- a/services/explorer-ui/src/pages/tx-effect-details/utils.ts
+++ b/services/explorer-ui/src/pages/tx-effect-details/utils.ts
@@ -2,6 +2,9 @@ import {
   type ChicmozL2DroppedTx,
   type ChicmozL2TxEffectDeluxe,
 } from "@chicmoz-pkg/types";
+import { createElement } from "react";
+import { EtherscanAddressLink } from "~/components/etherscan-address-link";
+import { formatFees, getFeeJuiceSymbol } from "~/lib/utils";
 import { API_URL, aztecExplorer } from "~/service/constants";
 import { type TabId } from "./types";
 
@@ -18,15 +21,46 @@ export type TxEffectDataType =
   | Array<{ logs: Array<{ data: Buffer }> }>
   | Array<{ leafSlot: string; value: string }>;
 
-export const getTxEffectData = (data: ChicmozL2TxEffectDeluxe) => {
+export const getTxEffectData = (
+  data: ChicmozL2TxEffectDeluxe,
+  feeJuiceAddress?: string,
+  feeJuiceDecimals?: number,
+  feeJuiceSymbol?: string,
+) => {
+  const formattedFee = formatFees(
+    data.transactionFee.toString(),
+    feeJuiceDecimals,
+  );
+  const symbol = getFeeJuiceSymbol(feeJuiceSymbol);
+
   return [
     {
       label: "HASH",
       value: data.txHash,
     },
     {
-      label: "TRANSACTION FEE (FJ)",
-      value: data.transactionFee.toString(),
+      label: "TRANSACTION FEE",
+      value: "CUSTOM",
+      customValue: createElement(
+        "span",
+        {
+          className:
+            "inline-flex w-full items-center justify-end gap-1 font-mono",
+        },
+        createElement(
+          "span",
+          undefined,
+          `${formattedFee.value}${formattedFee.denomination}`,
+        ),
+        feeJuiceAddress
+          ? createElement(EtherscanAddressLink, {
+              content: symbol,
+              endpoint: `/token/${feeJuiceAddress}`,
+              showExternalLinkIcon: false,
+              tooltipContent: "View token address on Etherscan",
+            })
+          : createElement("span", undefined, symbol),
+      ),
     },
     {
       label: "BLOCK NUMBER",

--- a/services/explorer-ui/src/pages/tx-effect/index.tsx
+++ b/services/explorer-ui/src/pages/tx-effect/index.tsx
@@ -4,6 +4,7 @@ import { Loader } from "~/components/loader";
 import { PendingTxsTable } from "~/components/pending-txs/pending-txs-table";
 import { TxEffectsTable } from "~/components/tx-effects/tx-effects-table";
 import {
+  useChainInfo,
   useLatestTableTxEffects,
   usePendingTxs,
   useSubTitle,
@@ -37,6 +38,7 @@ export const TxEffects: FC = () => {
     isLoading: isLoadingPendingTxs,
     error: pendingTxsError,
   } = usePendingTxs();
+  const { data: chainInfo } = useChainInfo();
 
   return (
     <BaseLayout>
@@ -69,6 +71,9 @@ export const TxEffects: FC = () => {
             txEffects={latestTxEffectsData}
             isLoading={isLoadingTxEffects}
             error={txEffectsError}
+            feeJuiceAddress={chainInfo?.l1ContractAddresses.feeJuiceAddress}
+            feeJuiceDecimals={chainInfo?.feeJuiceDecimals}
+            feeJuiceSymbol={chainInfo?.feeJuiceSymbol}
           />
         </div>
         <div className="bg-white rounded-lg shadow-lg w-full md:w-1/2">


### PR DESCRIPTION
## Summary
- add backend support for dynamic fee juice token metadata by fetching symbol/decimals from `chainInfo.l1ContractAddresses.feeJuiceAddress`, persisting it in chain info, and exposing it through the API
- update the explorer UI to replace hardcoded fee token labels with dynamic token metadata, add token links where appropriate, and align fee/staking amount formatting around decimal-aware compact formatting
- make fee and staking amounts easier to use in the UI by adding copyable amount interactions and reworking transaction details/table displays to match the staking asset presentation style

## Notes
- includes an explorer-api migration for `fee_juice_symbol` and `fee_juice_decimals`
- frontend formatting now uses the shared compact formatter for both staking asset and fee juice values, with lowercase `k` and at least 4 significant digits for non-compacted values