### PR TITLE
ci: migrate all services to GitHub Actions + Kustomize CI/CD

### DIFF
--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -1,0 +1,170 @@
+name: CI/CD Auth
+
+on:
+  push:
+    branches:
+      - production
+    paths:
+      - "services/auth/**"
+  workflow_dispatch: # no network input — always mainnet
+
+env:
+  REGISTRY: registry.digitalocean.com/aztlan-containers
+  CLUSTER_NAME: aztecscan-prod
+  IMAGE_NAME: auth-mainnet
+
+jobs:
+  set-up:
+    runs-on: ubuntu-latest
+    outputs:
+      tools-cache-key: ${{ steps.cache-key.outputs.key }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up tools directory
+        run: mkdir -p tools
+
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Copy doctl to tools directory
+        run: |
+          cp $(which doctl) tools/
+          chmod +x tools/doctl
+
+      - name: Install kubectl
+        run: |
+          curl -Lo tools/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          chmod +x tools/kubectl
+
+      - name: Generate cache key
+        id: cache-key
+        run: echo "key=${{ runner.os }}-tools-$(date '+%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Cache tools
+        uses: actions/cache@v4
+        with:
+          path: tools
+          key: ${{ steps.cache-key.outputs.key }}
+
+      - name: Log in to DigitalOcean Container Registry
+        run: tools/doctl registry login --expiry-seconds 1200
+
+  build-base:
+    runs-on: ubuntu-latest
+    needs: set-up
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to DigitalOcean Container Registry
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - run: doctl registry login --expiry-seconds 1200
+
+      - name: Build and push chicmoz-base
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: registry.digitalocean.com/aztlan-containers/chicmoz-base:latest
+          cache-from: type=gha,scope=chicmoz-base
+          cache-to: type=gha,scope=chicmoz-base,mode=max
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [set-up, build-base]
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Restore cached tools
+        uses: actions/cache@v4
+        with:
+          path: tools
+          key: ${{ needs.set-up.outputs.tools-cache-key }}
+          fail-on-cache-miss: true
+
+      - name: Add tools to PATH
+        run: |
+          chmod +x tools/*
+          echo "$PWD/tools" >> $GITHUB_PATH
+
+      - name: Log in to DigitalOcean Container Registry
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - run: doctl registry login --expiry-seconds 1200
+
+      - name: Build and push service image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: services/auth/Dockerfile
+          push: true
+          tags: |
+            registry.digitalocean.com/aztlan-containers/${{ env.IMAGE_NAME }}:latest
+            registry.digitalocean.com/aztlan-containers/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          build-args: |
+            BASE=registry.digitalocean.com/aztlan-containers/chicmoz-base:latest
+          cache-from: type=gha,scope=auth-mainnet
+          cache-to: type=gha,scope=auth-mainnet,mode=max
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [set-up, build]
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Restore cached tools
+        uses: actions/cache@v4
+        with:
+          path: tools
+          key: ${{ needs.set-up.outputs.tools-cache-key }}
+          fail-on-cache-miss: true
+
+      - name: Add tools to PATH
+        run: |
+          chmod +x tools/*
+          echo "$PWD/tools" >> $GITHUB_PATH
+
+      - name: Configure doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Save DigitalOcean kubeconfig
+        run: doctl kubernetes cluster kubeconfig save ${{ env.CLUSTER_NAME }}
+
+      - name: Ensure DigitalOcean registry credentials exist in cluster
+        run: |
+          doctl registries kubernetes-manifest aztlan-containers --namespace chicmoz-prod | kubectl apply -f -
+
+      - name: Apply manifests
+        run: kubectl apply -k services/auth/k8s/overlays/mainnet/
+
+      - name: Restart deployment
+        run: kubectl rollout restart deployment/auth -n chicmoz-prod
+
+      - name: Wait for rollout
+        run: kubectl rollout status deployment/auth -n chicmoz-prod --timeout=300s

--- a/.github/workflows/aztec-listener.yml
+++ b/.github/workflows/aztec-listener.yml
@@ -1,0 +1,226 @@
+name: CI/CD Aztec Listener
+
+on:
+  push:
+    branches:
+      - production-testnet
+      - production
+      - production-devnet
+    paths:
+      - "services/aztec-listener/**"
+  workflow_dispatch:
+    inputs:
+      network:
+        description: "Network to deploy to"
+        required: true
+        type: choice
+        options:
+          - testnet
+          - mainnet
+          - devnet
+
+env:
+  REGISTRY: registry.digitalocean.com/aztlan-containers
+  CLUSTER_NAME: aztecscan-prod
+
+jobs:
+  set-up:
+    runs-on: ubuntu-latest
+    outputs:
+      tools-cache-key: ${{ steps.cache-key.outputs.key }}
+      network: ${{ steps.network.outputs.network }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine network
+        id: network
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "network=${{ inputs.network }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref_name }}" = "production" ]; then
+            echo "network=mainnet" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref_name }}" = "production-testnet" ]; then
+            echo "network=testnet" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref_name }}" = "production-devnet" ]; then
+            echo "network=devnet" >> $GITHUB_OUTPUT
+          else
+            echo "ERROR: Cannot determine network from branch ${{ github.ref_name }}" >&2
+            exit 1
+          fi
+
+      - name: Set up tools directory
+        run: mkdir -p tools
+
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Copy doctl to tools directory
+        run: |
+          cp $(which doctl) tools/
+          chmod +x tools/doctl
+
+      - name: Install kubectl
+        run: |
+          curl -Lo tools/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          chmod +x tools/kubectl
+
+      - name: Generate cache key
+        id: cache-key
+        run: echo "key=${{ runner.os }}-tools-$(date '+%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Cache tools
+        uses: actions/cache@v4
+        with:
+          path: tools
+          key: ${{ steps.cache-key.outputs.key }}
+
+      - name: Log in to DigitalOcean Container Registry
+        run: tools/doctl registry login --expiry-seconds 1200
+
+  build-base:
+    runs-on: ubuntu-latest
+    needs: set-up
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to DigitalOcean Container Registry
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - run: doctl registry login --expiry-seconds 1200
+
+      - name: Build and push chicmoz-base
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: registry.digitalocean.com/aztlan-containers/chicmoz-base:latest
+          cache-from: type=gha,scope=chicmoz-base
+          cache-to: type=gha,scope=chicmoz-base,mode=max
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [set-up, build-base]
+    env:
+      NETWORK: ${{ needs.set-up.outputs.network }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Restore cached tools
+        uses: actions/cache@v4
+        with:
+          path: tools
+          key: ${{ needs.set-up.outputs.tools-cache-key }}
+          fail-on-cache-miss: true
+
+      - name: Add tools to PATH
+        run: |
+          chmod +x tools/*
+          echo "$PWD/tools" >> $GITHUB_PATH
+
+      - name: Log in to DigitalOcean Container Registry
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - run: doctl registry login --expiry-seconds 1200
+
+      - name: Build and push service image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: services/aztec-listener/Dockerfile
+          push: true
+          tags: |
+            registry.digitalocean.com/aztlan-containers/aztec-listener-${{ env.NETWORK }}:latest
+            registry.digitalocean.com/aztlan-containers/aztec-listener-${{ env.NETWORK }}:${{ github.sha }}
+          build-args: |
+            BASE=registry.digitalocean.com/aztlan-containers/chicmoz-base:latest
+          cache-from: type=gha,scope=aztec-listener-${{ env.NETWORK }}
+          cache-to: type=gha,scope=aztec-listener-${{ env.NETWORK }},mode=max
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [set-up, build]
+    env:
+      NETWORK: ${{ needs.set-up.outputs.network }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Restore cached tools
+        uses: actions/cache@v4
+        with:
+          path: tools
+          key: ${{ needs.set-up.outputs.tools-cache-key }}
+          fail-on-cache-miss: true
+
+      - name: Add tools to PATH
+        run: |
+          chmod +x tools/*
+          echo "$PWD/tools" >> $GITHUB_PATH
+
+      - name: Configure doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Save DigitalOcean kubeconfig
+        run: doctl kubernetes cluster kubeconfig save ${{ env.CLUSTER_NAME }}
+
+      - name: Ensure DigitalOcean registry credentials exist in cluster
+        run: |
+          doctl registries kubernetes-manifest aztlan-containers --namespace chicmoz-prod | kubectl apply -f -
+
+      - name: Inject Aztec RPC secret
+        env:
+          AZTEC_RPC_NODES_MAINNET: ${{ vars.AZTEC_RPC_NODES_MAINNET }}
+          AZTEC_RPC_NODES_TESTNET: ${{ vars.AZTEC_RPC_NODES_TESTNET }}
+          AZTEC_RPC_NODES_DEVNET: ${{ vars.AZTEC_RPC_NODES_DEVNET }}
+        run: |
+          NETWORK="${{ needs.set-up.outputs.network }}"
+          case "$NETWORK" in
+            mainnet)
+              kubectl create secret generic mainnet-config \
+                --from-literal=AZTEC_RPC_NODES_MAINNET=$AZTEC_RPC_NODES_MAINNET \
+                --namespace chicmoz-prod --dry-run=client -o yaml | kubectl apply -f -
+              ;;
+            testnet)
+              kubectl create secret generic testnet-config \
+                --from-literal=AZTEC_RPC_NODES_TESTNET=$AZTEC_RPC_NODES_TESTNET \
+                --namespace chicmoz-prod --dry-run=client -o yaml | kubectl apply -f -
+              ;;
+            devnet)
+              kubectl create secret generic devnet-config \
+                --from-literal=AZTEC_RPC_NODES_DEVNET=$AZTEC_RPC_NODES_DEVNET \
+                --namespace chicmoz-prod --dry-run=client -o yaml | kubectl apply -f -
+              ;;
+          esac
+
+      - name: Apply manifests
+        run: kubectl apply -k services/aztec-listener/k8s/overlays/${{ env.NETWORK }}/
+
+      - name: Restart deployment
+        run: kubectl rollout restart deployment/aztec-listener-${{ env.NETWORK }} -n chicmoz-prod
+
+      - name: Wait for rollout
+        run: kubectl rollout status deployment/aztec-listener-${{ env.NETWORK }} -n chicmoz-prod --timeout=300s

--- a/.github/workflows/aztec-listener.yml
+++ b/.github/workflows/aztec-listener.yml
@@ -200,17 +200,17 @@ jobs:
           NETWORK="${{ needs.set-up.outputs.network }}"
           case "$NETWORK" in
             mainnet)
-              kubectl create secret generic mainnet-config \
+              kubectl create secret generic aztec-listener-mainnet \
                 --from-literal=AZTEC_RPC_NODES_MAINNET=$AZTEC_RPC_NODES_MAINNET \
                 --namespace chicmoz-prod --dry-run=client -o yaml | kubectl apply -f -
               ;;
             testnet)
-              kubectl create secret generic testnet-config \
+              kubectl create secret generic aztec-listener-testnet \
                 --from-literal=AZTEC_RPC_NODES_TESTNET=$AZTEC_RPC_NODES_TESTNET \
                 --namespace chicmoz-prod --dry-run=client -o yaml | kubectl apply -f -
               ;;
             devnet)
-              kubectl create secret generic devnet-config \
+              kubectl create secret generic aztec-listener-devnet \
                 --from-literal=AZTEC_RPC_NODES_DEVNET=$AZTEC_RPC_NODES_DEVNET \
                 --namespace chicmoz-prod --dry-run=client -o yaml | kubectl apply -f -
               ;;

--- a/.github/workflows/compiler-orchestrator.yml
+++ b/.github/workflows/compiler-orchestrator.yml
@@ -1,0 +1,202 @@
+name: CI/CD Compiler Orchestrator
+
+on:
+  push:
+    branches:
+      - production-testnet
+      - production
+      - production-devnet
+    paths:
+      - "services/compiler-orchestrator/**"
+  workflow_dispatch:
+    inputs:
+      network:
+        description: "Network to deploy to"
+        required: true
+        type: choice
+        options:
+          - testnet
+          - mainnet
+          - devnet
+
+env:
+  REGISTRY: registry.digitalocean.com/aztlan-containers
+  CLUSTER_NAME: aztecscan-prod
+
+jobs:
+  set-up:
+    runs-on: ubuntu-latest
+    outputs:
+      tools-cache-key: ${{ steps.cache-key.outputs.key }}
+      network: ${{ steps.network.outputs.network }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine network
+        id: network
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "network=${{ inputs.network }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref_name }}" = "production" ]; then
+            echo "network=mainnet" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref_name }}" = "production-testnet" ]; then
+            echo "network=testnet" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref_name }}" = "production-devnet" ]; then
+            echo "network=devnet" >> $GITHUB_OUTPUT
+          else
+            echo "ERROR: Cannot determine network from branch ${{ github.ref_name }}" >&2
+            exit 1
+          fi
+
+      - name: Set up tools directory
+        run: mkdir -p tools
+
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Copy doctl to tools directory
+        run: |
+          cp $(which doctl) tools/
+          chmod +x tools/doctl
+
+      - name: Install kubectl
+        run: |
+          curl -Lo tools/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          chmod +x tools/kubectl
+
+      - name: Generate cache key
+        id: cache-key
+        run: echo "key=${{ runner.os }}-tools-$(date '+%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Cache tools
+        uses: actions/cache@v4
+        with:
+          path: tools
+          key: ${{ steps.cache-key.outputs.key }}
+
+      - name: Log in to DigitalOcean Container Registry
+        run: tools/doctl registry login --expiry-seconds 1200
+
+  build-base:
+    runs-on: ubuntu-latest
+    needs: set-up
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to DigitalOcean Container Registry
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - run: doctl registry login --expiry-seconds 1200
+
+      - name: Build and push chicmoz-base
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: registry.digitalocean.com/aztlan-containers/chicmoz-base:latest
+          cache-from: type=gha,scope=chicmoz-base
+          cache-to: type=gha,scope=chicmoz-base,mode=max
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [set-up, build-base]
+    env:
+      NETWORK: ${{ needs.set-up.outputs.network }}
+      IMAGE_NAME: compiler-orchestrator-${{ needs.set-up.outputs.network }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Restore cached tools
+        uses: actions/cache@v4
+        with:
+          path: tools
+          key: ${{ needs.set-up.outputs.tools-cache-key }}
+          fail-on-cache-miss: true
+
+      - name: Add tools to PATH
+        run: |
+          chmod +x tools/*
+          echo "$PWD/tools" >> $GITHUB_PATH
+
+      - name: Log in to DigitalOcean Container Registry
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - run: doctl registry login --expiry-seconds 1200
+
+      - name: Build and push service image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: services/compiler-orchestrator/Dockerfile
+          push: true
+          tags: |
+            registry.digitalocean.com/aztlan-containers/${{ env.IMAGE_NAME }}:latest
+            registry.digitalocean.com/aztlan-containers/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          build-args: |
+            BASE=registry.digitalocean.com/aztlan-containers/chicmoz-base:latest
+          cache-from: type=gha,scope=compiler-orchestrator-${{ env.NETWORK }}
+          cache-to: type=gha,scope=compiler-orchestrator-${{ env.NETWORK }},mode=max
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [set-up, build]
+    env:
+      NETWORK: ${{ needs.set-up.outputs.network }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Restore cached tools
+        uses: actions/cache@v4
+        with:
+          path: tools
+          key: ${{ needs.set-up.outputs.tools-cache-key }}
+          fail-on-cache-miss: true
+
+      - name: Add tools to PATH
+        run: |
+          chmod +x tools/*
+          echo "$PWD/tools" >> $GITHUB_PATH
+
+      - name: Configure doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Save DigitalOcean kubeconfig
+        run: doctl kubernetes cluster kubeconfig save ${{ env.CLUSTER_NAME }}
+
+      - name: Ensure DigitalOcean registry credentials exist in cluster
+        run: |
+          doctl registries kubernetes-manifest aztlan-containers --namespace chicmoz-prod | kubectl apply -f -
+
+      - name: Apply manifests
+        run: kubectl apply -k services/compiler-orchestrator/k8s/overlays/${{ env.NETWORK }}/
+
+      - name: Restart deployment
+        run: kubectl rollout restart deployment/compiler-orchestrator-${{ env.NETWORK }} -n chicmoz-prod
+
+      - name: Wait for rollout
+        run: kubectl rollout status deployment/compiler-orchestrator-${{ env.NETWORK }} -n chicmoz-prod --timeout=300s

--- a/.github/workflows/ethereum-listener.yml
+++ b/.github/workflows/ethereum-listener.yml
@@ -1,0 +1,237 @@
+name: CI/CD Ethereum Listener
+
+on:
+  push:
+    branches:
+      - production-testnet
+      - production
+      - production-devnet
+    paths:
+      - "services/ethereum-listener/**"
+  workflow_dispatch:
+    inputs:
+      network:
+        description: "Network to deploy to"
+        required: true
+        type: choice
+        options:
+          - testnet
+          - mainnet
+          - devnet
+
+env:
+  REGISTRY: registry.digitalocean.com/aztlan-containers
+  CLUSTER_NAME: aztecscan-prod
+
+jobs:
+  set-up:
+    runs-on: ubuntu-latest
+    outputs:
+      tools-cache-key: ${{ steps.cache-key.outputs.key }}
+      network: ${{ steps.network.outputs.network }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine network
+        id: network
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "network=${{ inputs.network }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref_name }}" = "production" ]; then
+            echo "network=mainnet" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref_name }}" = "production-testnet" ]; then
+            echo "network=testnet" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref_name }}" = "production-devnet" ]; then
+            echo "network=devnet" >> $GITHUB_OUTPUT
+          else
+            echo "ERROR: Cannot determine network from branch ${{ github.ref_name }}" >&2
+            exit 1
+          fi
+
+      - name: Set up tools directory
+        run: mkdir -p tools
+
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Copy doctl to tools directory
+        run: |
+          cp $(which doctl) tools/
+          chmod +x tools/doctl
+
+      - name: Install kubectl
+        run: |
+          curl -Lo tools/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          chmod +x tools/kubectl
+
+      - name: Generate cache key
+        id: cache-key
+        run: echo "key=${{ runner.os }}-tools-$(date '+%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Cache tools
+        uses: actions/cache@v4
+        with:
+          path: tools
+          key: ${{ steps.cache-key.outputs.key }}
+
+      - name: Log in to DigitalOcean Container Registry
+        run: tools/doctl registry login --expiry-seconds 1200
+
+  build-base:
+    runs-on: ubuntu-latest
+    needs: set-up
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to DigitalOcean Container Registry
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - run: doctl registry login --expiry-seconds 1200
+
+      - name: Build and push chicmoz-base
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: registry.digitalocean.com/aztlan-containers/chicmoz-base:latest
+          cache-from: type=gha,scope=chicmoz-base
+          cache-to: type=gha,scope=chicmoz-base,mode=max
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [set-up, build-base]
+    env:
+      NETWORK: ${{ needs.set-up.outputs.network }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Restore cached tools
+        uses: actions/cache@v4
+        with:
+          path: tools
+          key: ${{ needs.set-up.outputs.tools-cache-key }}
+          fail-on-cache-miss: true
+
+      - name: Add tools to PATH
+        run: |
+          chmod +x tools/*
+          echo "$PWD/tools" >> $GITHUB_PATH
+
+      - name: Log in to DigitalOcean Container Registry
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - run: doctl registry login --expiry-seconds 1200
+
+      - name: Build and push service image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: services/ethereum-listener/Dockerfile
+          push: true
+          tags: |
+            registry.digitalocean.com/aztlan-containers/ethereum-listener-${{ env.NETWORK }}:latest
+            registry.digitalocean.com/aztlan-containers/ethereum-listener-${{ env.NETWORK }}:${{ github.sha }}
+          build-args: |
+            BASE=registry.digitalocean.com/aztlan-containers/chicmoz-base:latest
+          cache-from: type=gha,scope=ethereum-listener-${{ env.NETWORK }}
+          cache-to: type=gha,scope=ethereum-listener-${{ env.NETWORK }},mode=max
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [set-up, build]
+    env:
+      NETWORK: ${{ needs.set-up.outputs.network }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Restore cached tools
+        uses: actions/cache@v4
+        with:
+          path: tools
+          key: ${{ needs.set-up.outputs.tools-cache-key }}
+          fail-on-cache-miss: true
+
+      - name: Add tools to PATH
+        run: |
+          chmod +x tools/*
+          echo "$PWD/tools" >> $GITHUB_PATH
+
+      - name: Configure doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Save DigitalOcean kubeconfig
+        run: doctl kubernetes cluster kubeconfig save ${{ env.CLUSTER_NAME }}
+
+      - name: Ensure DigitalOcean registry credentials exist in cluster
+        run: |
+          doctl registries kubernetes-manifest aztlan-containers --namespace chicmoz-prod | kubectl apply -f -
+
+      - name: Inject L1 RPC secrets
+        env:
+          MAINNET_AZTEC_L1_HTTP: ${{ vars.MAINNET_AZTEC_L1_HTTP }}
+          MAINNET_AZTEC_L1_WS: ${{ vars.MAINNET_AZTEC_L1_WS }}
+          ETHEREUM_HTTP_ALCHEMY_MAINNET_URL: ${{ vars.ETHEREUM_HTTP_ALCHEMY_MAINNET_URL }}
+          TESTNET_AZTEC_L1_HTTP: ${{ vars.TESTNET_AZTEC_L1_HTTP }}
+          TESTNET_AZTEC_L1_WS: ${{ vars.TESTNET_AZTEC_L1_WS }}
+          DEVNET_AZTEC_L1_HTTP: ${{ vars.DEVNET_AZTEC_L1_HTTP }}
+          DEVNET_AZTEC_L1_WS: ${{ vars.DEVNET_AZTEC_L1_WS }}
+          ETHEREUM_HTTP_ALCHEMY_SEPOLIA_URL: ${{ vars.ETHEREUM_HTTP_ALCHEMY_SEPOLIA_URL }}
+        run: |
+          NETWORK="${{ needs.set-up.outputs.network }}"
+          case "$NETWORK" in
+            mainnet)
+              kubectl create secret generic mainnet-config \
+                --from-literal=MAINNET_AZTEC_L1_HTTP=$MAINNET_AZTEC_L1_HTTP \
+                --from-literal=MAINNET_AZTEC_L1_WS=$MAINNET_AZTEC_L1_WS \
+                --from-literal=ETHEREUM_HTTP_ALCHEMY_MAINNET_URL=$ETHEREUM_HTTP_ALCHEMY_MAINNET_URL \
+                --namespace chicmoz-prod --dry-run=client -o yaml | kubectl apply -f -
+              ;;
+            testnet)
+              kubectl create secret generic testnet-config \
+                --from-literal=TESTNET_AZTEC_L1_HTTP=$TESTNET_AZTEC_L1_HTTP \
+                --from-literal=TESTNET_AZTEC_L1_WS=$TESTNET_AZTEC_L1_WS \
+                --from-literal=ETHEREUM_HTTP_ALCHEMY_SEPOLIA_URL=$ETHEREUM_HTTP_ALCHEMY_SEPOLIA_URL \
+                --namespace chicmoz-prod --dry-run=client -o yaml | kubectl apply -f -
+              ;;
+            devnet)
+              kubectl create secret generic devnet-config \
+                --from-literal=DEVNET_AZTEC_L1_HTTP=$DEVNET_AZTEC_L1_HTTP \
+                --from-literal=DEVNET_AZTEC_L1_WS=$DEVNET_AZTEC_L1_WS \
+                --from-literal=ETHEREUM_HTTP_ALCHEMY_SEPOLIA_URL=$ETHEREUM_HTTP_ALCHEMY_SEPOLIA_URL \
+                --namespace chicmoz-prod --dry-run=client -o yaml | kubectl apply -f -
+              ;;
+          esac
+
+      - name: Apply manifests
+        run: kubectl apply -k services/ethereum-listener/k8s/overlays/${{ env.NETWORK }}/
+
+      - name: Restart deployment
+        run: kubectl rollout restart deployment/ethereum-listener-${{ env.NETWORK }} -n chicmoz-prod
+
+      - name: Wait for rollout
+        run: kubectl rollout status deployment/ethereum-listener-${{ env.NETWORK }} -n chicmoz-prod --timeout=300s

--- a/.github/workflows/ethereum-listener.yml
+++ b/.github/workflows/ethereum-listener.yml
@@ -205,21 +205,21 @@ jobs:
           NETWORK="${{ needs.set-up.outputs.network }}"
           case "$NETWORK" in
             mainnet)
-              kubectl create secret generic mainnet-config \
+              kubectl create secret generic ethereum-listener-mainnet \
                 --from-literal=MAINNET_AZTEC_L1_HTTP=$MAINNET_AZTEC_L1_HTTP \
                 --from-literal=MAINNET_AZTEC_L1_WS=$MAINNET_AZTEC_L1_WS \
                 --from-literal=ETHEREUM_HTTP_ALCHEMY_MAINNET_URL=$ETHEREUM_HTTP_ALCHEMY_MAINNET_URL \
                 --namespace chicmoz-prod --dry-run=client -o yaml | kubectl apply -f -
               ;;
             testnet)
-              kubectl create secret generic testnet-config \
+              kubectl create secret generic ethereum-listener-testnet \
                 --from-literal=TESTNET_AZTEC_L1_HTTP=$TESTNET_AZTEC_L1_HTTP \
                 --from-literal=TESTNET_AZTEC_L1_WS=$TESTNET_AZTEC_L1_WS \
                 --from-literal=ETHEREUM_HTTP_ALCHEMY_SEPOLIA_URL=$ETHEREUM_HTTP_ALCHEMY_SEPOLIA_URL \
                 --namespace chicmoz-prod --dry-run=client -o yaml | kubectl apply -f -
               ;;
             devnet)
-              kubectl create secret generic devnet-config \
+              kubectl create secret generic ethereum-listener-devnet \
                 --from-literal=DEVNET_AZTEC_L1_HTTP=$DEVNET_AZTEC_L1_HTTP \
                 --from-literal=DEVNET_AZTEC_L1_WS=$DEVNET_AZTEC_L1_WS \
                 --from-literal=ETHEREUM_HTTP_ALCHEMY_SEPOLIA_URL=$ETHEREUM_HTTP_ALCHEMY_SEPOLIA_URL \

--- a/.github/workflows/explorer-api.yml
+++ b/.github/workflows/explorer-api.yml
@@ -1,0 +1,203 @@
+name: CI/CD Explorer API
+
+on:
+  push:
+    branches:
+      - production-testnet
+      - production
+      - production-devnet
+    paths:
+      - "services/explorer-api/**"
+  workflow_dispatch:
+    inputs:
+      network:
+        description: "Network to deploy to"
+        required: true
+        type: choice
+        options:
+          - testnet
+          - mainnet
+          - devnet
+
+env:
+  REGISTRY: registry.digitalocean.com/aztlan-containers
+  CLUSTER_NAME: aztecscan-prod
+
+jobs:
+  set-up:
+    runs-on: ubuntu-latest
+    outputs:
+      tools-cache-key: ${{ steps.cache-key.outputs.key }}
+      network: ${{ steps.network.outputs.network }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine network
+        id: network
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "network=${{ inputs.network }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref_name }}" = "production" ]; then
+            echo "network=mainnet" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref_name }}" = "production-testnet" ]; then
+            echo "network=testnet" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref_name }}" = "production-devnet" ]; then
+            echo "network=devnet" >> $GITHUB_OUTPUT
+          else
+            echo "ERROR: Cannot determine network from branch ${{ github.ref_name }}" >&2
+            exit 1
+          fi
+
+      - name: Set up tools directory
+        run: mkdir -p tools
+
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Copy doctl to tools directory
+        run: |
+          cp $(which doctl) tools/
+          chmod +x tools/doctl
+
+      - name: Install kubectl
+        run: |
+          curl -Lo tools/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          chmod +x tools/kubectl
+
+      - name: Generate cache key
+        id: cache-key
+        run: echo "key=${{ runner.os }}-tools-$(date '+%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Cache tools
+        uses: actions/cache@v4
+        with:
+          path: tools
+          key: ${{ steps.cache-key.outputs.key }}
+
+      - name: Log in to DigitalOcean Container Registry
+        run: tools/doctl registry login --expiry-seconds 1200
+
+  build-base:
+    runs-on: ubuntu-latest
+    needs: set-up
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to DigitalOcean Container Registry
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - run: doctl registry login --expiry-seconds 1200
+
+      - name: Build and push chicmoz-base
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: registry.digitalocean.com/aztlan-containers/chicmoz-base:latest
+          cache-from: type=gha,scope=chicmoz-base
+          cache-to: type=gha,scope=chicmoz-base,mode=max
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [set-up, build-base]
+    env:
+      NETWORK: ${{ needs.set-up.outputs.network }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Restore cached tools
+        uses: actions/cache@v4
+        with:
+          path: tools
+          key: ${{ needs.set-up.outputs.tools-cache-key }}
+          fail-on-cache-miss: true
+
+      - name: Add tools to PATH
+        run: |
+          chmod +x tools/*
+          echo "$PWD/tools" >> $GITHUB_PATH
+
+      - name: Log in to DigitalOcean Container Registry
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - run: doctl registry login --expiry-seconds 1200
+
+      - name: Build and push service image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: services/explorer-api/Dockerfile
+          push: true
+          tags: |
+            registry.digitalocean.com/aztlan-containers/explorer-api-${{ env.NETWORK }}:latest
+            registry.digitalocean.com/aztlan-containers/explorer-api-${{ env.NETWORK }}:${{ github.sha }}
+          build-args: |
+            BASE=registry.digitalocean.com/aztlan-containers/chicmoz-base:latest
+          cache-from: type=gha,scope=explorer-api-${{ env.NETWORK }}
+          cache-to: type=gha,scope=explorer-api-${{ env.NETWORK }},mode=max
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [set-up, build]
+    env:
+      NETWORK: ${{ needs.set-up.outputs.network }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Restore cached tools
+        uses: actions/cache@v4
+        with:
+          path: tools
+          key: ${{ needs.set-up.outputs.tools-cache-key }}
+          fail-on-cache-miss: true
+
+      - name: Add tools to PATH
+        run: |
+          chmod +x tools/*
+          echo "$PWD/tools" >> $GITHUB_PATH
+
+      - name: Configure doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Save DigitalOcean kubeconfig
+        run: doctl kubernetes cluster kubeconfig save ${{ env.CLUSTER_NAME }}
+
+      - name: Ensure DigitalOcean registry credentials exist in cluster
+        run: |
+          doctl registries kubernetes-manifest aztlan-containers --namespace chicmoz-prod | kubectl apply -f -
+
+      # NOTE: {network}-config secret is created by the old aztecscan-prod*.yml workflow during transition period
+
+      - name: Apply manifests
+        run: kubectl apply -k services/explorer-api/k8s/overlays/${{ env.NETWORK }}/
+
+      - name: Restart deployment
+        run: kubectl rollout restart deployment/explorer-api-${{ env.NETWORK }} -n chicmoz-prod
+
+      - name: Wait for rollout
+        run: kubectl rollout status deployment/explorer-api-${{ env.NETWORK }} -n chicmoz-prod --timeout=300s

--- a/.github/workflows/explorer-ui-v2.yml
+++ b/.github/workflows/explorer-ui-v2.yml
@@ -1,12 +1,23 @@
-name: CI/CD Explorer UI v2 — Testnet
+name: CI/CD Explorer UI v2
 
 on:
   push:
     branches:
       - production-testnet
+      - production
+      - production-devnet
     paths:
       - "services/explorer-ui-v2/**"
   workflow_dispatch:
+    inputs:
+      network:
+        description: "Network to deploy to"
+        required: true
+        type: choice
+        options:
+          - testnet
+          - mainnet
+          - devnet
 
 env:
   REGISTRY: registry.digitalocean.com/aztlan-containers
@@ -18,12 +29,29 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tools-cache-key: ${{ steps.cache-key.outputs.key }}
+      network: ${{ steps.network.outputs.network }}
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Determine network
+        id: network
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "network=${{ inputs.network }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref_name }}" = "production" ]; then
+            echo "network=mainnet" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref_name }}" = "production-testnet" ]; then
+            echo "network=testnet" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref_name }}" = "production-devnet" ]; then
+            echo "network=devnet" >> $GITHUB_OUTPUT
+          else
+            echo "ERROR: Cannot determine network from branch ${{ github.ref_name }}" >&2
+            exit 1
+          fi
 
       - name: Set up tools directory
         run: mkdir -p tools
@@ -86,14 +114,40 @@ jobs:
 
       - run: doctl registry login --expiry-seconds 1200
 
+      - name: Resolve network-specific build args
+        id: build-args
+        run: |
+          NETWORK="${{ needs.set-up.outputs.network }}"
+          case "$NETWORK" in
+            mainnet)
+              echo "l2_network_id=MAINNET" >> $GITHUB_OUTPUT
+              echo "api_url=https://api.aztecscan.xyz/v1" >> $GITHUB_OUTPUT
+              echo "ws_url=wss://ws.aztecscan.xyz" >> $GITHUB_OUTPUT
+              ;;
+            testnet)
+              echo "l2_network_id=TESTNET" >> $GITHUB_OUTPUT
+              echo "api_url=https://api.testnet.aztecscan.xyz/v1" >> $GITHUB_OUTPUT
+              echo "ws_url=wss://ws.testnet.aztecscan.xyz" >> $GITHUB_OUTPUT
+              ;;
+            devnet)
+              echo "l2_network_id=DEVNET" >> $GITHUB_OUTPUT
+              echo "api_url=https://api.devnet.aztecscan.xyz/v1" >> $GITHUB_OUTPUT
+              echo "ws_url=wss://ws.devnet.aztecscan.xyz" >> $GITHUB_OUTPUT
+              ;;
+            *)
+              echo "ERROR: Unknown network: $NETWORK" >&2
+              exit 1
+              ;;
+          esac
+
       - name: Extract metadata for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=sha,prefix=testnet-
-            type=raw,value=testnet-latest
+            type=sha,prefix=${{ needs.set-up.outputs.network }}-
+            type=raw,value=${{ needs.set-up.outputs.network }}-latest
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
@@ -104,11 +158,11 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
             NODE_ENV=production
-            VITE_L2_NETWORK_ID=TESTNET
+            VITE_L2_NETWORK_ID=${{ steps.build-args.outputs.l2_network_id }}
             VITE_CHICMOZ_ALL_UI_URLS=Mainnet|https://aztecscan.xyz,Testnet|https://testnet.aztecscan.xyz,Devnet|https://devnet.aztecscan.xyz
-            VITE_API_URL=https://api.testnet.aztecscan.xyz/v1
+            VITE_API_URL=${{ steps.build-args.outputs.api_url }}
             VITE_API_KEY=temporary-api-key
-            VITE_WS_URL=wss://ws.testnet.aztecscan.xyz
+            VITE_WS_URL=${{ steps.build-args.outputs.ws_url }}
             VITE_DISCORD_URL=https://discord.gg/xnw7fVXB7m
             VITE_GITHUB_URL=https://github.com/aztec-scan/chicmoz
             VITE_X_URL=https://x.com/aztecscan
@@ -151,10 +205,10 @@ jobs:
           doctl registries kubernetes-manifest aztlan-containers --namespace chicmoz-prod | kubectl apply -f -
 
       - name: Apply manifests
-        run: kubectl apply -k services/explorer-ui-v2/k8s/overlays/testnet/
+        run: kubectl apply -k services/explorer-ui-v2/k8s/overlays/${{ needs.set-up.outputs.network }}/
 
       - name: Restart deployment
-        run: kubectl rollout restart deployment/explorer-ui-v2-testnet -n chicmoz-prod
+        run: kubectl rollout restart deployment/explorer-ui-v2-${{ needs.set-up.outputs.network }} -n chicmoz-prod
 
       - name: Wait for rollout
-        run: kubectl rollout status deployment/explorer-ui-v2-testnet -n chicmoz-prod --timeout=300s
+        run: kubectl rollout status deployment/explorer-ui-v2-${{ needs.set-up.outputs.network }} -n chicmoz-prod --timeout=300s

--- a/.github/workflows/explorer-ui.yml
+++ b/.github/workflows/explorer-ui.yml
@@ -1,0 +1,233 @@
+name: CI/CD Explorer UI
+
+on:
+  push:
+    branches:
+      - production-testnet
+      - production
+      - production-devnet
+    paths:
+      - "services/explorer-ui/**"
+  workflow_dispatch:
+    inputs:
+      network:
+        description: "Network to deploy to"
+        required: true
+        type: choice
+        options:
+          - testnet
+          - mainnet
+          - devnet
+
+env:
+  REGISTRY: registry.digitalocean.com/aztlan-containers
+  CLUSTER_NAME: aztecscan-prod
+
+jobs:
+  set-up:
+    runs-on: ubuntu-latest
+    outputs:
+      tools-cache-key: ${{ steps.cache-key.outputs.key }}
+      network: ${{ steps.network.outputs.network }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine network
+        id: network
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "network=${{ inputs.network }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref_name }}" = "production" ]; then
+            echo "network=mainnet" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref_name }}" = "production-testnet" ]; then
+            echo "network=testnet" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref_name }}" = "production-devnet" ]; then
+            echo "network=devnet" >> $GITHUB_OUTPUT
+          else
+            echo "ERROR: Cannot determine network from branch ${{ github.ref_name }}" >&2
+            exit 1
+          fi
+
+      - name: Set up tools directory
+        run: mkdir -p tools
+
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Copy doctl to tools directory
+        run: |
+          cp $(which doctl) tools/
+          chmod +x tools/doctl
+
+      - name: Install kubectl
+        run: |
+          curl -Lo tools/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          chmod +x tools/kubectl
+
+      - name: Generate cache key
+        id: cache-key
+        run: echo "key=${{ runner.os }}-tools-$(date '+%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Cache tools
+        uses: actions/cache@v4
+        with:
+          path: tools
+          key: ${{ steps.cache-key.outputs.key }}
+
+      - name: Log in to DigitalOcean Container Registry
+        run: tools/doctl registry login --expiry-seconds 1200
+
+  build-base:
+    runs-on: ubuntu-latest
+    needs: set-up
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to DigitalOcean Container Registry
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - run: doctl registry login --expiry-seconds 1200
+
+      - name: Build and push chicmoz-base
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: registry.digitalocean.com/aztlan-containers/chicmoz-base:latest
+          cache-from: type=gha,scope=chicmoz-base
+          cache-to: type=gha,scope=chicmoz-base,mode=max
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [set-up, build-base]
+    env:
+      NETWORK: ${{ needs.set-up.outputs.network }}
+      IMAGE_NAME: explorer-ui-${{ needs.set-up.outputs.network }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Restore cached tools
+        uses: actions/cache@v4
+        with:
+          path: tools
+          key: ${{ needs.set-up.outputs.tools-cache-key }}
+          fail-on-cache-miss: true
+
+      - name: Add tools to PATH
+        run: |
+          chmod +x tools/*
+          echo "$PWD/tools" >> $GITHUB_PATH
+
+      - name: Log in to DigitalOcean Container Registry
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - run: doctl registry login --expiry-seconds 1200
+
+      - name: Resolve network-specific build args
+        id: build-args
+        run: |
+          case "${{ needs.set-up.outputs.network }}" in
+            mainnet)
+              echo "l2_network_id=MAINNET" >> $GITHUB_OUTPUT
+              echo "api_url=https://api.aztecscan.xyz/v1" >> $GITHUB_OUTPUT
+              echo "ws_url=wss://ws.aztecscan.xyz" >> $GITHUB_OUTPUT
+              ;;
+            testnet)
+              echo "l2_network_id=TESTNET" >> $GITHUB_OUTPUT
+              echo "api_url=https://api.testnet.aztecscan.xyz/v1" >> $GITHUB_OUTPUT
+              echo "ws_url=wss://ws.testnet.aztecscan.xyz" >> $GITHUB_OUTPUT
+              ;;
+            devnet)
+              echo "l2_network_id=DEVNET" >> $GITHUB_OUTPUT
+              echo "api_url=https://api.devnet.aztecscan.xyz/v1" >> $GITHUB_OUTPUT
+              echo "ws_url=wss://ws.devnet.aztecscan.xyz" >> $GITHUB_OUTPUT
+              ;;
+          esac
+
+      - name: Build and push service image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: services/explorer-ui/Dockerfile
+          push: true
+          tags: |
+            registry.digitalocean.com/aztlan-containers/${{ env.IMAGE_NAME }}:latest
+            registry.digitalocean.com/aztlan-containers/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          build-args: |
+            BASE=registry.digitalocean.com/aztlan-containers/chicmoz-base:latest
+            NODE_ENV=production
+            VITE_L2_NETWORK_ID=${{ steps.build-args.outputs.l2_network_id }}
+            VITE_CHICMOZ_ALL_UI_URLS=Mainnet|https://aztecscan.xyz,Testnet|https://testnet.aztecscan.xyz,Devnet|https://devnet.aztecscan.xyz
+            VITE_API_URL=${{ steps.build-args.outputs.api_url }}
+            VITE_API_KEY=temporary-api-key
+            VITE_WS_URL=${{ steps.build-args.outputs.ws_url }}
+            VITE_DISCORD_URL=https://discord.gg/xnw7fVXB7m
+            VITE_GITHUB_URL=https://github.com/aztec-scan/chicmoz
+            VITE_X_URL=https://x.com/aztecscan
+            VITE_VERSION_STRING=${{ github.sha }}
+          cache-from: type=gha,scope=explorer-ui-${{ env.NETWORK }}
+          cache-to: type=gha,scope=explorer-ui-${{ env.NETWORK }},mode=max
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [set-up, build]
+    env:
+      NETWORK: ${{ needs.set-up.outputs.network }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Restore cached tools
+        uses: actions/cache@v4
+        with:
+          path: tools
+          key: ${{ needs.set-up.outputs.tools-cache-key }}
+          fail-on-cache-miss: true
+
+      - name: Add tools to PATH
+        run: |
+          chmod +x tools/*
+          echo "$PWD/tools" >> $GITHUB_PATH
+
+      - name: Configure doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Save DigitalOcean kubeconfig
+        run: doctl kubernetes cluster kubeconfig save ${{ env.CLUSTER_NAME }}
+
+      - name: Ensure DigitalOcean registry credentials exist in cluster
+        run: |
+          doctl registries kubernetes-manifest aztlan-containers --namespace chicmoz-prod | kubectl apply -f -
+
+      - name: Apply manifests
+        run: kubectl apply -k services/explorer-ui/k8s/overlays/${{ env.NETWORK }}/
+
+      - name: Restart deployment
+        run: kubectl rollout restart deployment/explorer-ui-${{ env.NETWORK }} -n chicmoz-prod
+
+      - name: Wait for rollout
+        run: kubectl rollout status deployment/explorer-ui-${{ env.NETWORK }} -n chicmoz-prod --timeout=300s

--- a/.github/workflows/websocket-event-publisher.yml
+++ b/.github/workflows/websocket-event-publisher.yml
@@ -1,0 +1,201 @@
+name: CI/CD Websocket Event Publisher
+
+on:
+  push:
+    branches:
+      - production-testnet
+      - production
+      - production-devnet
+    paths:
+      - "services/websocket-event-publisher/**"
+  workflow_dispatch:
+    inputs:
+      network:
+        description: "Network to deploy to"
+        required: true
+        type: choice
+        options:
+          - testnet
+          - mainnet
+          - devnet
+
+env:
+  REGISTRY: registry.digitalocean.com/aztlan-containers
+  CLUSTER_NAME: aztecscan-prod
+
+jobs:
+  set-up:
+    runs-on: ubuntu-latest
+    outputs:
+      tools-cache-key: ${{ steps.cache-key.outputs.key }}
+      network: ${{ steps.network.outputs.network }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine network
+        id: network
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "network=${{ inputs.network }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref_name }}" = "production" ]; then
+            echo "network=mainnet" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref_name }}" = "production-testnet" ]; then
+            echo "network=testnet" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref_name }}" = "production-devnet" ]; then
+            echo "network=devnet" >> $GITHUB_OUTPUT
+          else
+            echo "ERROR: Cannot determine network from branch ${{ github.ref_name }}" >&2
+            exit 1
+          fi
+
+      - name: Set up tools directory
+        run: mkdir -p tools
+
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Copy doctl to tools directory
+        run: |
+          cp $(which doctl) tools/
+          chmod +x tools/doctl
+
+      - name: Install kubectl
+        run: |
+          curl -Lo tools/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          chmod +x tools/kubectl
+
+      - name: Generate cache key
+        id: cache-key
+        run: echo "key=${{ runner.os }}-tools-$(date '+%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Cache tools
+        uses: actions/cache@v4
+        with:
+          path: tools
+          key: ${{ steps.cache-key.outputs.key }}
+
+      - name: Log in to DigitalOcean Container Registry
+        run: tools/doctl registry login --expiry-seconds 1200
+
+  build-base:
+    runs-on: ubuntu-latest
+    needs: set-up
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to DigitalOcean Container Registry
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - run: doctl registry login --expiry-seconds 1200
+
+      - name: Build and push chicmoz-base
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: registry.digitalocean.com/aztlan-containers/chicmoz-base:latest
+          cache-from: type=gha,scope=chicmoz-base
+          cache-to: type=gha,scope=chicmoz-base,mode=max
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [set-up, build-base]
+    env:
+      NETWORK: ${{ needs.set-up.outputs.network }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Restore cached tools
+        uses: actions/cache@v4
+        with:
+          path: tools
+          key: ${{ needs.set-up.outputs.tools-cache-key }}
+          fail-on-cache-miss: true
+
+      - name: Add tools to PATH
+        run: |
+          chmod +x tools/*
+          echo "$PWD/tools" >> $GITHUB_PATH
+
+      - name: Log in to DigitalOcean Container Registry
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - run: doctl registry login --expiry-seconds 1200
+
+      - name: Build and push service image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: services/websocket-event-publisher/Dockerfile
+          push: true
+          tags: |
+            registry.digitalocean.com/aztlan-containers/websocket-event-publisher-${{ env.NETWORK }}:latest
+            registry.digitalocean.com/aztlan-containers/websocket-event-publisher-${{ env.NETWORK }}:${{ github.sha }}
+          build-args: |
+            BASE=registry.digitalocean.com/aztlan-containers/chicmoz-base:latest
+          cache-from: type=gha,scope=websocket-event-publisher-${{ env.NETWORK }}
+          cache-to: type=gha,scope=websocket-event-publisher-${{ env.NETWORK }},mode=max
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [set-up, build]
+    env:
+      NETWORK: ${{ needs.set-up.outputs.network }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Restore cached tools
+        uses: actions/cache@v4
+        with:
+          path: tools
+          key: ${{ needs.set-up.outputs.tools-cache-key }}
+          fail-on-cache-miss: true
+
+      - name: Add tools to PATH
+        run: |
+          chmod +x tools/*
+          echo "$PWD/tools" >> $GITHUB_PATH
+
+      - name: Configure doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Save DigitalOcean kubeconfig
+        run: doctl kubernetes cluster kubeconfig save ${{ env.CLUSTER_NAME }}
+
+      - name: Ensure DigitalOcean registry credentials exist in cluster
+        run: |
+          doctl registries kubernetes-manifest aztlan-containers --namespace chicmoz-prod | kubectl apply -f -
+
+      - name: Apply manifests
+        run: kubectl apply -k services/websocket-event-publisher/k8s/overlays/${{ env.NETWORK }}/
+
+      - name: Restart deployment
+        run: kubectl rollout restart deployment/websocket-event-publisher-${{ env.NETWORK }} -n chicmoz-prod
+
+      - name: Wait for rollout
+        run: kubectl rollout status deployment/websocket-event-publisher-${{ env.NETWORK }} -n chicmoz-prod --timeout=300s

--- a/docs/ci-cd-migration-impl-plan.md
+++ b/docs/ci-cd-migration-impl-plan.md
@@ -1,0 +1,1066 @@
+# CI/CD Migration — Implementation Plan for Remaining Services
+
+This document is a self-contained implementation plan for migrating all remaining Chicmoz services
+to the new GitHub Actions + Kustomize CI/CD pattern. It is written to be picked up and executed
+by a fresh LLM session with no prior context.
+
+---
+
+## Background
+
+`explorer-ui-v2` is the reference implementation of the new pattern. Study these files first:
+
+- `.github/workflows/explorer-ui-v2.yml` — the workflow template
+- `services/explorer-ui-v2/k8s/` — the Kustomize base/overlays template
+
+The old Skaffold-based workflows are:
+
+- `.github/workflows/aztecscan-prod.yml` (mainnet)
+- `.github/workflows/aztecscan-prod-testnet.yml` (testnet)
+- `.github/workflows/aztecscan-prod-devnet.yml` (devnet)
+
+**Do NOT delete the old Skaffold workflows.** They run in parallel as a safety net until the new
+per-service workflows are confirmed working in production.
+
+---
+
+## Image Naming Convention
+
+| Component     | Value                                                 |
+| ------------- | ----------------------------------------------------- |
+| Registry      | `registry.digitalocean.com/aztlan-containers`         |
+| Image name    | `<service>-{network}` (e.g. `explorer-api-mainnet`)   |
+| Mutable tag   | `latest`                                              |
+| Immutable tag | `{git-sha}` (short SHA from `docker/metadata-action`) |
+
+The network is encoded in the **image name**, not the tag. Tags are simply `latest` and `{sha}`.
+
+Each network gets its own image so mainnet/testnet/devnet can run different Aztec versions
+independently.
+
+---
+
+## Workflow Structure
+
+### Frontend services (`explorer-ui`) — 3 jobs
+
+```
+set-up → build → deploy
+```
+
+`explorer-ui` uses `ARG BASE` (old-pattern Dockerfile that depends on `chicmoz-base`),
+so it actually needs the same 4-job structure as backend services. See service spec below.
+
+### Backend services (all others) — 4 jobs
+
+```
+set-up → build-base → build → deploy
+```
+
+- `build-base` builds + pushes `registry.digitalocean.com/aztlan-containers/chicmoz-base`
+  from the root `Dockerfile` using GHA layer cache (`scope=chicmoz-base`)
+- `build` receives the base image SHA as `--build-arg BASE=...` and builds the service image
+  using GHA layer cache (`scope=<service>-{network}`)
+
+### Network detection (set-up job — all workflows)
+
+```yaml
+- name: Determine network
+  id: network
+  run: |
+    if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+      echo "network=${{ inputs.network }}" >> $GITHUB_OUTPUT
+    elif [ "${{ github.ref_name }}" = "production" ]; then
+      echo "network=mainnet" >> $GITHUB_OUTPUT
+    elif [ "${{ github.ref_name }}" = "production-testnet" ]; then
+      echo "network=testnet" >> $GITHUB_OUTPUT
+    elif [ "${{ github.ref_name }}" = "production-devnet" ]; then
+      echo "network=devnet" >> $GITHUB_OUTPUT
+    else
+      echo "ERROR: Cannot determine network from branch ${{ github.ref_name }}" >&2
+      exit 1
+    fi
+```
+
+`network` is a job output (`needs.set-up.outputs.network`) used throughout all downstream jobs.
+
+### build-base job template
+
+```yaml
+build-base:
+  runs-on: ubuntu-latest
+  needs: set-up
+  steps:
+    - uses: actions/checkout@v4
+    - uses: docker/setup-buildx-action@v3
+    - uses: digitalocean/action-doctl@v2
+      with:
+        token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+    - run: doctl registry login --expiry-seconds 1200
+    - name: Build and push chicmoz-base
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: Dockerfile
+        push: true
+        tags: registry.digitalocean.com/aztlan-containers/chicmoz-base:latest
+        cache-from: type=gha,scope=chicmoz-base
+        cache-to: type=gha,scope=chicmoz-base,mode=max
+```
+
+### build job — passing base image to service
+
+```yaml
+build:
+  runs-on: ubuntu-latest
+  needs: [set-up, build-base]
+  env:
+    NETWORK: ${{ needs.set-up.outputs.network }}
+  steps:
+    # ... checkout, buildx, doctl login ...
+    - name: Build and push service image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: services/<service>/Dockerfile
+        push: true
+        tags: |
+          registry.digitalocean.com/aztlan-containers/<service>-${{ env.NETWORK }}:latest
+          registry.digitalocean.com/aztlan-containers/<service>-${{ env.NETWORK }}:${{ github.sha }}
+        build-args: |
+          BASE=registry.digitalocean.com/aztlan-containers/chicmoz-base:latest
+        cache-from: type=gha,scope=<service>-${{ env.NETWORK }}
+        cache-to: type=gha,scope=<service>-${{ env.NETWORK }},mode=max
+```
+
+### deploy job template
+
+```yaml
+deploy:
+  runs-on: ubuntu-latest
+  needs: [set-up, build]
+  env:
+    NETWORK: ${{ needs.set-up.outputs.network }}
+  steps:
+    - uses: actions/checkout@v4
+    - name: Restore cached tools
+      uses: actions/cache@v4
+      with:
+        path: tools
+        key: ${{ needs.set-up.outputs.tools-cache-key }}
+        fail-on-cache-miss: true
+    - run: chmod +x tools/* && echo "$PWD/tools" >> $GITHUB_PATH
+    - uses: digitalocean/action-doctl@v2
+      with:
+        token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+    - run: doctl kubernetes cluster kubeconfig save ${{ env.CLUSTER_NAME }}
+    - run: doctl registries kubernetes-manifest aztlan-containers --namespace chicmoz-prod | kubectl apply -f -
+    # (optional) inject secrets — see per-service spec
+    - run: kubectl apply -k services/<service>/k8s/overlays/${{ env.NETWORK }}/
+    - run: kubectl rollout restart deployment/<service>-${{ env.NETWORK }} -n chicmoz-prod
+    - run: kubectl rollout status deployment/<service>-${{ env.NETWORK }} -n chicmoz-prod --timeout=300s
+```
+
+**Exception:** `auth` — no network suffix. Rollout targets `deployment/auth`. See auth spec.
+
+---
+
+## Kustomize Convention
+
+### Base `deployment.yaml` rules
+
+- No `namespace:` field (set by overlay)
+- `metadata.name`: `<service>` (no network suffix)
+- `spec.selector.matchLabels.app` and `spec.template.metadata.labels.app`: `<service>` (no suffix)
+- `containers[0].name`: `<service>`
+- Image: `registry.digitalocean.com/aztlan-containers/<service>` (no network suffix, no tag)
+- `imagePullPolicy: Always`
+- `imagePullSecrets: [{name: registry-aztlan-containers}]`
+- Env vars that are identical across all networks go in the base
+- `INSTANCE_NAME`, `L2_NETWORK_ID`, and any `secretKeyRef` env vars go in overlay patches
+
+### Overlay `kustomization.yaml` structure
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: chicmoz-prod
+nameSuffix: -mainnet # or -testnet / -devnet
+
+resources:
+  - ../../base
+  - httproute.yaml # if applicable
+  - postgres-config.yaml # if applicable
+
+images:
+  - name: registry.digitalocean.com/aztlan-containers/<service>
+    newName: registry.digitalocean.com/aztlan-containers/<service>-mainnet
+    newTag: latest
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: <service>
+      spec:
+        template:
+          spec:
+            containers:
+              - name: <service>
+                env:
+                  - name: INSTANCE_NAME
+                    value: "mainnet_<service>"
+                  - name: L2_NETWORK_ID
+                    value: "MAINNET"
+```
+
+### ConfigMap name transformation (important)
+
+Kustomize's `nameSuffix` DOES transform `envFrom.configMapRef.name` when the ConfigMap is a
+resource in the same kustomization. So `postgres-config-explorer-api` in the base becomes
+`postgres-config-explorer-api-mainnet` in the mainnet overlay — this is correct behaviour and
+requires no extra patches.
+
+### secretKeyRef — must be overlay patches
+
+`secretKeyRef.name` (e.g. `mainnet-config`) and `secretKeyRef.key` differ per network.
+They cannot go in the base. Use strategic merge patches in each overlay (see per-service specs).
+
+### backendRefs.name — must be hardcoded
+
+Kustomize `nameSuffix` only transforms `metadata.name`. It does NOT transform:
+
+- `backendRefs.name` in HTTPRoutes
+- `targetRefs.name` in SecurityPolicies
+- `extensionRef.name` in HTTPRoute filters
+
+These must be hardcoded to the full suffixed name (e.g. `explorer-api-mainnet-service`).
+
+---
+
+## Implementation Order
+
+Implement services in this order (simplest first):
+
+1. `websocket-event-publisher` — no secrets, no DB, has httproute, good warm-up
+2. `explorer-api` — most complex; do this early so edge cases are resolved
+3. `aztec-listener` — secrets, testnet-specific env patches
+4. `ethereum-listener` — secrets with different keys per network
+5. `explorer-ui` — frontend build args, needs chicmoz-base
+6. `auth` — mainnet only, no nameSuffix edge case
+7. `compiler-orchestrator` — RBAC complexity
+8. Update `docs/ci-cd-migration.md` status table
+
+---
+
+## Service 1: `websocket-event-publisher`
+
+### Workflow: `.github/workflows/websocket-event-publisher.yml`
+
+```yaml
+name: CI/CD Websocket Event Publisher
+
+on:
+  push:
+    branches: [production-testnet, production, production-devnet]
+    paths: ["services/websocket-event-publisher/**"]
+  workflow_dispatch:
+    inputs:
+      network:
+        description: "Network to deploy to"
+        required: true
+        type: choice
+        options: [testnet, mainnet, devnet]
+
+env:
+  REGISTRY: registry.digitalocean.com/aztlan-containers
+  CLUSTER_NAME: aztecscan-prod
+```
+
+Jobs: `set-up` → `build-base` → `build` → `deploy`
+No secrets. No build args beyond `BASE`.
+
+### Kustomize files
+
+**`services/websocket-event-publisher/k8s/base/deployment.yaml`**
+Source: `k8s/production/websocket-event-publisher/mainnet/deployment.yaml`
+
+- Remove `namespace`, `status: {}`
+- `metadata.name: websocket-event-publisher`
+- `labels.app: websocket-event-publisher`
+- Image: `registry.digitalocean.com/aztlan-containers/websocket-event-publisher`
+- Add `imagePullPolicy: Always`
+- Keep: `resources`, both ports (`websocket-port: 3000`, `health-port: 3001`), liveness/readiness probes
+- Base env: `PORT: "3000"`, `NODE_ENV: production`
+- Remove from base: `INSTANCE_NAME`, `L2_NETWORK_ID`
+
+**`services/websocket-event-publisher/k8s/base/service.yaml`**
+Source: `k8s/production/websocket-event-publisher/mainnet/service.yaml`
+
+- Remove `namespace`
+- `metadata.name: websocket-event-publisher`
+- `selector.app: websocket-event-publisher`
+
+**`services/websocket-event-publisher/k8s/base/kustomization.yaml`**
+
+```yaml
+resources:
+  - deployment.yaml
+  - service.yaml
+```
+
+**`services/websocket-event-publisher/k8s/overlays/mainnet/kustomization.yaml`**
+
+```yaml
+namespace: chicmoz-prod
+nameSuffix: -mainnet
+resources:
+  - ../../base
+  - httproute.yaml
+images:
+  - name: registry.digitalocean.com/aztlan-containers/websocket-event-publisher
+    newName: registry.digitalocean.com/aztlan-containers/websocket-event-publisher-mainnet
+    newTag: latest
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: websocket-event-publisher
+      spec:
+        template:
+          spec:
+            containers:
+              - name: websocket-event-publisher
+                env:
+                  - name: INSTANCE_NAME
+                    value: "mainnet_websocket-event-publisher"
+                  - name: L2_NETWORK_ID
+                    value: "MAINNET"
+```
+
+**`services/websocket-event-publisher/k8s/overlays/mainnet/httproute.yaml`**
+Source: `k8s/production/websocket-event-publisher/mainnet/httproute.yaml`
+
+- Keep all 8 parentRefs and both hostnames (`ws.aztecscan.xyz`, `ws.mainnet.aztecscan.xyz`)
+- `backendRefs.name: websocket-event-publisher-mainnet` (hardcoded — nameSuffix doesn't transform this)
+- `metadata.name: websocket-event-publisher` (nameSuffix appends -mainnet automatically)
+
+**Testnet overlay:** same pattern. `nameSuffix: -testnet`, `newName: ...-testnet`, `INSTANCE_NAME: testnet_websocket-event-publisher`, `L2_NETWORK_ID: TESTNET`
+Source httproute: `k8s/production/websocket-event-publisher/testnet/httproute.yaml`
+
+**Devnet overlay:** same pattern. Additionally include `backendtrafficpolicy.yaml`:
+
+- Source: `k8s/production/websocket-event-publisher/devnet/backendtrafficpolicy.yaml`
+- Add to `resources:` in the devnet kustomization.yaml
+
+---
+
+## Service 2: `explorer-api`
+
+### Workflow: `.github/workflows/explorer-api.yml`
+
+Jobs: `set-up` → `build-base` → `build` → `deploy`
+No build args beyond `BASE`. No secrets needed in deploy (the shared `{network}-config` secret
+is created by the still-running old Skaffold workflows during transition).
+Add a comment in the deploy job: `# NOTE: {network}-config secret is created by the old aztecscan-prod*.yml workflow during transition period`
+
+### Kustomize files
+
+**`services/explorer-api/k8s/base/deployment.yaml`**
+Source: `k8s/production/explorer-api/mainnet/deployment.yaml`
+
+- Remove `namespace`, `status: {}`
+- `metadata.name: explorer-api`
+- `labels.app: explorer-api-label` → use `explorer-api`
+- Image: `registry.digitalocean.com/aztlan-containers/explorer-api`
+- Add `imagePullPolicy: Always`
+- Keep: init container (migrations with `yarn run migrate`), `envFrom` both configMapRefs
+  - Use names WITHOUT network suffix: `postgres-config-global` (stays as-is), `postgres-config-explorer-api`
+  - Kustomize will append nameSuffix to `postgres-config-explorer-api` → `postgres-config-explorer-api-mainnet` ✓
+- Keep: `readinessProbe`, `resources`, ports
+- Base env: `NODE_ENV: production`, `PUBLIC_API_KEY: temporary-api-key`
+- Remove from base: `INSTANCE_NAME`, `L2_NETWORK_ID`
+
+**`services/explorer-api/k8s/base/service.yaml`**
+
+- `metadata.name: explorer-api`
+- `selector.app: explorer-api`
+
+**`services/explorer-api/k8s/base/kustomization.yaml`**
+
+```yaml
+resources:
+  - deployment.yaml
+  - service.yaml
+```
+
+**`services/explorer-api/k8s/overlays/mainnet/postgres-config.yaml`**
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-config-explorer-api # nameSuffix appends -mainnet → postgres-config-explorer-api-mainnet
+  namespace: chicmoz-prod
+data:
+  POSTGRES_DB_NAME: "explorer_api_mainnet"
+```
+
+**`services/explorer-api/k8s/overlays/mainnet/http-filter.yaml`**
+Source: `k8s/production/explorer-api/mainnet/http-filter.yaml`
+
+- `metadata.name: explorer-api-rewrite` (nameSuffix → `explorer-api-rewrite-mainnet`)
+
+**`services/explorer-api/k8s/overlays/mainnet/httproute.yaml`**
+Source: `k8s/production/explorer-api/mainnet/httproute.yaml`
+
+- Keep all 8 parentRefs and both hostnames
+- `backendRefs.name: explorer-api-mainnet-service` (hardcoded)
+- `filters.extensionRef.name: explorer-api-rewrite-mainnet` (hardcoded — the suffixed filter name)
+- `metadata.name: explorer-api` (nameSuffix appends automatically)
+
+**`services/explorer-api/k8s/overlays/mainnet/securitypolicy.yaml`**
+Source: `k8s/production/explorer-api/mainnet/securitypolicy.yaml`
+
+- `targetRefs.name: explorer-api-mainnet` (hardcoded)
+- Keep all CORS origins and extAuth config exactly
+- `extAuth.http.backendRefs[0].name: auth-service` (hardcoded — auth service name is stable, no suffix)
+
+**`services/explorer-api/k8s/overlays/mainnet/kustomization.yaml`**
+
+```yaml
+namespace: chicmoz-prod
+nameSuffix: -mainnet
+resources:
+  - ../../base
+  - httproute.yaml
+  - postgres-config.yaml
+  - http-filter.yaml
+  - securitypolicy.yaml
+images:
+  - name: registry.digitalocean.com/aztlan-containers/explorer-api
+    newName: registry.digitalocean.com/aztlan-containers/explorer-api-mainnet
+    newTag: latest
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: explorer-api
+      spec:
+        template:
+          spec:
+            containers:
+              - name: explorer-api
+                env:
+                  - name: INSTANCE_NAME
+                    value: "mainnet_explorer-api"
+                  - name: L2_NETWORK_ID
+                    value: "MAINNET"
+            initContainers:
+              - name: run-migrations
+                env:
+                  - name: INSTANCE_NAME
+                    value: "mainnet_explorer-api"
+```
+
+**Testnet overlay:** same structure, no `securitypolicy.yaml`. DB name: `explorer_api_testnet`.
+
+**Devnet overlay:** same as testnet, but add an extra patch for `REDIS_HOST`:
+
+```yaml
+- name: REDIS_HOST
+  value: "redis-cache"
+```
+
+(This env var exists in the devnet deployment but not mainnet/testnet.)
+DB name: `explorer_api_devnet`.
+
+---
+
+## Service 3: `aztec-listener`
+
+### Workflow: `.github/workflows/aztec-listener.yml`
+
+Jobs: `set-up` → `build-base` → `build` → `deploy`
+
+**Secret injection in deploy job:**
+
+```yaml
+- name: Inject Aztec RPC secret
+  env:
+    AZTEC_RPC_NODES_MAINNET: ${{ vars.AZTEC_RPC_NODES_MAINNET }}
+    AZTEC_RPC_NODES_TESTNET: ${{ vars.AZTEC_RPC_NODES_TESTNET }}
+    AZTEC_RPC_NODES_DEVNET: ${{ vars.AZTEC_RPC_NODES_DEVNET }}
+  run: |
+    NETWORK="${{ needs.set-up.outputs.network }}"
+    case "$NETWORK" in
+      mainnet)
+        kubectl create secret generic mainnet-config \
+          --from-literal=AZTEC_RPC_NODES_MAINNET=$AZTEC_RPC_NODES_MAINNET \
+          --namespace chicmoz-prod --dry-run=client -o yaml | kubectl apply -f -
+        ;;
+      testnet)
+        kubectl create secret generic testnet-config \
+          --from-literal=AZTEC_RPC_NODES_TESTNET=$AZTEC_RPC_NODES_TESTNET \
+          --namespace chicmoz-prod --dry-run=client -o yaml | kubectl apply -f -
+        ;;
+      devnet)
+        kubectl create secret generic devnet-config \
+          --from-literal=AZTEC_RPC_NODES_DEVNET=$AZTEC_RPC_NODES_DEVNET \
+          --namespace chicmoz-prod --dry-run=client -o yaml | kubectl apply -f -
+        ;;
+    esac
+```
+
+### Kustomize files
+
+**`services/aztec-listener/k8s/base/deployment.yaml`**
+Source: `k8s/production/aztec-listener/mainnet/deployment.yaml`
+
+- No service file (aztec-listener has no HTTP exposure)
+- Remove `namespace`, `status: {}`
+- `metadata.name: aztec-listener`
+- Image: `registry.digitalocean.com/aztlan-containers/aztec-listener`
+- Add `imagePullPolicy: Always`
+- Keep: init container (migrations), `envFrom` both configMapRefs
+  - `postgres-config-global` (unchanged)
+  - `postgres-config-aztec-listener` (nameSuffix will append network suffix ✓)
+- Keep: `resources`
+- Base env: `NODE_ENV: production`, `IGNORE_PROCESSED_HEIGHT: "false"`, `AZTEC_LISTEN_FOR_BLOCKS: "true"`, `AZTEC_LISTEN_FOR_PENDING_TXS: "true"`
+- Remove from base: `INSTANCE_NAME`, `L2_NETWORK_ID`, `AZTEC_RPC_URLS` (secretKeyRef — overlay patch)
+
+**`services/aztec-listener/k8s/base/kustomization.yaml`**
+
+```yaml
+resources:
+  - deployment.yaml
+```
+
+**Per overlay `postgres-config.yaml`:**
+
+```yaml
+# mainnet: POSTGRES_DB_NAME: "aztec_listener_mainnet"
+# testnet: POSTGRES_DB_NAME: "aztec_listener_testnet"
+# devnet:  POSTGRES_DB_NAME: "aztec_listener_devnet"
+metadata:
+  name: postgres-config-aztec-listener # nameSuffix appends network
+```
+
+**Per overlay patches (mainnet example):**
+
+```yaml
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: aztec-listener
+      spec:
+        template:
+          spec:
+            containers:
+              - name: aztec-listener
+                env:
+                  - name: INSTANCE_NAME
+                    value: "mainnet_aztec-listener"
+                  - name: L2_NETWORK_ID
+                    value: "MAINNET"
+                  - name: AZTEC_RPC_URLS
+                    valueFrom:
+                      secretKeyRef:
+                        name: mainnet-config
+                        key: AZTEC_RPC_NODES_MAINNET
+```
+
+**Testnet overlay adds extra env vars** (present in testnet deployment but not mainnet):
+
+```yaml
+- name: AZTEC_DISABLE_ETERNAL_CATCHUP
+  value: "false"
+- name: NODE_OPTIONS
+  value: "--max-old-space-size=1536"
+```
+
+---
+
+## Service 4: `ethereum-listener`
+
+### Workflow: `.github/workflows/ethereum-listener.yml`
+
+Jobs: `set-up` → `build-base` → `build` → `deploy`
+
+**Secret injection in deploy job (all 3 secrets per network):**
+
+```yaml
+- name: Inject L1 RPC secrets
+  env:
+    MAINNET_AZTEC_L1_HTTP: ${{ vars.MAINNET_AZTEC_L1_HTTP }}
+    MAINNET_AZTEC_L1_WS: ${{ vars.MAINNET_AZTEC_L1_WS }}
+    ETHEREUM_HTTP_ALCHEMY_MAINNET_URL: ${{ vars.ETHEREUM_HTTP_ALCHEMY_MAINNET_URL }}
+    TESTNET_AZTEC_L1_HTTP: ${{ vars.TESTNET_AZTEC_L1_HTTP }}
+    TESTNET_AZTEC_L1_WS: ${{ vars.TESTNET_AZTEC_L1_WS }}
+    DEVNET_AZTEC_L1_HTTP: ${{ vars.DEVNET_AZTEC_L1_HTTP }}
+    DEVNET_AZTEC_L1_WS: ${{ vars.DEVNET_AZTEC_L1_WS }}
+    ETHEREUM_HTTP_ALCHEMY_SEPOLIA_URL: ${{ vars.ETHEREUM_HTTP_ALCHEMY_SEPOLIA_URL }}
+  run: |
+    NETWORK="${{ needs.set-up.outputs.network }}"
+    case "$NETWORK" in
+      mainnet)
+        kubectl create secret generic mainnet-config \
+          --from-literal=MAINNET_AZTEC_L1_HTTP=$MAINNET_AZTEC_L1_HTTP \
+          --from-literal=MAINNET_AZTEC_L1_WS=$MAINNET_AZTEC_L1_WS \
+          --from-literal=ETHEREUM_HTTP_ALCHEMY_MAINNET_URL=$ETHEREUM_HTTP_ALCHEMY_MAINNET_URL \
+          --namespace chicmoz-prod --dry-run=client -o yaml | kubectl apply -f -
+        ;;
+      testnet)
+        kubectl create secret generic testnet-config \
+          --from-literal=TESTNET_AZTEC_L1_HTTP=$TESTNET_AZTEC_L1_HTTP \
+          --from-literal=TESTNET_AZTEC_L1_WS=$TESTNET_AZTEC_L1_WS \
+          --from-literal=ETHEREUM_HTTP_ALCHEMY_SEPOLIA_URL=$ETHEREUM_HTTP_ALCHEMY_SEPOLIA_URL \
+          --namespace chicmoz-prod --dry-run=client -o yaml | kubectl apply -f -
+        ;;
+      devnet)
+        kubectl create secret generic devnet-config \
+          --from-literal=DEVNET_AZTEC_L1_HTTP=$DEVNET_AZTEC_L1_HTTP \
+          --from-literal=DEVNET_AZTEC_L1_WS=$DEVNET_AZTEC_L1_WS \
+          --from-literal=ETHEREUM_HTTP_ALCHEMY_SEPOLIA_URL=$ETHEREUM_HTTP_ALCHEMY_SEPOLIA_URL \
+          --namespace chicmoz-prod --dry-run=client -o yaml | kubectl apply -f -
+        ;;
+    esac
+```
+
+### Kustomize files
+
+**`services/ethereum-listener/k8s/base/deployment.yaml`**
+Source: `k8s/production/ethereum-listener/mainnet/deployment.yaml`
+
+- No service file
+- Remove `namespace`, `status: {}`
+- `metadata.name: ethereum-listener`
+- Image: `registry.digitalocean.com/aztlan-containers/ethereum-listener`
+- Add `imagePullPolicy: Always`
+- Keep: init container, `envFrom` both configMapRefs (`postgres-config-global`, `postgres-config-ethereum-listener`)
+- Keep: `resources`
+- Base env: `NODE_ENV: production`, `LISTENER_DISABLED: "false"`, `LISTEN_FOR_BLOCKS: "true"`
+- Remove from base: `INSTANCE_NAME`, `L2_NETWORK_ID`, all 3 `secretKeyRef` env vars
+
+**Per overlay patches (mainnet example):**
+
+```yaml
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: ethereum-listener
+      spec:
+        template:
+          spec:
+            containers:
+              - name: ethereum-listener
+                env:
+                  - name: INSTANCE_NAME
+                    value: "ethereum-listener-mainnet"
+                  - name: L2_NETWORK_ID
+                    value: "MAINNET"
+                  - name: ETHEREUM_HTTP_RPC_URL
+                    valueFrom:
+                      secretKeyRef:
+                        name: mainnet-config
+                        key: MAINNET_AZTEC_L1_HTTP
+                  - name: ETHEREUM_WS_RPC_URL
+                    valueFrom:
+                      secretKeyRef:
+                        name: mainnet-config
+                        key: MAINNET_AZTEC_L1_WS
+                  - name: ETHEREUM_ALCHEMY_HTTP_URL
+                    valueFrom:
+                      secretKeyRef:
+                        name: mainnet-config
+                        key: ETHEREUM_HTTP_ALCHEMY_MAINNET_URL
+```
+
+Testnet/devnet: substitute `testnet-config`/`devnet-config` and the corresponding key names.
+Note: testnet and devnet both use `ETHEREUM_HTTP_ALCHEMY_SEPOLIA_URL` (same Sepolia key).
+
+**`postgres-config.yaml` DB names:**
+
+- mainnet: `ethereum_listener_mainnet`
+- testnet: `ethereum_listener_testnet`
+- devnet: `ethereum_listener_devnet`
+
+---
+
+## Service 5: `explorer-ui`
+
+### Workflow: `.github/workflows/explorer-ui.yml`
+
+Jobs: `set-up` → `build-base` → `build` → `deploy`
+
+`explorer-ui` uses `ARG BASE` in its Dockerfile (unlike `explorer-ui-v2`), so it needs the
+`build-base` job identical to backend services.
+
+**Resolve network-specific build args in build job:**
+
+```yaml
+- name: Resolve network-specific build args
+  id: build-args
+  run: |
+    case "${{ needs.set-up.outputs.network }}" in
+      mainnet)
+        echo "l2_network_id=MAINNET" >> $GITHUB_OUTPUT
+        echo "api_url=https://api.aztecscan.xyz/v1" >> $GITHUB_OUTPUT
+        echo "ws_url=wss://ws.aztecscan.xyz" >> $GITHUB_OUTPUT
+        ;;
+      testnet)
+        echo "l2_network_id=TESTNET" >> $GITHUB_OUTPUT
+        echo "api_url=https://api.testnet.aztecscan.xyz/v1" >> $GITHUB_OUTPUT
+        echo "ws_url=wss://ws.testnet.aztecscan.xyz" >> $GITHUB_OUTPUT
+        ;;
+      devnet)
+        echo "l2_network_id=DEVNET" >> $GITHUB_OUTPUT
+        echo "api_url=https://api.devnet.aztecscan.xyz/v1" >> $GITHUB_OUTPUT
+        echo "ws_url=wss://ws.devnet.aztecscan.xyz" >> $GITHUB_OUTPUT
+        ;;
+    esac
+```
+
+**`IMAGE_NAME`** for `explorer-ui` is `explorer-ui-{network}` (different image per network because
+VITE vars are baked in at build time). Construct in build job:
+
+```yaml
+IMAGE_NAME: explorer-ui-${{ needs.set-up.outputs.network }}
+```
+
+**Docker build-args in build job:**
+
+```
+BASE=registry.digitalocean.com/aztlan-containers/chicmoz-base:latest
+NODE_ENV=production
+VITE_L2_NETWORK_ID=${{ steps.build-args.outputs.l2_network_id }}
+VITE_CHICMOZ_ALL_UI_URLS=Mainnet|https://aztecscan.xyz,Testnet|https://testnet.aztecscan.xyz,Devnet|https://devnet.aztecscan.xyz
+VITE_API_URL=${{ steps.build-args.outputs.api_url }}
+VITE_API_KEY=temporary-api-key
+VITE_WS_URL=${{ steps.build-args.outputs.ws_url }}
+VITE_DISCORD_URL=https://discord.gg/xnw7fVXB7m
+VITE_GITHUB_URL=https://github.com/aztec-scan/chicmoz
+VITE_X_URL=https://x.com/aztecscan
+VITE_VERSION_STRING=${{ github.sha }}
+```
+
+### Kustomize files
+
+**`services/explorer-ui/k8s/base/deployment.yaml`**
+Source: `k8s/production/explorer-ui/mainnet/deployment.yaml`
+
+- Remove `namespace`
+- `metadata.name: explorer-ui`
+- `labels.app: explorer-ui`
+- Image: `registry.digitalocean.com/aztlan-containers/explorer-ui`
+- Add `imagePullPolicy: Always`
+- Keep: `resources`, ports (`http-app-port: 80`)
+- No env vars in base (nginx static server — no runtime config)
+
+**`services/explorer-ui/k8s/base/service.yaml`**
+
+- `metadata.name: explorer-ui`, `selector.app: explorer-ui`
+
+**`services/explorer-ui/k8s/base/kustomization.yaml`**
+
+```yaml
+resources:
+  - deployment.yaml
+  - service.yaml
+```
+
+**Mainnet overlay:**
+
+```yaml
+namespace: chicmoz-prod
+nameSuffix: -mainnet
+resources:
+  - ../../base
+  - httproute.yaml
+images:
+  - name: registry.digitalocean.com/aztlan-containers/explorer-ui
+    newName: registry.digitalocean.com/aztlan-containers/explorer-ui-mainnet
+    newTag: latest
+```
+
+No patches needed (no runtime env vars — nginx static server).
+
+**Mainnet httproute:** copy from `k8s/production/explorer-ui/mainnet/httproute.yaml` exactly.
+
+- `backendRefs.name: explorer-ui-mainnet-service` (hardcoded)
+- All 8 parentRefs kept. Both hostnames kept (`aztecscan.xyz`, `mainnet.aztecscan.xyz`).
+
+**Testnet httproute:** copy from `k8s/production/explorer-ui/testnet/httproute.yaml`.
+
+- `backendRefs.name: explorer-ui-testnet-service` (hardcoded)
+
+**Devnet httproute:** does NOT exist in old manifests — create it:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: explorer-ui
+  namespace: chicmoz-prod
+  labels:
+    app.kubernetes.io/name: explorer-ui
+    app.kubernetes.io/part-of: chicmoz-prod
+spec:
+  parentRefs:
+    - name: aztecscan-gateway
+      sectionName: ui-devnet-http
+    - name: aztecscan-gateway
+      sectionName: ui-devnet-https
+  hostnames:
+    - devnet.aztecscan.xyz
+  rules:
+    - backendRefs:
+        - name: explorer-ui-devnet-service # hardcoded
+          port: 80
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+```
+
+**Deploy rollout:** `deployment/explorer-ui-{network}` (standard pattern).
+
+---
+
+## Service 6: `auth`
+
+### Workflow: `.github/workflows/auth.yml`
+
+**Mainnet only** — no network detection needed.
+
+```yaml
+on:
+  push:
+    branches: [production]
+    paths: ["services/auth/**"]
+  workflow_dispatch: # no network input — always mainnet
+```
+
+Jobs: `set-up` (simplified — no network detection step) → `build-base` → `build` → `deploy`
+
+`IMAGE_NAME: auth-mainnet` (hardcoded, no `{network}` variable)
+
+No secrets in deploy.
+
+**Deploy rollout:** `deployment/auth` — NO network suffix (see critical note below).
+
+### Critical: No `nameSuffix` for auth
+
+Auth's service must remain named exactly `auth-service` because
+`k8s/production/explorer-api/mainnet/securitypolicy.yaml` (and the new Kustomize version)
+hardcodes `extAuth.http.backendRefs[0].name: auth-service`. Adding a `-mainnet` suffix to auth
+would break the mainnet extAuth integration.
+
+### Kustomize files
+
+**`services/auth/k8s/base/deployment.yaml`**
+Source: `k8s/production/auth/deployment.yaml`
+
+- Remove `namespace`, `status: {}`
+- `metadata.name: auth`
+- Image: `registry.digitalocean.com/aztlan-containers/auth`
+- Add `imagePullPolicy: Always`
+- Keep ALL env vars (all hardcoded — no network-specific values, no secrets):
+  `PORT: "80"`, `POSTGRES_DB_NAME: "auth"`, `REDIS_HOST: redis-cache`,
+  `REDIS_PORT: "6379"`, `NODE_ENV: production`
+- Keep: `envFrom: postgres-config-global`, `readinessProbe`, `resources`, ports
+
+**`services/auth/k8s/base/service.yaml`**
+
+- `metadata.name: auth` — Kustomize will NOT add a suffix (no nameSuffix in overlay)
+- Resulting service name stays `auth-service` after overlay processing...
+  Wait — with no `nameSuffix`, `metadata.name: auth` stays `auth`, and the service
+  `metadata.name: auth` produces a service named `auth`. But the old service is `auth-service`.
+
+  **Resolution:** Set `metadata.name: auth-service` directly in base service.yaml (hardcoded).
+  This avoids any naming confusion and keeps the service name stable.
+
+**`services/auth/k8s/base/kustomization.yaml`**
+
+```yaml
+resources:
+  - deployment.yaml
+  - service.yaml
+```
+
+**`services/auth/k8s/overlays/mainnet/postgres-config.yaml`**
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-config-auth
+  namespace: chicmoz-prod
+data:
+  POSTGRES_DB_NAME: "auth"
+```
+
+**`services/auth/k8s/overlays/mainnet/kustomization.yaml`**
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: chicmoz-prod
+# NO nameSuffix — auth-service name must remain stable for securitypolicy extAuth reference
+
+resources:
+  - ../../base
+  - postgres-config.yaml
+
+images:
+  - name: registry.digitalocean.com/aztlan-containers/auth
+    newName: registry.digitalocean.com/aztlan-containers/auth-mainnet
+    newTag: latest
+```
+
+---
+
+## Service 7: `compiler-orchestrator`
+
+### Workflow: `.github/workflows/compiler-orchestrator.yml`
+
+Jobs: `set-up` → `build-base` → `build` → `deploy`
+No secrets. `workflow_dispatch` with network dropdown.
+
+### Kustomize files
+
+**RBAC handling:** The `ServiceAccount`, `Role`, and `RoleBinding` are network-agnostic in terms
+of structure but their names will get the `nameSuffix` appended when in base. The
+`serviceAccountName` in the deployment also gets transformed by Kustomize — this is fine.
+Include `rbac.yaml` in the **base** so it's shared.
+
+**`services/compiler-orchestrator/k8s/base/rbac.yaml`**
+Copy from `k8s/production/compiler-orchestrator/mainnet/rbac.yaml` exactly but:
+
+- `metadata.name: compiler-orchestrator` (on ServiceAccount, Role, RoleBinding)
+- Kustomize nameSuffix will transform all three to e.g. `compiler-orchestrator-mainnet`
+- `spec.template.spec.serviceAccountName: compiler-orchestrator` in deployment —
+  Kustomize DOES transform `serviceAccountName` when it matches a ServiceAccount in the same
+  kustomization — this works correctly.
+
+**`services/compiler-orchestrator/k8s/base/deployment.yaml`**
+Source: `k8s/production/compiler-orchestrator/mainnet/deployment.yaml`
+
+- Remove `namespace`, `status: {}`
+- `metadata.name: compiler-orchestrator`
+- Image: `registry.digitalocean.com/aztlan-containers/compiler-orchestrator`
+- Add `imagePullPolicy: Always`
+- `serviceAccountName: compiler-orchestrator`
+- Keep: `resources`, liveness/readiness probes
+- Base env (identical across networks):
+  `NODE_ENV: production`, `K8S_NAMESPACE: chicmoz-prod`,
+  `MAX_CONCURRENT_JOBS: "3"`, `JOB_TIMEOUT_SECONDS: "300"`,
+  `IMAGE_PULL_SECRET: registry-aztlan-containers`
+- Remove from base: `INSTANCE_NAME`, `L2_NETWORK_ID`, `COMPILER_IMAGE` (overlay patches)
+
+**`services/compiler-orchestrator/k8s/base/kustomization.yaml`**
+
+```yaml
+resources:
+  - deployment.yaml
+  - rbac.yaml
+```
+
+**Per overlay patches (mainnet example):**
+
+```yaml
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: compiler-orchestrator
+      spec:
+        template:
+          spec:
+            containers:
+              - name: compiler-orchestrator
+                env:
+                  - name: INSTANCE_NAME
+                    value: "mainnet_compiler-orchestrator"
+                  - name: L2_NETWORK_ID
+                    value: "MAINNET"
+                  - name: COMPILER_IMAGE
+                    value: "registry.digitalocean.com/aztlan-containers/contract-compiler-mainnet:4.2.0"
+```
+
+**Current `COMPILER_IMAGE` values (hardcoded — update manually when Aztec version changes):**
+
+- mainnet: `registry.digitalocean.com/aztlan-containers/contract-compiler-mainnet:4.2.0`
+- testnet: `registry.digitalocean.com/aztlan-containers/contract-compiler-testnet:4.2.0`
+- devnet: `registry.digitalocean.com/aztlan-containers/contract-compiler-devnet:4.2.0`
+
+---
+
+## Step 8: Update `docs/ci-cd-migration.md`
+
+Update the Services Migration Status table to mark all services as Done:
+
+```markdown
+| explorer-ui-v2 | testnet, mainnet, devnet | — (new service) | explorer-ui-v2.yml | ✅ Done |
+| explorer-ui | mainnet, testnet, devnet | k8s/production/explorer-ui/skaffold._.yaml | explorer-ui.yml | ✅ Done |
+| explorer-api | mainnet, testnet, devnet | k8s/production/explorer-api/skaffold._.yaml | explorer-api.yml | ✅ Done |
+| aztec-listener | mainnet, testnet, devnet | k8s/production/aztec-listener/skaffold._.yaml | aztec-listener.yml | ✅ Done |
+| ethereum-listener | mainnet, testnet, devnet | k8s/production/ethereum-listener/skaffold._.yaml | ethereum-listener.yml | ✅ Done |
+| websocket-event-publisher | mainnet, testnet, devnet | k8s/production/websocket-event-publisher/skaffold._.yaml | websocket-event-publisher.yml | ✅ Done |
+| auth | mainnet | k8s/production/auth/skaffold.yaml | auth.yml | ✅ Done |
+| compiler-orchestrator | mainnet, testnet, devnet | k8s/production/compiler-orchestrator/skaffold._.yaml | compiler-orchestrator.yml | ✅ Done |
+```
+
+Also add a note under "Notes on Backend Services" — "Building the chicmoz-base image":
+
+```markdown
+### Building the chicmoz-base image
+
+Backend services depend on a shared base image (`chicmoz-base`) built from the root `Dockerfile`.
+In the new per-service workflows, a `build-base` job builds and pushes this image before the
+service build job runs. GHA layer caching (`scope=chicmoz-base`) is shared across all service
+workflows, so the base is only rebuilt when the root `Dockerfile` or monorepo package files change.
+```
+
+---
+
+## Key Gotchas Summary
+
+1. **`backendRefs.name`, `targetRefs.name`, `extensionRef.name`** — NOT transformed by nameSuffix.
+   Always hardcode to the full suffixed name (e.g. `explorer-api-mainnet-service`).
+
+2. **`envFrom.configMapRef.name`** — IS transformed by nameSuffix when the ConfigMap is a resource
+   in the same kustomization. Use base names without suffix in the base deployment.
+
+3. **`secretKeyRef`** — cannot go in the base. Use per-overlay strategic merge patches.
+
+4. **Auth has no `nameSuffix`** — `auth-service` must stay exactly `auth-service` for the
+   `explorer-api` mainnet `securitypolicy.yaml` extAuth reference to work.
+
+5. **`explorer-ui` uses `ARG BASE`** (old-pattern Dockerfile) — needs a `build-base` job,
+   unlike `explorer-ui-v2` which builds standalone from `node:22-alpine`.
+
+6. **`COMPILER_IMAGE` version is hardcoded** in `compiler-orchestrator` overlay patches.
+   Update it manually when the contract-compiler image version changes.
+
+7. **Old Skaffold workflows are NOT deleted** — they stay running in parallel.
+
+8. **`explorer-ui` devnet httproute does not exist in old manifests** — create it following
+   the testnet pattern. Section names: `ui-devnet-http`, `ui-devnet-https`.
+   Hostname: `devnet.aztecscan.xyz`.
+
+9. **`devnet` old workflow used a broken `doctl` command** (missing registry name + sed patch).
+   All new workflows use `doctl registries kubernetes-manifest aztlan-containers` consistently.
+
+10. **`VERSION_STRING`** — old pattern used `git describe --tags`. New pattern uses `${{ github.sha }}`
+    directly (consistent with `explorer-ui-v2`).

--- a/docs/ci-cd-migration.md
+++ b/docs/ci-cd-migration.md
@@ -367,22 +367,29 @@ The flat per-network manifests under `k8s/production/<service>/` are superseded 
 
 ## Services Migration Status
 
-| Service                     | Networks                 | Old Skaffold files                                         | New workflow         | Status     |
-| --------------------------- | ------------------------ | ---------------------------------------------------------- | -------------------- | ---------- |
-| `explorer-ui-v2`            | testnet, mainnet, devnet | — (new service)                                            | `explorer-ui-v2.yml` | ✅ Done    |
-| `explorer-ui`               | mainnet, testnet, devnet | `k8s/production/explorer-ui/skaffold.*.yaml`               | —                    | ⏳ Pending |
-| `explorer-api`              | mainnet, testnet, devnet | `k8s/production/explorer-api/skaffold.*.yaml`              | —                    | ⏳ Pending |
-| `aztec-listener`            | mainnet, testnet, devnet | `k8s/production/aztec-listener/skaffold.*.yaml`            | —                    | ⏳ Pending |
-| `ethereum-listener`         | mainnet, testnet, devnet | `k8s/production/ethereum-listener/skaffold.*.yaml`         | —                    | ⏳ Pending |
-| `websocket-event-publisher` | mainnet, testnet, devnet | `k8s/production/websocket-event-publisher/skaffold.*.yaml` | —                    | ⏳ Pending |
-| `auth`                      | mainnet                  | `k8s/production/auth/skaffold.yaml`                        | —                    | ⏳ Pending |
-| `compiler-orchestrator`     | mainnet, testnet, devnet | `k8s/production/compiler-orchestrator/skaffold.*.yaml`     | —                    | ⏳ Pending |
+| Service                     | Networks                 | Old Skaffold files                                         | New workflow                    | Status  |
+| --------------------------- | ------------------------ | ---------------------------------------------------------- | ------------------------------- | ------- |
+| `explorer-ui-v2`            | testnet, mainnet, devnet | — (new service)                                            | `explorer-ui-v2.yml`            | ✅ Done |
+| `explorer-ui`               | mainnet, testnet, devnet | `k8s/production/explorer-ui/skaffold.*.yaml`               | `explorer-ui.yml`               | ✅ Done |
+| `explorer-api`              | mainnet, testnet, devnet | `k8s/production/explorer-api/skaffold.*.yaml`              | `explorer-api.yml`              | ✅ Done |
+| `aztec-listener`            | mainnet, testnet, devnet | `k8s/production/aztec-listener/skaffold.*.yaml`            | `aztec-listener.yml`            | ✅ Done |
+| `ethereum-listener`         | mainnet, testnet, devnet | `k8s/production/ethereum-listener/skaffold.*.yaml`         | `ethereum-listener.yml`         | ✅ Done |
+| `websocket-event-publisher` | mainnet, testnet, devnet | `k8s/production/websocket-event-publisher/skaffold.*.yaml` | `websocket-event-publisher.yml` | ✅ Done |
+| `auth`                      | mainnet                  | `k8s/production/auth/skaffold.yaml`                        | `auth.yml`                      | ✅ Done |
+| `compiler-orchestrator`     | mainnet, testnet, devnet | `k8s/production/compiler-orchestrator/skaffold.*.yaml`     | `compiler-orchestrator.yml`     | ✅ Done |
 
 ---
 
 ## Notes on Backend Services
 
 Backend services (everything except the UI services) have additional concerns vs the frontend:
+
+### Building the chicmoz-base image
+
+Backend services depend on a shared base image (`chicmoz-base`) built from the root `Dockerfile`.
+In the new per-service workflows, a `build-base` job builds and pushes this image before the
+service build job runs. GHA layer caching (`scope=chicmoz-base`) is shared across all service
+workflows, so the base is only rebuilt when the root `Dockerfile` or monorepo package files change.
 
 ### Secrets injection
 

--- a/docs/ci-cd-migration.md
+++ b/docs/ci-cd-migration.md
@@ -49,15 +49,24 @@ Every push to `production-testnet` rebuilds and redeploys **all services**, even
 ## New Pattern (GitHub Actions + Kustomize)
 
 ```
-.github/workflows/<service>-{network}.yml   ← one workflow per service per network
-  ├── set-up job   → install doctl + kubectl, cache tools
-  ├── build job    → docker buildx + push, GHA layer cache, sha + network-latest tags
+.github/workflows/<service>.yml   ← one workflow per service (handles all networks)
+  ├── set-up job   → determine network from branch, install doctl + kubectl, cache tools
+  ├── build job    → resolve network-specific VITE vars, docker buildx + push,
+  │                  GHA layer cache, sha + network-latest tags
   └── deploy job   → kubectl apply -k services/<service>/k8s/overlays/{network}/
                       kubectl rollout restart deployment/<service>-{network} -n chicmoz-prod
                       kubectl rollout status deployment/<service>-{network} -n chicmoz-prod
 ```
 
-Each workflow is **path-filtered** — only triggers when files under `services/<service>/` change. Services deploy independently.
+Each workflow is **path-filtered** — only triggers when files under `services/<service>/` change. Services deploy independently. **Network is derived from the branch** that triggered the push:
+
+| Branch               | Network   |
+| -------------------- | --------- |
+| `production`         | `mainnet` |
+| `production-testnet` | `testnet` |
+| `production-devnet`  | `devnet`  |
+
+For manual deploys via `workflow_dispatch`, the network is selected from a dropdown input.
 
 ---
 
@@ -156,17 +165,26 @@ spec:
 
 ## GitHub Actions Workflow Structure
 
-Reference: `.github/workflows/explorer-ui-v2-testnet.yml`
+Reference: `.github/workflows/explorer-ui-v2.yml`
 
 ```yaml
-name: CI/CD <Service> — <Network>
+name: CI/CD <Service>
 
 on:
   push:
-    branches: [production-testnet] # production | production-testnet | production-devnet
+    branches:
+      - production-testnet
+      - production
+      - production-devnet
     paths:
       - "services/<service>/**" # path filter — only triggers on changes to this service
   workflow_dispatch: # allows manual re-deploy from GitHub UI
+    inputs:
+      network:
+        description: "Network to deploy to"
+        required: true
+        type: choice
+        options: [testnet, mainnet, devnet]
 
 env:
   REGISTRY: registry.digitalocean.com/aztlan-containers
@@ -174,10 +192,58 @@ env:
   IMAGE_NAME: <service>
 
 jobs:
-  set-up: # installs doctl + kubectl, caches them by date
-  build: # docker buildx, pushes {network}-latest + {network}-{sha}
-  deploy: # kubectl apply -k, rollout restart, rollout status
+  set-up: # determines network from branch or dispatch input, installs doctl + kubectl, caches by date
+  build: # resolves network-specific VITE vars, docker buildx, pushes {network}-latest + {network}-{sha}
+  deploy: # kubectl apply -k overlays/{network}/, rollout restart, rollout status
 ```
+
+### Network Detection (set-up job)
+
+```yaml
+- name: Determine network
+  id: network
+  run: |
+    if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+      echo "network=${{ inputs.network }}" >> $GITHUB_OUTPUT
+    elif [ "${{ github.ref_name }}" = "production" ]; then
+      echo "network=mainnet" >> $GITHUB_OUTPUT
+    elif [ "${{ github.ref_name }}" = "production-testnet" ]; then
+      echo "network=testnet" >> $GITHUB_OUTPUT
+    elif [ "${{ github.ref_name }}" = "production-devnet" ]; then
+      echo "network=devnet" >> $GITHUB_OUTPUT
+    fi
+```
+
+The derived `network` value is passed as a job output (`needs.set-up.outputs.network`) and used throughout the workflow for image tags, build args, Kustomize overlay path, and deployment name.
+
+### Network-Specific Build Args (frontend services)
+
+Frontend services resolve per-network `VITE_*` vars in a `build-args` step using a `case` statement before the Docker build:
+
+```yaml
+- name: Resolve network-specific build args
+  id: build-args
+  run: |
+    case "${{ needs.set-up.outputs.network }}" in
+      mainnet)
+        echo "l2_network_id=MAINNET" >> $GITHUB_OUTPUT
+        echo "api_url=https://api.aztecscan.xyz/v1" >> $GITHUB_OUTPUT
+        echo "ws_url=wss://ws.aztecscan.xyz" >> $GITHUB_OUTPUT
+        ;;
+      testnet)
+        echo "l2_network_id=TESTNET" >> $GITHUB_OUTPUT
+        echo "api_url=https://api.testnet.aztecscan.xyz/v1" >> $GITHUB_OUTPUT
+        echo "ws_url=wss://ws.testnet.aztecscan.xyz" >> $GITHUB_OUTPUT
+        ;;
+      devnet)
+        echo "l2_network_id=DEVNET" >> $GITHUB_OUTPUT
+        echo "api_url=https://api.devnet.aztecscan.xyz/v1" >> $GITHUB_OUTPUT
+        echo "ws_url=wss://ws.devnet.aztecscan.xyz" >> $GITHUB_OUTPUT
+        ;;
+    esac
+```
+
+Backend services have no build-time env vars — all config is injected at runtime via K8s Secrets.
 
 ### Image Tagging Convention
 
@@ -226,16 +292,16 @@ Add `patches:` for any network-specific env vars or config (e.g. different DB na
 
 For services with environment variables injected via K8s Secrets (e.g. `aztec-listener`, `ethereum-listener`, `explorer-api`), keep using `secretKeyRef` in the base deployment — the secret is created by the workflow before `kubectl apply -k`.
 
-### Step 3 — Create `.github/workflows/<service>-{network}.yml`
+### Step 3 — Create `.github/workflows/<service>.yml`
 
-Use `explorer-ui-v2-testnet.yml` as the template. Key things to customise:
+Use `explorer-ui-v2.yml` as the template. **One file per service** — it handles all networks by deriving the target network from the branch. Key things to customise:
 
-- `on.push.branches` — the relevant production branch
 - `on.push.paths` — `services/<service>/**`
 - `IMAGE_NAME` — the image name in the registry
 - `build.build-args` — all `ARG` values from the service's `Dockerfile`
-- For backend services: add a step to `kubectl create secret generic ...` before `kubectl apply -k` (see `aztecscan-prod-testnet.yml` for reference on how secrets are currently injected)
-- `deploy` step: `kubectl apply -k services/<service>/k8s/overlays/{network}/`
+- For frontend services: add the `Resolve network-specific build args` step with the correct per-network `VITE_*` values
+- For backend services: add a step to `kubectl create secret generic ...` before `kubectl apply -k`, keyed by `${{ needs.set-up.outputs.network }}` (see `aztecscan-prod-testnet.yml` for reference on how secrets are currently injected)
+- `deploy` step targets `services/<service>/k8s/overlays/${{ needs.set-up.outputs.network }}/`
 
 ### Step 4 — Add gateway listeners (if new hostname)
 
@@ -283,30 +349,34 @@ The flat per-network manifests under `k8s/production/<service>/` are superseded 
 
 `explorer-ui-v2` is the first service using the new pattern. Use it as the canonical example.
 
-| File                                                              | Purpose                                          |
-| ----------------------------------------------------------------- | ------------------------------------------------ |
-| `services/explorer-ui-v2/k8s/base/kustomization.yaml`             | Base resource list                               |
-| `services/explorer-ui-v2/k8s/base/deployment.yaml`                | Generic deployment — no namespace, no image tag  |
-| `services/explorer-ui-v2/k8s/base/service.yaml`                   | ClusterIP service                                |
-| `services/explorer-ui-v2/k8s/base/httproute.yaml`                 | Gateway HTTPRoute for `v2.testnet.aztecscan.xyz` |
-| `services/explorer-ui-v2/k8s/overlays/testnet/kustomization.yaml` | Testnet: sets namespace + pins image tag         |
-| `.github/workflows/explorer-ui-v2-testnet.yml`                    | Full build + deploy workflow                     |
-| `k8s/local/explorer-ui-v2/skaffold.testnet.yaml`                  | Local dev — Skaffold unchanged                   |
+| File                                                              | Purpose                                         |
+| ----------------------------------------------------------------- | ----------------------------------------------- |
+| `services/explorer-ui-v2/k8s/base/kustomization.yaml`             | Base resource list                              |
+| `services/explorer-ui-v2/k8s/base/deployment.yaml`                | Generic deployment — no namespace, no image tag |
+| `services/explorer-ui-v2/k8s/base/service.yaml`                   | ClusterIP service                               |
+| `services/explorer-ui-v2/k8s/overlays/testnet/kustomization.yaml` | Testnet: sets namespace + pins image tag        |
+| `services/explorer-ui-v2/k8s/overlays/testnet/httproute.yaml`     | Testnet HTTPRoute — `v2.testnet.aztecscan.xyz`  |
+| `services/explorer-ui-v2/k8s/overlays/mainnet/kustomization.yaml` | Mainnet: sets namespace + pins image tag        |
+| `services/explorer-ui-v2/k8s/overlays/mainnet/httproute.yaml`     | Mainnet HTTPRoute — `v2.aztecscan.xyz`          |
+| `services/explorer-ui-v2/k8s/overlays/devnet/kustomization.yaml`  | Devnet: sets namespace + pins image tag         |
+| `services/explorer-ui-v2/k8s/overlays/devnet/httproute.yaml`      | Devnet HTTPRoute — `v2.devnet.aztecscan.xyz`    |
+| `.github/workflows/explorer-ui-v2.yml`                            | Single workflow — all networks, branch-derived  |
+| `k8s/local/explorer-ui-v2/skaffold.testnet.yaml`                  | Local dev — Skaffold unchanged                  |
 
 ---
 
 ## Services Migration Status
 
-| Service                     | Networks                 | Old Skaffold files                                         | New workflow                 | Status     |
-| --------------------------- | ------------------------ | ---------------------------------------------------------- | ---------------------------- | ---------- |
-| `explorer-ui-v2`            | testnet                  | — (new service)                                            | `explorer-ui-v2-testnet.yml` | ✅ Done    |
-| `explorer-ui`               | mainnet, testnet, devnet | `k8s/production/explorer-ui/skaffold.*.yaml`               | —                            | ⏳ Pending |
-| `explorer-api`              | mainnet, testnet, devnet | `k8s/production/explorer-api/skaffold.*.yaml`              | —                            | ⏳ Pending |
-| `aztec-listener`            | mainnet, testnet, devnet | `k8s/production/aztec-listener/skaffold.*.yaml`            | —                            | ⏳ Pending |
-| `ethereum-listener`         | mainnet, testnet, devnet | `k8s/production/ethereum-listener/skaffold.*.yaml`         | —                            | ⏳ Pending |
-| `websocket-event-publisher` | mainnet, testnet, devnet | `k8s/production/websocket-event-publisher/skaffold.*.yaml` | —                            | ⏳ Pending |
-| `auth`                      | mainnet                  | `k8s/production/auth/skaffold.yaml`                        | —                            | ⏳ Pending |
-| `compiler-orchestrator`     | mainnet, testnet, devnet | `k8s/production/compiler-orchestrator/skaffold.*.yaml`     | —                            | ⏳ Pending |
+| Service                     | Networks                 | Old Skaffold files                                         | New workflow         | Status     |
+| --------------------------- | ------------------------ | ---------------------------------------------------------- | -------------------- | ---------- |
+| `explorer-ui-v2`            | testnet, mainnet, devnet | — (new service)                                            | `explorer-ui-v2.yml` | ✅ Done    |
+| `explorer-ui`               | mainnet, testnet, devnet | `k8s/production/explorer-ui/skaffold.*.yaml`               | —                    | ⏳ Pending |
+| `explorer-api`              | mainnet, testnet, devnet | `k8s/production/explorer-api/skaffold.*.yaml`              | —                    | ⏳ Pending |
+| `aztec-listener`            | mainnet, testnet, devnet | `k8s/production/aztec-listener/skaffold.*.yaml`            | —                    | ⏳ Pending |
+| `ethereum-listener`         | mainnet, testnet, devnet | `k8s/production/ethereum-listener/skaffold.*.yaml`         | —                    | ⏳ Pending |
+| `websocket-event-publisher` | mainnet, testnet, devnet | `k8s/production/websocket-event-publisher/skaffold.*.yaml` | —                    | ⏳ Pending |
+| `auth`                      | mainnet                  | `k8s/production/auth/skaffold.yaml`                        | —                    | ⏳ Pending |
+| `compiler-orchestrator`     | mainnet, testnet, devnet | `k8s/production/compiler-orchestrator/skaffold.*.yaml`     | —                    | ⏳ Pending |
 
 ---
 

--- a/docs/fee-juice-balance-history.md
+++ b/docs/fee-juice-balance-history.md
@@ -1,0 +1,140 @@
+# Fee Juice Balance History — Research Findings
+
+## Goal
+
+Add a fee-juice balance history view to the **address page** in the explorer UI. The data should cover any address that appears as a fee-payer, initiator, or sender in L2 transactions.
+
+---
+
+## Current Data Flow (What Already Works)
+
+### Ingestion — `aztec-listener`
+
+| File                                                                                      | Line    | Role                                                                                                                                                      |
+| ----------------------------------------------------------------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `services/aztec-listener/src/svcs/poller/pollers/block_poller/index.ts`                   | 165     | Calls `handleProvenTransactions(block)` per proven block                                                                                                  |
+| `services/aztec-listener/src/svcs/poller/pollers/block_poller/handle-proven-block-txs.ts` | 46–57   | Reads `feePayer` from each proven tx, calls `getBalanceOf`, publishes Kafka message                                                                       |
+| `services/aztec-listener/src/svcs/poller/network-client/index.ts`                         | 222–235 | `getBalanceOf(blockNumber, address)` — reads FeeJuice storage slot 1 via `getPublicStorageAt`. **Accepts any `AztecAddress`**, not coupled to fee-payers. |
+
+**Key insight:** `getBalanceOf` is reusable for any address. The coupling to fee-payer is only in the caller.
+
+### Kafka Message
+
+| File                                     | Key                                                                                         |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `packages/message-registry/src/aztec.ts` | `CONTRACT_INSTANCE_BALANCE_EVENT` → `{ contractAddress, balance, timestamp, sourceTxHash }` |
+
+### Storage — `explorer-api`
+
+| File                                                                                           | Line | Role                                                                                          |
+| ---------------------------------------------------------------------------------------------- | ---- | --------------------------------------------------------------------------------------------- |
+| `services/explorer-api/src/events/received/on-contract-instance-balance.ts`                    | 25   | Kafka consumer — calls `storeContractInstanceBalance(event)`                                  |
+| `services/explorer-api/src/svcs/database/controllers/contract-instance-balance/store.ts`       | 6    | `INSERT INTO contract_instance_balance ON CONFLICT DO NOTHING`                                |
+| `services/explorer-api/src/svcs/database/schema/contract-instance-balance/index.ts`            | 5    | Table: `contract_instance_balance` — PK `(contract_address, timestamp)`                       |
+| `services/explorer-api/src/svcs/database/controllers/contract-instance-balance/get-balance.ts` | 63   | `getContractInstanceBalanceHistory(address)` — `SELECT ... ORDER BY timestamp ASC LIMIT 1000` |
+
+### HTTP Endpoint
+
+| File                                                                                         | Line | Role                                                         |
+| -------------------------------------------------------------------------------------------- | ---- | ------------------------------------------------------------ |
+| `services/explorer-api/src/svcs/http-server/routes/index.ts`                                 | 277  | Route: `GET /l2/contract-instances/:address/balance/history` |
+| `services/explorer-api/src/svcs/http-server/routes/controllers/contract-instance-balance.ts` | 106  | Controller — Redis cache + DB fallback                       |
+| `services/explorer-api/src/svcs/http-server/routes/utils/db-wrapper.ts`                      | 41   | Redis cache helper                                           |
+
+---
+
+## Address Sources — Where Addresses Come From
+
+### Addresses captured per transaction
+
+| Address Type                      | Pipeline                         | Table                           | Column             |
+| --------------------------------- | -------------------------------- | ------------------------------- | ------------------ |
+| `feePayer`                        | Block poller + Pending tx poller | `tx`, `tx_effect`               | `fee_payer`        |
+| `initiator`                       | Pending tx poller                | `tx`                            | `initiator`        |
+| `msgSender` per public call       | Pending tx poller                | `tx_public_call_request`        | `msg_sender`       |
+| `contractAddress` per public call | Pending tx poller                | `tx_public_call_request`        | `contract_address` |
+| Deployed contract instances       | Contract events                  | `l2_contract_instance_deployed` | `address`          |
+
+### Relevant files for address extraction
+
+| File                                                                    | Line  | Notes                                                                                   |
+| ----------------------------------------------------------------------- | ----- | --------------------------------------------------------------------------------------- |
+| `services/aztec-listener/src/events/emitted/on-pending-txs.ts`          | 156   | Extracts `feePayer`, `initiator`, all `msgSender`/`contractAddress` per public call     |
+| `packages/backend-utils/src/parse-block.ts`                             | 36–68 | Parses `L2Block` → `ChicmozL2Block`, preserves `feePayer` and `initiator` on tx effects |
+| `services/explorer-api/src/svcs/database/schema/l2tx/index.ts`          | 10–45 | `l2Tx` table: `feePayer`, `initiator` columns                                           |
+| `services/explorer-api/src/svcs/database/schema/l2public-call/index.ts` | 17    | `tx_public_call_request` table: `msg_sender`, `contract_address` columns                |
+
+### The `/l2/public-call-requests?senderAddress=` endpoint
+
+| File                                                                           | Line    | Notes                                                                                                                 |
+| ------------------------------------------------------------------------------ | ------- | --------------------------------------------------------------------------------------------------------------------- |
+| `services/explorer-api/src/svcs/http-server/routes/paths_and_validation.ts`    | 48, 155 | Path + `getPublicCallRequestsSchema` (optional `senderAddress` query param)                                           |
+| `services/explorer-api/src/svcs/http-server/routes/controllers/public-call.ts` | 120–154 | Controller — dispatches to `getPublicCallRequestsBySenderAddress`                                                     |
+| `services/explorer-api/src/svcs/database/controllers/l2Public-call/get.ts`     | 61–71   | `SELECT * FROM tx_public_call_request WHERE msg_sender = :address` — **no DB index on `msg_sender`**, full table scan |
+
+---
+
+## Gaps / What Needs to Be Built
+
+### 1. Balance only captured for fee-payers of proven txs
+
+`handle-proven-block-txs.ts` only iterates `provenTx.feePayer`. To cover the address page for any address (initiator, sender, etc.) we need to either:
+
+- Extend the proven-tx handler to also snapshot `initiator` balances, or
+- Add a new on-demand balance fetch triggered when an address is first "seen"
+
+### 2. No aggregate "seen addresses" table
+
+There is no cross-table index of unique addresses. To populate balance history for all address types, a new addresses table or a fan-out in the Kafka publisher would be needed.
+
+### 3. `tx_effect` rows don't populate `feePayer`/`initiator` from on-chain blocks
+
+`services/explorer-api/src/svcs/database/controllers/l2block/store.ts` lines 160–172 — `feePayer` and `initiator` exist in the `tx_effect` schema but are **not set** during block ingestion. Only the pending-tx path populates them.
+
+### 4. Missing DB index on `msg_sender`
+
+`tx_public_call_request.msg_sender` has no index — `/l2/public-call-requests?senderAddress=` does a full table scan.
+
+---
+
+## Proposed Extension Points
+
+### Option A — Minimal (fee-payer only, reuse existing endpoint)
+
+- The address page calls the existing `/l2/contract-instances/${address}/balance/history`
+- No backend changes needed if the address is always a fee-payer of proven txs
+- Limitation: addresses that only appear as `initiator` or `msgSender` will have no history
+
+### Option B — Fan-out in `handle-proven-block-txs.ts`
+
+- Extend `handle-proven-block-txs.ts` to also publish `CONTRACT_INSTANCE_BALANCE_EVENT` for `initiator` addresses
+- `getBalanceOf` already accepts any `AztecAddress` — minimal change
+
+### Option C — New "address seen" event + balance snapshot
+
+- When any new address is first seen (from pending txs, blocks, or public call requests), publish a new Kafka event
+- Trigger a balance snapshot for that address
+- Requires a new Kafka topic and a new "seen addresses" table
+
+---
+
+## Decision Points Before Implementation
+
+1. **Which address types** should have balance history? (fee-payer only, fee-payer + initiator, all msgSenders)
+2. **Historical vs. latest** — should balance be snapshotted at the proven block height (historical accuracy) or always fetched as "latest"?
+3. **Endpoint reuse** — does the address page reuse `/l2/contract-instances/${address}/balance/history` or get a new dedicated endpoint?
+4. **DB index** — should a migration add an index on `tx_public_call_request.msg_sender` as part of this work?
+
+---
+
+## Files to Touch When Implementing
+
+| File                                                                                      | Reason                                               |
+| ----------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `services/aztec-listener/src/svcs/poller/pollers/block_poller/handle-proven-block-txs.ts` | Extend to snapshot balance for more address types    |
+| `services/aztec-listener/src/svcs/poller/network-client/index.ts`                         | `getBalanceOf` — already reusable, no changes needed |
+| `packages/message-registry/src/aztec.ts`                                                  | Add new event type if needed                         |
+| `services/explorer-api/src/events/received/`                                              | New or updated Kafka consumer                        |
+| `services/explorer-api/src/svcs/database/schema/`                                         | New table or migration if needed                     |
+| `services/explorer-api/src/svcs/http-server/routes/`                                      | New or reused endpoint wiring                        |
+| `services/explorer-api/migrations/`                                                       | DB migration for new table or index                  |

--- a/services/auth/k8s/base/deployment.yaml
+++ b/services/auth/k8s/base/deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: auth
+  labels:
+    app: auth
+    app.kubernetes.io/name: auth
+    app.kubernetes.io/part-of: chicmoz-prod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: auth
+  template:
+    metadata:
+      labels:
+        app: auth
+    spec:
+      imagePullSecrets:
+        - name: registry-aztlan-containers
+      containers:
+        - name: auth
+          image: registry.digitalocean.com/aztlan-containers/auth
+          imagePullPolicy: Always
+          resources:
+            limits:
+              memory: 400Mi
+              cpu: 300m
+          ports:
+            - name: http-app-port
+              containerPort: 80
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: postgres-config-global
+          env:
+            - name: PORT
+              value: "80"
+            - name: POSTGRES_DB_NAME
+              value: "auth"
+            - name: REDIS_HOST
+              value: "redis-cache"
+            - name: REDIS_PORT
+              value: "6379"
+            - name: NODE_ENV
+              value: "production"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 80
+            initialDelaySeconds: 15
+            periodSeconds: 10

--- a/services/auth/k8s/base/kustomization.yaml
+++ b/services/auth/k8s/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/services/auth/k8s/base/service.yaml
+++ b/services/auth/k8s/base/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: auth-service # hardcoded — must remain auth-service for securitypolicy extAuth reference
+  labels:
+    app.kubernetes.io/name: auth
+    app.kubernetes.io/part-of: chicmoz-prod
+spec:
+  selector:
+    app: auth
+  ports:
+    - name: http-app
+      protocol: TCP
+      port: 80
+      targetPort: http-app-port

--- a/services/auth/k8s/overlays/mainnet/kustomization.yaml
+++ b/services/auth/k8s/overlays/mainnet/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: chicmoz-prod
+# NO nameSuffix — auth-service name must remain stable for securitypolicy extAuth reference
+
+resources:
+  - ../../base
+  - postgres-config.yaml
+
+images:
+  - name: registry.digitalocean.com/aztlan-containers/auth
+    newName: registry.digitalocean.com/aztlan-containers/auth-mainnet
+    newTag: latest

--- a/services/auth/k8s/overlays/mainnet/postgres-config.yaml
+++ b/services/auth/k8s/overlays/mainnet/postgres-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-config-auth
+  namespace: chicmoz-prod
+data:
+  POSTGRES_DB_NAME: "auth"

--- a/services/aztec-listener/k8s/base/deployment.yaml
+++ b/services/aztec-listener/k8s/base/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aztec-listener
+  labels:
+    app: aztec-listener
+    app.kubernetes.io/name: aztec-listener
+    app.kubernetes.io/part-of: chicmoz-prod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: aztec-listener
+  template:
+    metadata:
+      labels:
+        app: aztec-listener
+    spec:
+      imagePullSecrets:
+        - name: registry-aztlan-containers
+      initContainers:
+        - name: run-migrations
+          image: registry.digitalocean.com/aztlan-containers/aztec-listener
+          command: ["yarn", "run", "migrate"]
+          envFrom:
+            - configMapRef:
+                name: postgres-config-global
+            - configMapRef:
+                name: postgres-config-aztec-listener # nameSuffix appends network suffix
+          env:
+            - name: NODE_ENV
+              value: "production"
+            - name: TOTAL_DB_RESET
+              value: "false"
+      containers:
+        - name: aztec-listener
+          image: registry.digitalocean.com/aztlan-containers/aztec-listener
+          imagePullPolicy: Always
+          resources:
+            limits:
+              memory: 2000Mi
+              cpu: 1000m
+          envFrom:
+            - configMapRef:
+                name: postgres-config-global
+            - configMapRef:
+                name: postgres-config-aztec-listener # nameSuffix appends network suffix
+          env:
+            - name: NODE_ENV
+              value: "production"
+            - name: IGNORE_PROCESSED_HEIGHT
+              value: "false"
+            - name: AZTEC_LISTEN_FOR_BLOCKS
+              value: "true"
+            - name: AZTEC_LISTEN_FOR_PENDING_TXS
+              value: "true"

--- a/services/aztec-listener/k8s/base/kustomization.yaml
+++ b/services/aztec-listener/k8s/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml

--- a/services/aztec-listener/k8s/overlays/devnet/kustomization.yaml
+++ b/services/aztec-listener/k8s/overlays/devnet/kustomization.yaml
@@ -1,0 +1,36 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: chicmoz-prod
+nameSuffix: -devnet
+
+resources:
+  - ../../base
+  - postgres-config.yaml
+
+images:
+  - name: registry.digitalocean.com/aztlan-containers/aztec-listener
+    newName: registry.digitalocean.com/aztlan-containers/aztec-listener-devnet
+    newTag: latest
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: aztec-listener
+      spec:
+        template:
+          spec:
+            containers:
+              - name: aztec-listener
+                env:
+                  - name: INSTANCE_NAME
+                    value: "devnet_aztec-listener"
+                  - name: L2_NETWORK_ID
+                    value: "DEVNET"
+                  - name: AZTEC_RPC_URLS
+                    valueFrom:
+                      secretKeyRef:
+                        name: devnet-config
+                        key: AZTEC_RPC_NODES_DEVNET

--- a/services/aztec-listener/k8s/overlays/devnet/kustomization.yaml
+++ b/services/aztec-listener/k8s/overlays/devnet/kustomization.yaml
@@ -32,5 +32,5 @@ patches:
                   - name: AZTEC_RPC_URLS
                     valueFrom:
                       secretKeyRef:
-                        name: devnet-config
+                        name: aztec-listener-devnet
                         key: AZTEC_RPC_NODES_DEVNET

--- a/services/aztec-listener/k8s/overlays/devnet/postgres-config.yaml
+++ b/services/aztec-listener/k8s/overlays/devnet/postgres-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-config-aztec-listener # nameSuffix appends -devnet → postgres-config-aztec-listener-devnet
+  namespace: chicmoz-prod
+data:
+  POSTGRES_DB_NAME: "aztec_listener_devnet"

--- a/services/aztec-listener/k8s/overlays/mainnet/kustomization.yaml
+++ b/services/aztec-listener/k8s/overlays/mainnet/kustomization.yaml
@@ -1,0 +1,36 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: chicmoz-prod
+nameSuffix: -mainnet
+
+resources:
+  - ../../base
+  - postgres-config.yaml
+
+images:
+  - name: registry.digitalocean.com/aztlan-containers/aztec-listener
+    newName: registry.digitalocean.com/aztlan-containers/aztec-listener-mainnet
+    newTag: latest
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: aztec-listener
+      spec:
+        template:
+          spec:
+            containers:
+              - name: aztec-listener
+                env:
+                  - name: INSTANCE_NAME
+                    value: "mainnet_aztec-listener"
+                  - name: L2_NETWORK_ID
+                    value: "MAINNET"
+                  - name: AZTEC_RPC_URLS
+                    valueFrom:
+                      secretKeyRef:
+                        name: mainnet-config
+                        key: AZTEC_RPC_NODES_MAINNET

--- a/services/aztec-listener/k8s/overlays/mainnet/kustomization.yaml
+++ b/services/aztec-listener/k8s/overlays/mainnet/kustomization.yaml
@@ -32,5 +32,5 @@ patches:
                   - name: AZTEC_RPC_URLS
                     valueFrom:
                       secretKeyRef:
-                        name: mainnet-config
+                        name: aztec-listener-mainnet
                         key: AZTEC_RPC_NODES_MAINNET

--- a/services/aztec-listener/k8s/overlays/mainnet/postgres-config.yaml
+++ b/services/aztec-listener/k8s/overlays/mainnet/postgres-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-config-aztec-listener # nameSuffix appends -mainnet → postgres-config-aztec-listener-mainnet
+  namespace: chicmoz-prod
+data:
+  POSTGRES_DB_NAME: "aztec_listener_mainnet"

--- a/services/aztec-listener/k8s/overlays/testnet/kustomization.yaml
+++ b/services/aztec-listener/k8s/overlays/testnet/kustomization.yaml
@@ -32,7 +32,7 @@ patches:
                   - name: AZTEC_RPC_URLS
                     valueFrom:
                       secretKeyRef:
-                        name: testnet-config
+                        name: aztec-listener-testnet
                         key: AZTEC_RPC_NODES_TESTNET
                   - name: AZTEC_DISABLE_ETERNAL_CATCHUP
                     value: "false"

--- a/services/aztec-listener/k8s/overlays/testnet/kustomization.yaml
+++ b/services/aztec-listener/k8s/overlays/testnet/kustomization.yaml
@@ -1,0 +1,40 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: chicmoz-prod
+nameSuffix: -testnet
+
+resources:
+  - ../../base
+  - postgres-config.yaml
+
+images:
+  - name: registry.digitalocean.com/aztlan-containers/aztec-listener
+    newName: registry.digitalocean.com/aztlan-containers/aztec-listener-testnet
+    newTag: latest
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: aztec-listener
+      spec:
+        template:
+          spec:
+            containers:
+              - name: aztec-listener
+                env:
+                  - name: INSTANCE_NAME
+                    value: "testnet_aztec-listener"
+                  - name: L2_NETWORK_ID
+                    value: "TESTNET"
+                  - name: AZTEC_RPC_URLS
+                    valueFrom:
+                      secretKeyRef:
+                        name: testnet-config
+                        key: AZTEC_RPC_NODES_TESTNET
+                  - name: AZTEC_DISABLE_ETERNAL_CATCHUP
+                    value: "false"
+                  - name: NODE_OPTIONS
+                    value: "--max-old-space-size=1536"

--- a/services/aztec-listener/k8s/overlays/testnet/postgres-config.yaml
+++ b/services/aztec-listener/k8s/overlays/testnet/postgres-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-config-aztec-listener # nameSuffix appends -testnet → postgres-config-aztec-listener-testnet
+  namespace: chicmoz-prod
+data:
+  POSTGRES_DB_NAME: "aztec_listener_testnet"

--- a/services/compiler-orchestrator/k8s/base/deployment.yaml
+++ b/services/compiler-orchestrator/k8s/base/deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: compiler-orchestrator
+  labels:
+    app: compiler-orchestrator
+    app.kubernetes.io/name: compiler-orchestrator
+    app.kubernetes.io/part-of: chicmoz-prod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: compiler-orchestrator
+  template:
+    metadata:
+      labels:
+        app: compiler-orchestrator
+    spec:
+      imagePullSecrets:
+        - name: registry-aztlan-containers
+      serviceAccountName: compiler-orchestrator
+      containers:
+        - name: compiler-orchestrator
+          image: registry.digitalocean.com/aztlan-containers/compiler-orchestrator
+          imagePullPolicy: Always
+          resources:
+            limits:
+              memory: 256Mi
+              cpu: 250m
+          livenessProbe:
+            exec:
+              command: ["node", "-e", "process.exit(0)"]
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            exec:
+              command: ["node", "-e", "process.exit(0)"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          env:
+            - name: NODE_ENV
+              value: "production"
+            - name: K8S_NAMESPACE
+              value: "chicmoz-prod"
+            - name: MAX_CONCURRENT_JOBS
+              value: "3"
+            - name: JOB_TIMEOUT_SECONDS
+              value: "300"
+            - name: IMAGE_PULL_SECRET
+              value: "registry-aztlan-containers"

--- a/services/compiler-orchestrator/k8s/base/kustomization.yaml
+++ b/services/compiler-orchestrator/k8s/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - rbac.yaml

--- a/services/compiler-orchestrator/k8s/base/rbac.yaml
+++ b/services/compiler-orchestrator/k8s/base/rbac.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: compiler-orchestrator
+  namespace: chicmoz-prod
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: compiler-orchestrator-role
+  namespace: chicmoz-prod
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create", "get", "list", "watch", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["create", "get", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create", "get", "list", "watch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: compiler-orchestrator-rolebinding
+  namespace: chicmoz-prod
+subjects:
+  - kind: ServiceAccount
+    name: compiler-orchestrator
+    namespace: chicmoz-prod
+roleRef:
+  kind: Role
+  name: compiler-orchestrator-role
+  apiGroup: rbac.authorization.k8s.io

--- a/services/compiler-orchestrator/k8s/overlays/devnet/kustomization.yaml
+++ b/services/compiler-orchestrator/k8s/overlays/devnet/kustomization.yaml
@@ -1,0 +1,32 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: chicmoz-prod
+nameSuffix: -devnet
+
+resources:
+  - ../../base
+
+images:
+  - name: registry.digitalocean.com/aztlan-containers/compiler-orchestrator
+    newName: registry.digitalocean.com/aztlan-containers/compiler-orchestrator-devnet
+    newTag: latest
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: compiler-orchestrator
+      spec:
+        template:
+          spec:
+            containers:
+              - name: compiler-orchestrator
+                env:
+                  - name: INSTANCE_NAME
+                    value: "devnet_compiler-orchestrator"
+                  - name: L2_NETWORK_ID
+                    value: "DEVNET"
+                  - name: COMPILER_IMAGE
+                    value: "registry.digitalocean.com/aztlan-containers/contract-compiler-devnet:4.2.0"

--- a/services/compiler-orchestrator/k8s/overlays/mainnet/kustomization.yaml
+++ b/services/compiler-orchestrator/k8s/overlays/mainnet/kustomization.yaml
@@ -1,0 +1,32 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: chicmoz-prod
+nameSuffix: -mainnet
+
+resources:
+  - ../../base
+
+images:
+  - name: registry.digitalocean.com/aztlan-containers/compiler-orchestrator
+    newName: registry.digitalocean.com/aztlan-containers/compiler-orchestrator-mainnet
+    newTag: latest
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: compiler-orchestrator
+      spec:
+        template:
+          spec:
+            containers:
+              - name: compiler-orchestrator
+                env:
+                  - name: INSTANCE_NAME
+                    value: "mainnet_compiler-orchestrator"
+                  - name: L2_NETWORK_ID
+                    value: "MAINNET"
+                  - name: COMPILER_IMAGE
+                    value: "registry.digitalocean.com/aztlan-containers/contract-compiler-mainnet:4.2.0"

--- a/services/compiler-orchestrator/k8s/overlays/testnet/kustomization.yaml
+++ b/services/compiler-orchestrator/k8s/overlays/testnet/kustomization.yaml
@@ -1,0 +1,32 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: chicmoz-prod
+nameSuffix: -testnet
+
+resources:
+  - ../../base
+
+images:
+  - name: registry.digitalocean.com/aztlan-containers/compiler-orchestrator
+    newName: registry.digitalocean.com/aztlan-containers/compiler-orchestrator-testnet
+    newTag: latest
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: compiler-orchestrator
+      spec:
+        template:
+          spec:
+            containers:
+              - name: compiler-orchestrator
+                env:
+                  - name: INSTANCE_NAME
+                    value: "testnet_compiler-orchestrator"
+                  - name: L2_NETWORK_ID
+                    value: "TESTNET"
+                  - name: COMPILER_IMAGE
+                    value: "registry.digitalocean.com/aztlan-containers/contract-compiler-testnet:4.2.0"

--- a/services/ethereum-listener/k8s/base/deployment.yaml
+++ b/services/ethereum-listener/k8s/base/deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ethereum-listener
+  labels:
+    app: ethereum-listener
+    app.kubernetes.io/name: ethereum-listener
+    app.kubernetes.io/part-of: chicmoz-prod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ethereum-listener
+  template:
+    metadata:
+      labels:
+        app: ethereum-listener
+    spec:
+      imagePullSecrets:
+        - name: registry-aztlan-containers
+      initContainers:
+        - name: run-migrations
+          image: registry.digitalocean.com/aztlan-containers/ethereum-listener
+          command: ["yarn", "run", "migrate"]
+          envFrom:
+            - configMapRef:
+                name: postgres-config-global
+            - configMapRef:
+                name: postgres-config-ethereum-listener # nameSuffix appends network suffix
+          env:
+            - name: TOTAL_DB_RESET
+              value: "false"
+      containers:
+        - name: ethereum-listener
+          image: registry.digitalocean.com/aztlan-containers/ethereum-listener
+          imagePullPolicy: Always
+          resources:
+            limits:
+              memory: 300Mi
+              cpu: 500m
+          envFrom:
+            - configMapRef:
+                name: postgres-config-global
+            - configMapRef:
+                name: postgres-config-ethereum-listener # nameSuffix appends network suffix
+          env:
+            - name: NODE_ENV
+              value: "production"
+            - name: LISTENER_DISABLED
+              value: "false"
+            - name: LISTEN_FOR_BLOCKS
+              value: "true"

--- a/services/ethereum-listener/k8s/base/kustomization.yaml
+++ b/services/ethereum-listener/k8s/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml

--- a/services/ethereum-listener/k8s/overlays/devnet/kustomization.yaml
+++ b/services/ethereum-listener/k8s/overlays/devnet/kustomization.yaml
@@ -1,0 +1,46 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: chicmoz-prod
+nameSuffix: -devnet
+
+resources:
+  - ../../base
+  - postgres-config.yaml
+
+images:
+  - name: registry.digitalocean.com/aztlan-containers/ethereum-listener
+    newName: registry.digitalocean.com/aztlan-containers/ethereum-listener-devnet
+    newTag: latest
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: ethereum-listener
+      spec:
+        template:
+          spec:
+            containers:
+              - name: ethereum-listener
+                env:
+                  - name: INSTANCE_NAME
+                    value: "ethereum-listener-devnet"
+                  - name: L2_NETWORK_ID
+                    value: "DEVNET"
+                  - name: ETHEREUM_HTTP_RPC_URL
+                    valueFrom:
+                      secretKeyRef:
+                        name: devnet-config
+                        key: DEVNET_AZTEC_L1_HTTP
+                  - name: ETHEREUM_WS_RPC_URL
+                    valueFrom:
+                      secretKeyRef:
+                        name: devnet-config
+                        key: DEVNET_AZTEC_L1_WS
+                  - name: ETHEREUM_ALCHEMY_HTTP_URL
+                    valueFrom:
+                      secretKeyRef:
+                        name: devnet-config
+                        key: ETHEREUM_HTTP_ALCHEMY_SEPOLIA_URL

--- a/services/ethereum-listener/k8s/overlays/devnet/kustomization.yaml
+++ b/services/ethereum-listener/k8s/overlays/devnet/kustomization.yaml
@@ -32,15 +32,15 @@ patches:
                   - name: ETHEREUM_HTTP_RPC_URL
                     valueFrom:
                       secretKeyRef:
-                        name: devnet-config
+                        name: ethereum-listener-devnet
                         key: DEVNET_AZTEC_L1_HTTP
                   - name: ETHEREUM_WS_RPC_URL
                     valueFrom:
                       secretKeyRef:
-                        name: devnet-config
+                        name: ethereum-listener-devnet
                         key: DEVNET_AZTEC_L1_WS
                   - name: ETHEREUM_ALCHEMY_HTTP_URL
                     valueFrom:
                       secretKeyRef:
-                        name: devnet-config
+                        name: ethereum-listener-devnet
                         key: ETHEREUM_HTTP_ALCHEMY_SEPOLIA_URL

--- a/services/ethereum-listener/k8s/overlays/devnet/postgres-config.yaml
+++ b/services/ethereum-listener/k8s/overlays/devnet/postgres-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-config-ethereum-listener # nameSuffix appends -devnet → postgres-config-ethereum-listener-devnet
+  namespace: chicmoz-prod
+data:
+  POSTGRES_DB_NAME: "ethereum_listener_devnet"

--- a/services/ethereum-listener/k8s/overlays/mainnet/kustomization.yaml
+++ b/services/ethereum-listener/k8s/overlays/mainnet/kustomization.yaml
@@ -32,15 +32,15 @@ patches:
                   - name: ETHEREUM_HTTP_RPC_URL
                     valueFrom:
                       secretKeyRef:
-                        name: mainnet-config
+                        name: ethereum-listener-mainnet
                         key: MAINNET_AZTEC_L1_HTTP
                   - name: ETHEREUM_WS_RPC_URL
                     valueFrom:
                       secretKeyRef:
-                        name: mainnet-config
+                        name: ethereum-listener-mainnet
                         key: MAINNET_AZTEC_L1_WS
                   - name: ETHEREUM_ALCHEMY_HTTP_URL
                     valueFrom:
                       secretKeyRef:
-                        name: mainnet-config
+                        name: ethereum-listener-mainnet
                         key: ETHEREUM_HTTP_ALCHEMY_MAINNET_URL

--- a/services/ethereum-listener/k8s/overlays/mainnet/kustomization.yaml
+++ b/services/ethereum-listener/k8s/overlays/mainnet/kustomization.yaml
@@ -1,0 +1,46 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: chicmoz-prod
+nameSuffix: -mainnet
+
+resources:
+  - ../../base
+  - postgres-config.yaml
+
+images:
+  - name: registry.digitalocean.com/aztlan-containers/ethereum-listener
+    newName: registry.digitalocean.com/aztlan-containers/ethereum-listener-mainnet
+    newTag: latest
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: ethereum-listener
+      spec:
+        template:
+          spec:
+            containers:
+              - name: ethereum-listener
+                env:
+                  - name: INSTANCE_NAME
+                    value: "ethereum-listener-mainnet"
+                  - name: L2_NETWORK_ID
+                    value: "MAINNET"
+                  - name: ETHEREUM_HTTP_RPC_URL
+                    valueFrom:
+                      secretKeyRef:
+                        name: mainnet-config
+                        key: MAINNET_AZTEC_L1_HTTP
+                  - name: ETHEREUM_WS_RPC_URL
+                    valueFrom:
+                      secretKeyRef:
+                        name: mainnet-config
+                        key: MAINNET_AZTEC_L1_WS
+                  - name: ETHEREUM_ALCHEMY_HTTP_URL
+                    valueFrom:
+                      secretKeyRef:
+                        name: mainnet-config
+                        key: ETHEREUM_HTTP_ALCHEMY_MAINNET_URL

--- a/services/ethereum-listener/k8s/overlays/mainnet/postgres-config.yaml
+++ b/services/ethereum-listener/k8s/overlays/mainnet/postgres-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-config-ethereum-listener # nameSuffix appends -mainnet → postgres-config-ethereum-listener-mainnet
+  namespace: chicmoz-prod
+data:
+  POSTGRES_DB_NAME: "ethereum_listener_mainnet"

--- a/services/ethereum-listener/k8s/overlays/testnet/kustomization.yaml
+++ b/services/ethereum-listener/k8s/overlays/testnet/kustomization.yaml
@@ -32,15 +32,15 @@ patches:
                   - name: ETHEREUM_HTTP_RPC_URL
                     valueFrom:
                       secretKeyRef:
-                        name: testnet-config
+                        name: ethereum-listener-testnet
                         key: TESTNET_AZTEC_L1_HTTP
                   - name: ETHEREUM_WS_RPC_URL
                     valueFrom:
                       secretKeyRef:
-                        name: testnet-config
+                        name: ethereum-listener-testnet
                         key: TESTNET_AZTEC_L1_WS
                   - name: ETHEREUM_ALCHEMY_HTTP_URL
                     valueFrom:
                       secretKeyRef:
-                        name: testnet-config
+                        name: ethereum-listener-testnet
                         key: ETHEREUM_HTTP_ALCHEMY_SEPOLIA_URL

--- a/services/ethereum-listener/k8s/overlays/testnet/kustomization.yaml
+++ b/services/ethereum-listener/k8s/overlays/testnet/kustomization.yaml
@@ -1,0 +1,46 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: chicmoz-prod
+nameSuffix: -testnet
+
+resources:
+  - ../../base
+  - postgres-config.yaml
+
+images:
+  - name: registry.digitalocean.com/aztlan-containers/ethereum-listener
+    newName: registry.digitalocean.com/aztlan-containers/ethereum-listener-testnet
+    newTag: latest
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: ethereum-listener
+      spec:
+        template:
+          spec:
+            containers:
+              - name: ethereum-listener
+                env:
+                  - name: INSTANCE_NAME
+                    value: "ethereum-listener-testnet"
+                  - name: L2_NETWORK_ID
+                    value: "TESTNET"
+                  - name: ETHEREUM_HTTP_RPC_URL
+                    valueFrom:
+                      secretKeyRef:
+                        name: testnet-config
+                        key: TESTNET_AZTEC_L1_HTTP
+                  - name: ETHEREUM_WS_RPC_URL
+                    valueFrom:
+                      secretKeyRef:
+                        name: testnet-config
+                        key: TESTNET_AZTEC_L1_WS
+                  - name: ETHEREUM_ALCHEMY_HTTP_URL
+                    valueFrom:
+                      secretKeyRef:
+                        name: testnet-config
+                        key: ETHEREUM_HTTP_ALCHEMY_SEPOLIA_URL

--- a/services/ethereum-listener/k8s/overlays/testnet/postgres-config.yaml
+++ b/services/ethereum-listener/k8s/overlays/testnet/postgres-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-config-ethereum-listener # nameSuffix appends -testnet → postgres-config-ethereum-listener-testnet
+  namespace: chicmoz-prod
+data:
+  POSTGRES_DB_NAME: "ethereum_listener_testnet"

--- a/services/explorer-api/k8s/base/deployment.yaml
+++ b/services/explorer-api/k8s/base/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: explorer-api
+  labels:
+    app: explorer-api
+    app.kubernetes.io/name: explorer-api
+    app.kubernetes.io/part-of: chicmoz-prod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: explorer-api
+  template:
+    metadata:
+      labels:
+        app: explorer-api
+    spec:
+      imagePullSecrets:
+        - name: registry-aztlan-containers
+      initContainers:
+        - name: run-migrations
+          image: registry.digitalocean.com/aztlan-containers/explorer-api
+          command: ["yarn", "run", "migrate"]
+          envFrom:
+            - configMapRef:
+                name: postgres-config-global
+            - configMapRef:
+                name: postgres-config-explorer-api # nameSuffix appends network suffix → postgres-config-explorer-api-{network}
+          env:
+            - name: NODE_ENV
+              value: "production"
+            - name: TOTAL_DB_RESET
+              value: "false"
+      containers:
+        - name: explorer-api
+          image: registry.digitalocean.com/aztlan-containers/explorer-api
+          imagePullPolicy: Always
+          resources:
+            limits:
+              memory: 1024Mi
+              cpu: 500m
+          ports:
+            - name: http-app-port
+              containerPort: 80
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: postgres-config-global
+            - configMapRef:
+                name: postgres-config-explorer-api # nameSuffix appends network suffix → postgres-config-explorer-api-{network}
+          env:
+            - name: NODE_ENV
+              value: "production"
+            - name: PUBLIC_API_KEY
+              value: "temporary-api-key"
+          readinessProbe:
+            httpGet:
+              # /health is a strict composite health check (DB + CACHE + MB) and
+              # can return 500 even when the HTTP server and DB are usable.
+              # For readiness we only need the pod to accept traffic.
+              path: /open-api-specification
+              port: 80
+            initialDelaySeconds: 15
+            periodSeconds: 10

--- a/services/explorer-api/k8s/base/kustomization.yaml
+++ b/services/explorer-api/k8s/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/services/explorer-api/k8s/base/service.yaml
+++ b/services/explorer-api/k8s/base/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: explorer-api
+  labels:
+    app.kubernetes.io/name: explorer-api
+    app.kubernetes.io/part-of: chicmoz-prod
+spec:
+  selector:
+    app: explorer-api
+  ports:
+    - name: http-app
+      protocol: TCP
+      port: 80
+      targetPort: http-app-port

--- a/services/explorer-api/k8s/overlays/devnet/http-filter.yaml
+++ b/services/explorer-api/k8s/overlays/devnet/http-filter.yaml
@@ -1,0 +1,12 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: HTTPRouteFilter
+metadata:
+  name: explorer-api-rewrite # nameSuffix appends -devnet → explorer-api-rewrite-devnet
+  namespace: chicmoz-prod
+spec:
+  urlRewrite:
+    path:
+      type: ReplaceRegexMatch
+      replaceRegexMatch:
+        pattern: ^/v1/[^/]+/(.*)$
+        substitution: '/\1'

--- a/services/explorer-api/k8s/overlays/devnet/httproute.yaml
+++ b/services/explorer-api/k8s/overlays/devnet/httproute.yaml
@@ -23,5 +23,5 @@ spec:
             kind: HTTPRouteFilter
             name: explorer-api-rewrite-devnet # hardcoded — nameSuffix does NOT transform extensionRef
       backendRefs:
-        - name: explorer-api-devnet-service # hardcoded — nameSuffix does NOT transform backendRefs
+        - name: explorer-api-devnet # hardcoded — nameSuffix does NOT transform backendRefs
           port: 80

--- a/services/explorer-api/k8s/overlays/devnet/httproute.yaml
+++ b/services/explorer-api/k8s/overlays/devnet/httproute.yaml
@@ -1,0 +1,27 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: explorer-api # nameSuffix appends -devnet → explorer-api-devnet
+  namespace: chicmoz-prod
+spec:
+  parentRefs:
+    - name: aztecscan-gateway
+      sectionName: api-devnet-http
+    - name: aztecscan-gateway
+      sectionName: api-devnet-https
+  hostnames:
+    - api.devnet.aztecscan.xyz
+  rules:
+    - matches:
+        - path:
+            type: RegularExpression
+            value: /v1/([^/]+)/(.*)
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: gateway.envoyproxy.io
+            kind: HTTPRouteFilter
+            name: explorer-api-rewrite-devnet # hardcoded — nameSuffix does NOT transform extensionRef
+      backendRefs:
+        - name: explorer-api-devnet-service # hardcoded — nameSuffix does NOT transform backendRefs
+          port: 80

--- a/services/explorer-api/k8s/overlays/devnet/kustomization.yaml
+++ b/services/explorer-api/k8s/overlays/devnet/kustomization.yaml
@@ -1,0 +1,41 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: chicmoz-prod
+nameSuffix: -devnet
+
+resources:
+  - ../../base
+  - httproute.yaml
+  - postgres-config.yaml
+  - http-filter.yaml
+  - securitypolicy.yaml
+
+images:
+  - name: registry.digitalocean.com/aztlan-containers/explorer-api
+    newName: registry.digitalocean.com/aztlan-containers/explorer-api-devnet
+    newTag: latest
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: explorer-api
+      spec:
+        template:
+          spec:
+            containers:
+              - name: explorer-api
+                env:
+                  - name: INSTANCE_NAME
+                    value: "devnet_explorer-api"
+                  - name: L2_NETWORK_ID
+                    value: "DEVNET"
+                  - name: REDIS_HOST
+                    value: "redis-cache"
+            initContainers:
+              - name: run-migrations
+                env:
+                  - name: INSTANCE_NAME
+                    value: "devnet_explorer-api"

--- a/services/explorer-api/k8s/overlays/devnet/kustomization.yaml
+++ b/services/explorer-api/k8s/overlays/devnet/kustomization.yaml
@@ -39,3 +39,27 @@ patches:
                 env:
                   - name: INSTANCE_NAME
                     value: "devnet_explorer-api"
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: explorer-api
+      spec:
+        selector:
+          matchLabels:
+            app: explorer-api
+            network: devnet
+        template:
+          metadata:
+            labels:
+              app: explorer-api
+              network: devnet
+  - patch: |-
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: explorer-api
+      spec:
+        selector:
+          app: explorer-api
+          network: devnet

--- a/services/explorer-api/k8s/overlays/devnet/postgres-config.yaml
+++ b/services/explorer-api/k8s/overlays/devnet/postgres-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-config-explorer-api # nameSuffix appends -devnet → postgres-config-explorer-api-devnet
+  namespace: chicmoz-prod
+data:
+  POSTGRES_DB_NAME: "explorer_api_devnet"

--- a/services/explorer-api/k8s/overlays/devnet/securitypolicy.yaml
+++ b/services/explorer-api/k8s/overlays/devnet/securitypolicy.yaml
@@ -1,0 +1,56 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: explorer-api-security # nameSuffix appends -devnet → explorer-api-security-devnet
+  namespace: chicmoz-prod
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: explorer-api-devnet # hardcoded — nameSuffix does NOT transform targetRefs
+  cors:
+    allowOrigins:
+      - "https://docs.aztecscan.xyz"
+      - "https://devnet.aztecscan.xyz"
+    allowMethods:
+      - GET
+      - PUT
+      - POST
+      - DELETE
+      - PATCH
+      - OPTIONS
+    allowHeaders:
+      - DNT
+      - Keep-Alive
+      - User-Agent
+      - X-Requested-With
+      - If-Modified-Since
+      - Cache-Control
+      - Content-Type
+      - Range
+      - Authorization
+      - access-control-allow-credentials
+      - X-Api-Key
+    allowCredentials: true
+    exposeHeaders:
+      - x-api-key
+    maxAge: 24h
+  extAuth:
+    timeout: 5s
+    http:
+      backendRefs:
+        - name: auth-service # hardcoded — auth service name is stable, no suffix
+          namespace: chicmoz-prod
+          port: 80
+      path: /_external-auth-envoy
+      headersToBackend:
+        - x-forwarded-for
+        - x-forwarded-proto
+        - x-forwarded-host
+        - x-forwarded-uri
+        - x-envoy-original-path
+        - x-request-id
+        - ":authority"
+        - ":scheme"
+        - ":path"
+    failOpen: false

--- a/services/explorer-api/k8s/overlays/mainnet/http-filter.yaml
+++ b/services/explorer-api/k8s/overlays/mainnet/http-filter.yaml
@@ -1,0 +1,12 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: HTTPRouteFilter
+metadata:
+  name: explorer-api-rewrite # nameSuffix appends -mainnet → explorer-api-rewrite-mainnet
+  namespace: chicmoz-prod
+spec:
+  urlRewrite:
+    path:
+      type: ReplaceRegexMatch
+      replaceRegexMatch:
+        pattern: ^/v1/[^/]+/(.*)$
+        substitution: '/\1'

--- a/services/explorer-api/k8s/overlays/mainnet/httproute.yaml
+++ b/services/explorer-api/k8s/overlays/mainnet/httproute.yaml
@@ -39,5 +39,5 @@ spec:
             kind: HTTPRouteFilter
             name: explorer-api-rewrite-mainnet # hardcoded — nameSuffix does NOT transform extensionRef
       backendRefs:
-        - name: explorer-api-mainnet-service # hardcoded — nameSuffix does NOT transform backendRefs
+        - name: explorer-api-mainnet # hardcoded — nameSuffix does NOT transform backendRefs
           port: 80

--- a/services/explorer-api/k8s/overlays/mainnet/httproute.yaml
+++ b/services/explorer-api/k8s/overlays/mainnet/httproute.yaml
@@ -1,0 +1,43 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: explorer-api # nameSuffix appends -mainnet → explorer-api-mainnet
+  namespace: chicmoz-prod
+  labels:
+    app.kubernetes.io/name: explorer-api
+    app.kubernetes.io/part-of: chicmoz-prod
+spec:
+  parentRefs:
+    - name: aztecscan-gateway
+      sectionName: api-http
+    - name: aztecscan-gateway
+      sectionName: api-https
+    - name: aztecscan-gateway
+      sectionName: api-mainnet-http
+    - name: aztecscan-gateway
+      sectionName: api-mainnet-https
+    - name: aztecscan-gateway
+      sectionName: api-primary-http
+    - name: aztecscan-gateway
+      sectionName: api-primary-https
+    - name: aztecscan-gateway
+      sectionName: api-mainnet-primary-http
+    - name: aztecscan-gateway
+      sectionName: api-mainnet-primary-https
+  hostnames:
+    - api.aztecscan.xyz
+    - api.mainnet.aztecscan.xyz
+  rules:
+    - matches:
+        - path:
+            type: RegularExpression
+            value: /v1/([^/]+)/(.*)
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: gateway.envoyproxy.io
+            kind: HTTPRouteFilter
+            name: explorer-api-rewrite-mainnet # hardcoded — nameSuffix does NOT transform extensionRef
+      backendRefs:
+        - name: explorer-api-mainnet-service # hardcoded — nameSuffix does NOT transform backendRefs
+          port: 80

--- a/services/explorer-api/k8s/overlays/mainnet/kustomization.yaml
+++ b/services/explorer-api/k8s/overlays/mainnet/kustomization.yaml
@@ -37,3 +37,27 @@ patches:
                 env:
                   - name: INSTANCE_NAME
                     value: "mainnet_explorer-api"
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: explorer-api
+      spec:
+        selector:
+          matchLabels:
+            app: explorer-api
+            network: mainnet
+        template:
+          metadata:
+            labels:
+              app: explorer-api
+              network: mainnet
+  - patch: |-
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: explorer-api
+      spec:
+        selector:
+          app: explorer-api
+          network: mainnet

--- a/services/explorer-api/k8s/overlays/mainnet/kustomization.yaml
+++ b/services/explorer-api/k8s/overlays/mainnet/kustomization.yaml
@@ -1,0 +1,39 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: chicmoz-prod
+nameSuffix: -mainnet
+
+resources:
+  - ../../base
+  - httproute.yaml
+  - postgres-config.yaml
+  - http-filter.yaml
+  - securitypolicy.yaml
+
+images:
+  - name: registry.digitalocean.com/aztlan-containers/explorer-api
+    newName: registry.digitalocean.com/aztlan-containers/explorer-api-mainnet
+    newTag: latest
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: explorer-api
+      spec:
+        template:
+          spec:
+            containers:
+              - name: explorer-api
+                env:
+                  - name: INSTANCE_NAME
+                    value: "mainnet_explorer-api"
+                  - name: L2_NETWORK_ID
+                    value: "MAINNET"
+            initContainers:
+              - name: run-migrations
+                env:
+                  - name: INSTANCE_NAME
+                    value: "mainnet_explorer-api"

--- a/services/explorer-api/k8s/overlays/mainnet/postgres-config.yaml
+++ b/services/explorer-api/k8s/overlays/mainnet/postgres-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-config-explorer-api # nameSuffix appends -mainnet → postgres-config-explorer-api-mainnet
+  namespace: chicmoz-prod
+data:
+  POSTGRES_DB_NAME: "explorer_api_mainnet"

--- a/services/explorer-api/k8s/overlays/mainnet/securitypolicy.yaml
+++ b/services/explorer-api/k8s/overlays/mainnet/securitypolicy.yaml
@@ -1,0 +1,58 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: explorer-api-security # nameSuffix appends -mainnet → explorer-api-security-mainnet
+  namespace: chicmoz-prod
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: explorer-api-mainnet # hardcoded — nameSuffix does NOT transform targetRefs
+  cors:
+    allowOrigins:
+      - https://aztecscan.xyz
+      - https://mainnet.aztecscan.xyz
+      - https://api.aztecscan.xyz
+      - https://docs.aztecscan.xyz
+    allowMethods:
+      - GET
+      - PUT
+      - POST
+      - DELETE
+      - PATCH
+      - OPTIONS
+    allowHeaders:
+      - DNT
+      - Keep-Alive
+      - User-Agent
+      - X-Requested-With
+      - If-Modified-Since
+      - Cache-Control
+      - Content-Type
+      - Range
+      - Authorization
+      - access-control-allow-credentials
+      - x-api-key
+    allowCredentials: true
+    exposeHeaders:
+      - x-api-key
+    maxAge: 24h
+  extAuth:
+    timeout: 5s
+    http:
+      backendRefs:
+        - name: auth-service # hardcoded — auth service name is stable, no suffix
+          namespace: chicmoz-prod
+          port: 80
+      path: /_external-auth-envoy
+      headersToBackend:
+        - x-forwarded-for
+        - x-forwarded-proto
+        - x-forwarded-host
+        - x-forwarded-uri
+        - x-envoy-original-path
+        - x-request-id
+        - ":authority"
+        - ":scheme"
+        - ":path"
+    failOpen: false

--- a/services/explorer-api/k8s/overlays/testnet/http-filter.yaml
+++ b/services/explorer-api/k8s/overlays/testnet/http-filter.yaml
@@ -1,0 +1,12 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: HTTPRouteFilter
+metadata:
+  name: explorer-api-rewrite # nameSuffix appends -testnet → explorer-api-rewrite-testnet
+  namespace: chicmoz-prod
+spec:
+  urlRewrite:
+    path:
+      type: ReplaceRegexMatch
+      replaceRegexMatch:
+        pattern: ^/v1/[^/]+/(.*)$
+        substitution: '/\1'

--- a/services/explorer-api/k8s/overlays/testnet/httproute.yaml
+++ b/services/explorer-api/k8s/overlays/testnet/httproute.yaml
@@ -1,0 +1,34 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: explorer-api # nameSuffix appends -testnet → explorer-api-testnet
+  namespace: chicmoz-prod
+  labels:
+    app.kubernetes.io/name: explorer-api
+    app.kubernetes.io/part-of: chicmoz-prod
+spec:
+  parentRefs:
+    - name: aztecscan-gateway
+      sectionName: api-testnet-http
+    - name: aztecscan-gateway
+      sectionName: api-testnet-https
+    - name: aztecscan-gateway
+      sectionName: api-testnet-primary-http
+    - name: aztecscan-gateway
+      sectionName: api-testnet-primary-https
+  hostnames:
+    - api.testnet.aztecscan.xyz
+  rules:
+    - matches:
+        - path:
+            type: RegularExpression
+            value: /v1/([^/]+)/(.*)
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: gateway.envoyproxy.io
+            kind: HTTPRouteFilter
+            name: explorer-api-rewrite-testnet # hardcoded — nameSuffix does NOT transform extensionRef
+      backendRefs:
+        - name: explorer-api-testnet-service # hardcoded — nameSuffix does NOT transform backendRefs
+          port: 80

--- a/services/explorer-api/k8s/overlays/testnet/httproute.yaml
+++ b/services/explorer-api/k8s/overlays/testnet/httproute.yaml
@@ -30,5 +30,5 @@ spec:
             kind: HTTPRouteFilter
             name: explorer-api-rewrite-testnet # hardcoded — nameSuffix does NOT transform extensionRef
       backendRefs:
-        - name: explorer-api-testnet-service # hardcoded — nameSuffix does NOT transform backendRefs
+        - name: explorer-api-testnet # hardcoded — nameSuffix does NOT transform backendRefs
           port: 80

--- a/services/explorer-api/k8s/overlays/testnet/kustomization.yaml
+++ b/services/explorer-api/k8s/overlays/testnet/kustomization.yaml
@@ -1,0 +1,39 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: chicmoz-prod
+nameSuffix: -testnet
+
+resources:
+  - ../../base
+  - httproute.yaml
+  - postgres-config.yaml
+  - http-filter.yaml
+  - securitypolicy.yaml
+
+images:
+  - name: registry.digitalocean.com/aztlan-containers/explorer-api
+    newName: registry.digitalocean.com/aztlan-containers/explorer-api-testnet
+    newTag: latest
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: explorer-api
+      spec:
+        template:
+          spec:
+            containers:
+              - name: explorer-api
+                env:
+                  - name: INSTANCE_NAME
+                    value: "testnet_explorer-api"
+                  - name: L2_NETWORK_ID
+                    value: "TESTNET"
+            initContainers:
+              - name: run-migrations
+                env:
+                  - name: INSTANCE_NAME
+                    value: "testnet_explorer-api"

--- a/services/explorer-api/k8s/overlays/testnet/kustomization.yaml
+++ b/services/explorer-api/k8s/overlays/testnet/kustomization.yaml
@@ -37,3 +37,27 @@ patches:
                 env:
                   - name: INSTANCE_NAME
                     value: "testnet_explorer-api"
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: explorer-api
+      spec:
+        selector:
+          matchLabels:
+            app: explorer-api
+            network: testnet
+        template:
+          metadata:
+            labels:
+              app: explorer-api
+              network: testnet
+  - patch: |-
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: explorer-api
+      spec:
+        selector:
+          app: explorer-api
+          network: testnet

--- a/services/explorer-api/k8s/overlays/testnet/postgres-config.yaml
+++ b/services/explorer-api/k8s/overlays/testnet/postgres-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-config-explorer-api # nameSuffix appends -testnet → postgres-config-explorer-api-testnet
+  namespace: chicmoz-prod
+data:
+  POSTGRES_DB_NAME: "explorer_api_testnet"

--- a/services/explorer-api/k8s/overlays/testnet/securitypolicy.yaml
+++ b/services/explorer-api/k8s/overlays/testnet/securitypolicy.yaml
@@ -1,0 +1,56 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: explorer-api-security # nameSuffix appends -testnet → explorer-api-security-testnet
+  namespace: chicmoz-prod
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: explorer-api-testnet # hardcoded — nameSuffix does NOT transform targetRefs
+  cors:
+    allowOrigins:
+      - https://testnet.aztecscan.xyz
+      - https://docs.aztecscan.xyz
+    allowMethods:
+      - GET
+      - PUT
+      - POST
+      - DELETE
+      - PATCH
+      - OPTIONS
+    allowHeaders:
+      - DNT
+      - Keep-Alive
+      - User-Agent
+      - X-Requested-With
+      - If-Modified-Since
+      - Cache-Control
+      - Content-Type
+      - Range
+      - Authorization
+      - access-control-allow-credentials
+      - x-api-key
+    allowCredentials: true
+    exposeHeaders:
+      - x-api-key
+    maxAge: 24h
+  extAuth:
+    timeout: 5s
+    http:
+      backendRefs:
+        - name: auth-service # hardcoded — auth service name is stable, no suffix
+          namespace: chicmoz-prod
+          port: 80
+      path: /_external-auth-envoy
+      headersToBackend:
+        - x-forwarded-for
+        - x-forwarded-proto
+        - x-forwarded-host
+        - x-forwarded-uri
+        - x-envoy-original-path
+        - x-request-id
+        - ":authority"
+        - ":scheme"
+        - ":path"
+    failOpen: false

--- a/services/explorer-ui-v2/k8s/overlays/devnet/httproute.yaml
+++ b/services/explorer-ui-v2/k8s/overlays/devnet/httproute.yaml
@@ -1,0 +1,24 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: explorer-ui-v2
+  namespace: chicmoz-prod
+  labels:
+    app.kubernetes.io/name: explorer-ui-v2
+    app.kubernetes.io/part-of: chicmoz-prod
+spec:
+  parentRefs:
+    - name: aztecscan-gateway
+      sectionName: ui-v2-devnet-http
+    - name: aztecscan-gateway
+      sectionName: ui-v2-devnet-https
+  hostnames:
+    - v2.devnet.aztecscan.xyz
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: explorer-ui-v2-devnet # hardcoded — nameSuffix does NOT transform backendRefs
+          port: 80

--- a/services/explorer-ui-v2/k8s/overlays/devnet/kustomization.yaml
+++ b/services/explorer-ui-v2/k8s/overlays/devnet/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: chicmoz-prod
+nameSuffix: -devnet
+
+resources:
+  - ../../base
+  - httproute.yaml
+
+images:
+  - name: registry.digitalocean.com/aztlan-containers/explorer-ui-v2
+    newTag: devnet-latest

--- a/services/explorer-ui-v2/k8s/overlays/mainnet/httproute.yaml
+++ b/services/explorer-ui-v2/k8s/overlays/mainnet/httproute.yaml
@@ -1,0 +1,24 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: explorer-ui-v2
+  namespace: chicmoz-prod
+  labels:
+    app.kubernetes.io/name: explorer-ui-v2
+    app.kubernetes.io/part-of: chicmoz-prod
+spec:
+  parentRefs:
+    - name: aztecscan-gateway
+      sectionName: ui-v2-mainnet-http
+    - name: aztecscan-gateway
+      sectionName: ui-v2-mainnet-https
+  hostnames:
+    - v2.aztecscan.xyz
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: explorer-ui-v2-mainnet # hardcoded — nameSuffix does NOT transform backendRefs
+          port: 80

--- a/services/explorer-ui-v2/k8s/overlays/mainnet/kustomization.yaml
+++ b/services/explorer-ui-v2/k8s/overlays/mainnet/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: chicmoz-prod
+nameSuffix: -mainnet
+
+resources:
+  - ../../base
+  - httproute.yaml
+
+images:
+  - name: registry.digitalocean.com/aztlan-containers/explorer-ui-v2
+    newTag: mainnet-latest

--- a/services/explorer-ui/k8s/base/deployment.yaml
+++ b/services/explorer-ui/k8s/base/deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: explorer-ui
+  labels:
+    app: explorer-ui
+    app.kubernetes.io/name: explorer-ui
+    app.kubernetes.io/part-of: chicmoz-prod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: explorer-ui
+  template:
+    metadata:
+      labels:
+        app: explorer-ui
+    spec:
+      imagePullSecrets:
+        - name: registry-aztlan-containers
+      containers:
+        - name: explorer-ui
+          image: registry.digitalocean.com/aztlan-containers/explorer-ui
+          imagePullPolicy: Always
+          resources:
+            limits:
+              memory: 300Mi
+              cpu: 200m
+          ports:
+            - name: http-app-port
+              containerPort: 80
+              protocol: TCP

--- a/services/explorer-ui/k8s/base/kustomization.yaml
+++ b/services/explorer-ui/k8s/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/services/explorer-ui/k8s/base/service.yaml
+++ b/services/explorer-ui/k8s/base/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: explorer-ui
+  labels:
+    app.kubernetes.io/name: explorer-ui
+    app.kubernetes.io/part-of: chicmoz-prod
+spec:
+  selector:
+    app: explorer-ui
+  ports:
+    - name: http-app
+      protocol: TCP
+      port: 80
+      targetPort: http-app-port

--- a/services/explorer-ui/k8s/overlays/devnet/httproute.yaml
+++ b/services/explorer-ui/k8s/overlays/devnet/httproute.yaml
@@ -16,7 +16,7 @@ spec:
     - devnet.aztecscan.xyz
   rules:
     - backendRefs:
-        - name: explorer-ui-devnet-service # hardcoded — nameSuffix does NOT transform backendRefs
+        - name: explorer-ui-devnet # hardcoded — nameSuffix does NOT transform backendRefs
           port: 80
       matches:
         - path:

--- a/services/explorer-ui/k8s/overlays/devnet/httproute.yaml
+++ b/services/explorer-ui/k8s/overlays/devnet/httproute.yaml
@@ -1,0 +1,24 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: explorer-ui # nameSuffix appends -devnet → explorer-ui-devnet
+  namespace: chicmoz-prod
+  labels:
+    app.kubernetes.io/name: explorer-ui
+    app.kubernetes.io/part-of: chicmoz-prod
+spec:
+  parentRefs:
+    - name: aztecscan-gateway
+      sectionName: ui-devnet-http
+    - name: aztecscan-gateway
+      sectionName: ui-devnet-https
+  hostnames:
+    - devnet.aztecscan.xyz
+  rules:
+    - backendRefs:
+        - name: explorer-ui-devnet-service # hardcoded — nameSuffix does NOT transform backendRefs
+          port: 80
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/services/explorer-ui/k8s/overlays/devnet/kustomization.yaml
+++ b/services/explorer-ui/k8s/overlays/devnet/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: chicmoz-prod
+nameSuffix: -devnet
+
+resources:
+  - ../../base
+  - httproute.yaml
+
+images:
+  - name: registry.digitalocean.com/aztlan-containers/explorer-ui
+    newName: registry.digitalocean.com/aztlan-containers/explorer-ui-devnet
+    newTag: latest

--- a/services/explorer-ui/k8s/overlays/devnet/kustomization.yaml
+++ b/services/explorer-ui/k8s/overlays/devnet/kustomization.yaml
@@ -12,3 +12,29 @@ images:
   - name: registry.digitalocean.com/aztlan-containers/explorer-ui
     newName: registry.digitalocean.com/aztlan-containers/explorer-ui-devnet
     newTag: latest
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: explorer-ui
+      spec:
+        selector:
+          matchLabels:
+            app: explorer-ui
+            network: devnet
+        template:
+          metadata:
+            labels:
+              app: explorer-ui
+              network: devnet
+  - patch: |-
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: explorer-ui
+      spec:
+        selector:
+          app: explorer-ui
+          network: devnet

--- a/services/explorer-ui/k8s/overlays/mainnet/httproute.yaml
+++ b/services/explorer-ui/k8s/overlays/mainnet/httproute.yaml
@@ -1,0 +1,37 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: explorer-ui # nameSuffix appends -mainnet → explorer-ui-mainnet
+  namespace: chicmoz-prod
+  labels:
+    app.kubernetes.io/name: explorer-ui
+    app.kubernetes.io/part-of: chicmoz-prod
+spec:
+  parentRefs:
+    - name: aztecscan-gateway
+      sectionName: ui-http
+    - name: aztecscan-gateway
+      sectionName: ui-https
+    - name: aztecscan-gateway
+      sectionName: ui-mainnet-http
+    - name: aztecscan-gateway
+      sectionName: ui-mainnet-https
+    - name: aztecscan-gateway
+      sectionName: ui-primary-http
+    - name: aztecscan-gateway
+      sectionName: ui-primary-https
+    - name: aztecscan-gateway
+      sectionName: ui-mainnet-primary-http
+    - name: aztecscan-gateway
+      sectionName: ui-mainnet-primary-https
+  hostnames:
+    - aztecscan.xyz
+    - mainnet.aztecscan.xyz
+  rules:
+    - backendRefs:
+        - name: explorer-ui-mainnet-service # hardcoded — nameSuffix does NOT transform backendRefs
+          port: 80
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/services/explorer-ui/k8s/overlays/mainnet/httproute.yaml
+++ b/services/explorer-ui/k8s/overlays/mainnet/httproute.yaml
@@ -29,7 +29,7 @@ spec:
     - mainnet.aztecscan.xyz
   rules:
     - backendRefs:
-        - name: explorer-ui-mainnet-service # hardcoded — nameSuffix does NOT transform backendRefs
+        - name: explorer-ui-mainnet # hardcoded — nameSuffix does NOT transform backendRefs
           port: 80
       matches:
         - path:

--- a/services/explorer-ui/k8s/overlays/mainnet/kustomization.yaml
+++ b/services/explorer-ui/k8s/overlays/mainnet/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: chicmoz-prod
+nameSuffix: -mainnet
+
+resources:
+  - ../../base
+  - httproute.yaml
+
+images:
+  - name: registry.digitalocean.com/aztlan-containers/explorer-ui
+    newName: registry.digitalocean.com/aztlan-containers/explorer-ui-mainnet
+    newTag: latest

--- a/services/explorer-ui/k8s/overlays/mainnet/kustomization.yaml
+++ b/services/explorer-ui/k8s/overlays/mainnet/kustomization.yaml
@@ -12,3 +12,29 @@ images:
   - name: registry.digitalocean.com/aztlan-containers/explorer-ui
     newName: registry.digitalocean.com/aztlan-containers/explorer-ui-mainnet
     newTag: latest
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: explorer-ui
+      spec:
+        selector:
+          matchLabels:
+            app: explorer-ui
+            network: mainnet
+        template:
+          metadata:
+            labels:
+              app: explorer-ui
+              network: mainnet
+  - patch: |-
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: explorer-ui
+      spec:
+        selector:
+          app: explorer-ui
+          network: mainnet

--- a/services/explorer-ui/k8s/overlays/testnet/httproute.yaml
+++ b/services/explorer-ui/k8s/overlays/testnet/httproute.yaml
@@ -20,7 +20,7 @@ spec:
     - testnet.aztecscan.xyz
   rules:
     - backendRefs:
-        - name: explorer-ui-testnet-service # hardcoded — nameSuffix does NOT transform backendRefs
+        - name: explorer-ui-testnet # hardcoded — nameSuffix does NOT transform backendRefs
           port: 80
       matches:
         - path:

--- a/services/explorer-ui/k8s/overlays/testnet/httproute.yaml
+++ b/services/explorer-ui/k8s/overlays/testnet/httproute.yaml
@@ -1,0 +1,28 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: explorer-ui # nameSuffix appends -testnet → explorer-ui-testnet
+  namespace: chicmoz-prod
+  labels:
+    app.kubernetes.io/name: explorer-ui
+    app.kubernetes.io/part-of: chicmoz-prod
+spec:
+  parentRefs:
+    - name: aztecscan-gateway
+      sectionName: ui-testnet-http
+    - name: aztecscan-gateway
+      sectionName: ui-testnet-https
+    - name: aztecscan-gateway
+      sectionName: ui-testnet-primary-http
+    - name: aztecscan-gateway
+      sectionName: ui-testnet-primary-https
+  hostnames:
+    - testnet.aztecscan.xyz
+  rules:
+    - backendRefs:
+        - name: explorer-ui-testnet-service # hardcoded — nameSuffix does NOT transform backendRefs
+          port: 80
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/services/explorer-ui/k8s/overlays/testnet/kustomization.yaml
+++ b/services/explorer-ui/k8s/overlays/testnet/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: chicmoz-prod
+nameSuffix: -testnet
+
+resources:
+  - ../../base
+  - httproute.yaml
+
+images:
+  - name: registry.digitalocean.com/aztlan-containers/explorer-ui
+    newName: registry.digitalocean.com/aztlan-containers/explorer-ui-testnet
+    newTag: latest

--- a/services/explorer-ui/k8s/overlays/testnet/kustomization.yaml
+++ b/services/explorer-ui/k8s/overlays/testnet/kustomization.yaml
@@ -12,3 +12,29 @@ images:
   - name: registry.digitalocean.com/aztlan-containers/explorer-ui
     newName: registry.digitalocean.com/aztlan-containers/explorer-ui-testnet
     newTag: latest
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: explorer-ui
+      spec:
+        selector:
+          matchLabels:
+            app: explorer-ui
+            network: testnet
+        template:
+          metadata:
+            labels:
+              app: explorer-ui
+              network: testnet
+  - patch: |-
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: explorer-ui
+      spec:
+        selector:
+          app: explorer-ui
+          network: testnet

--- a/services/websocket-event-publisher/k8s/base/deployment.yaml
+++ b/services/websocket-event-publisher/k8s/base/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: websocket-event-publisher
+  labels:
+    app: websocket-event-publisher
+    app.kubernetes.io/name: websocket-event-publisher
+    app.kubernetes.io/part-of: chicmoz-prod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: websocket-event-publisher
+  template:
+    metadata:
+      labels:
+        app: websocket-event-publisher
+    spec:
+      imagePullSecrets:
+        - name: registry-aztlan-containers
+      containers:
+        - name: websocket-event-publisher
+          image: registry.digitalocean.com/aztlan-containers/websocket-event-publisher
+          imagePullPolicy: Always
+          resources:
+            limits:
+              memory: 300Mi
+              cpu: 500m
+          ports:
+            - name: websocket-port
+              containerPort: 3000
+              protocol: TCP
+            - name: health-port
+              containerPort: 3001
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3001
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3001
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 2
+          env:
+            - name: PORT
+              value: "3000"
+            - name: NODE_ENV
+              value: "production"

--- a/services/websocket-event-publisher/k8s/base/kustomization.yaml
+++ b/services/websocket-event-publisher/k8s/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/services/websocket-event-publisher/k8s/base/service.yaml
+++ b/services/websocket-event-publisher/k8s/base/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: websocket-event-publisher
+  labels:
+    app.kubernetes.io/name: websocket-event-publisher
+    app.kubernetes.io/part-of: chicmoz-prod
+spec:
+  selector:
+    app: websocket-event-publisher
+  ports:
+    - name: websocket
+      protocol: TCP
+      port: 80
+      targetPort: websocket-port

--- a/services/websocket-event-publisher/k8s/overlays/devnet/backendtrafficpolicy.yaml
+++ b/services/websocket-event-publisher/k8s/overlays/devnet/backendtrafficpolicy.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: websocket-event-publisher
+  namespace: chicmoz-prod
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: websocket-event-publisher-devnet # hardcoded — nameSuffix does NOT transform targetRefs
+  timeout:
+    http:
+      requestTimeout: 3600s

--- a/services/websocket-event-publisher/k8s/overlays/devnet/httproute.yaml
+++ b/services/websocket-event-publisher/k8s/overlays/devnet/httproute.yaml
@@ -1,0 +1,17 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: websocket-event-publisher
+  namespace: chicmoz-prod
+spec:
+  parentRefs:
+    - name: aztecscan-gateway
+      sectionName: ws-devnet-http
+    - name: aztecscan-gateway
+      sectionName: ws-devnet-https
+  hostnames:
+    - ws.devnet.aztecscan.xyz
+  rules:
+    - backendRefs:
+        - name: websocket-event-publisher-devnet # hardcoded — nameSuffix does NOT transform backendRefs
+          port: 80

--- a/services/websocket-event-publisher/k8s/overlays/devnet/kustomization.yaml
+++ b/services/websocket-event-publisher/k8s/overlays/devnet/kustomization.yaml
@@ -30,3 +30,27 @@ patches:
                     value: "devnet_websocket-event-publisher"
                   - name: L2_NETWORK_ID
                     value: "DEVNET"
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: websocket-event-publisher
+      spec:
+        selector:
+          matchLabels:
+            app: websocket-event-publisher
+            network: devnet
+        template:
+          metadata:
+            labels:
+              app: websocket-event-publisher
+              network: devnet
+  - patch: |-
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: websocket-event-publisher
+      spec:
+        selector:
+          app: websocket-event-publisher
+          network: devnet

--- a/services/websocket-event-publisher/k8s/overlays/devnet/kustomization.yaml
+++ b/services/websocket-event-publisher/k8s/overlays/devnet/kustomization.yaml
@@ -1,0 +1,32 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: chicmoz-prod
+nameSuffix: -devnet
+
+resources:
+  - ../../base
+  - httproute.yaml
+  - backendtrafficpolicy.yaml
+
+images:
+  - name: registry.digitalocean.com/aztlan-containers/websocket-event-publisher
+    newName: registry.digitalocean.com/aztlan-containers/websocket-event-publisher-devnet
+    newTag: latest
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: websocket-event-publisher
+      spec:
+        template:
+          spec:
+            containers:
+              - name: websocket-event-publisher
+                env:
+                  - name: INSTANCE_NAME
+                    value: "devnet_websocket-event-publisher"
+                  - name: L2_NETWORK_ID
+                    value: "DEVNET"

--- a/services/websocket-event-publisher/k8s/overlays/mainnet/httproute.yaml
+++ b/services/websocket-event-publisher/k8s/overlays/mainnet/httproute.yaml
@@ -1,0 +1,37 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: websocket-event-publisher
+  namespace: chicmoz-prod
+  labels:
+    app.kubernetes.io/name: websocket-event-publisher
+    app.kubernetes.io/part-of: chicmoz-prod
+spec:
+  parentRefs:
+    - name: aztecscan-gateway
+      sectionName: ws-http
+    - name: aztecscan-gateway
+      sectionName: ws-https
+    - name: aztecscan-gateway
+      sectionName: ws-mainnet-http
+    - name: aztecscan-gateway
+      sectionName: ws-mainnet-https
+    - name: aztecscan-gateway
+      sectionName: ws-primary-http
+    - name: aztecscan-gateway
+      sectionName: ws-primary-https
+    - name: aztecscan-gateway
+      sectionName: ws-mainnet-primary-http
+    - name: aztecscan-gateway
+      sectionName: ws-mainnet-primary-https
+  hostnames:
+    - ws.aztecscan.xyz
+    - ws.mainnet.aztecscan.xyz
+  rules:
+    - backendRefs:
+        - name: websocket-event-publisher-mainnet # hardcoded — nameSuffix does NOT transform backendRefs
+          port: 80
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/services/websocket-event-publisher/k8s/overlays/mainnet/kustomization.yaml
+++ b/services/websocket-event-publisher/k8s/overlays/mainnet/kustomization.yaml
@@ -29,3 +29,27 @@ patches:
                     value: "mainnet_websocket-event-publisher"
                   - name: L2_NETWORK_ID
                     value: "MAINNET"
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: websocket-event-publisher
+      spec:
+        selector:
+          matchLabels:
+            app: websocket-event-publisher
+            network: mainnet
+        template:
+          metadata:
+            labels:
+              app: websocket-event-publisher
+              network: mainnet
+  - patch: |-
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: websocket-event-publisher
+      spec:
+        selector:
+          app: websocket-event-publisher
+          network: mainnet

--- a/services/websocket-event-publisher/k8s/overlays/mainnet/kustomization.yaml
+++ b/services/websocket-event-publisher/k8s/overlays/mainnet/kustomization.yaml
@@ -1,0 +1,31 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: chicmoz-prod
+nameSuffix: -mainnet
+
+resources:
+  - ../../base
+  - httproute.yaml
+
+images:
+  - name: registry.digitalocean.com/aztlan-containers/websocket-event-publisher
+    newName: registry.digitalocean.com/aztlan-containers/websocket-event-publisher-mainnet
+    newTag: latest
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: websocket-event-publisher
+      spec:
+        template:
+          spec:
+            containers:
+              - name: websocket-event-publisher
+                env:
+                  - name: INSTANCE_NAME
+                    value: "mainnet_websocket-event-publisher"
+                  - name: L2_NETWORK_ID
+                    value: "MAINNET"

--- a/services/websocket-event-publisher/k8s/overlays/testnet/httproute.yaml
+++ b/services/websocket-event-publisher/k8s/overlays/testnet/httproute.yaml
@@ -1,0 +1,28 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: websocket-event-publisher
+  namespace: chicmoz-prod
+  labels:
+    app.kubernetes.io/name: websocket-event-publisher
+    app.kubernetes.io/part-of: chicmoz-prod
+spec:
+  parentRefs:
+    - name: aztecscan-gateway
+      sectionName: ws-testnet-http
+    - name: aztecscan-gateway
+      sectionName: ws-testnet-https
+    - name: aztecscan-gateway
+      sectionName: ws-testnet-primary-http
+    - name: aztecscan-gateway
+      sectionName: ws-testnet-primary-https
+  hostnames:
+    - ws.testnet.aztecscan.xyz
+  rules:
+    - backendRefs:
+        - name: websocket-event-publisher-testnet # hardcoded — nameSuffix does NOT transform backendRefs
+          port: 80
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/services/websocket-event-publisher/k8s/overlays/testnet/kustomization.yaml
+++ b/services/websocket-event-publisher/k8s/overlays/testnet/kustomization.yaml
@@ -1,0 +1,31 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: chicmoz-prod
+nameSuffix: -testnet
+
+resources:
+  - ../../base
+  - httproute.yaml
+
+images:
+  - name: registry.digitalocean.com/aztlan-containers/websocket-event-publisher
+    newName: registry.digitalocean.com/aztlan-containers/websocket-event-publisher-testnet
+    newTag: latest
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: websocket-event-publisher
+      spec:
+        template:
+          spec:
+            containers:
+              - name: websocket-event-publisher
+                env:
+                  - name: INSTANCE_NAME
+                    value: "testnet_websocket-event-publisher"
+                  - name: L2_NETWORK_ID
+                    value: "TESTNET"

--- a/services/websocket-event-publisher/k8s/overlays/testnet/kustomization.yaml
+++ b/services/websocket-event-publisher/k8s/overlays/testnet/kustomization.yaml
@@ -29,3 +29,27 @@ patches:
                     value: "testnet_websocket-event-publisher"
                   - name: L2_NETWORK_ID
                     value: "TESTNET"
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: websocket-event-publisher
+      spec:
+        selector:
+          matchLabels:
+            app: websocket-event-publisher
+            network: testnet
+        template:
+          metadata:
+            labels:
+              app: websocket-event-publisher
+              network: testnet
+  - patch: |-
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: websocket-event-publisher
+      spec:
+        selector:
+          app: websocket-event-publisher
+          network: testnet


### PR DESCRIPTION
## Summary

Migrates all remaining Chicmoz services from the monolithic Skaffold-based production workflows to the new per-service GitHub Actions + Kustomize pattern established by `explorer-ui-v2`.

**Services migrated:**
- `websocket-event-publisher` — mainnet, testnet, devnet
- `explorer-api` — mainnet, testnet, devnet (includes HTTPRoute, SecurityPolicy, HTTP filter per overlay)
- `aztec-listener` — mainnet, testnet, devnet
- `ethereum-listener` — mainnet, testnet, devnet
- `explorer-ui` — mainnet, testnet, devnet (network-specific `VITE_*` build args baked at image build time)
- `auth` — mainnet only (no `nameSuffix` to preserve `auth-service` name for SecurityPolicy extAuth references)
- `compiler-orchestrator` — mainnet, testnet, devnet (includes RBAC: ServiceAccount, Role, RoleBinding in base)

## Pattern

Each service gets:
- `.github/workflows/<service>.yml` — 4-job pipeline: `set-up → build-base → build → deploy`
- `services/<service>/k8s/base/` — network-agnostic Deployment (+ Service, RBAC where applicable)
- `services/<service>/k8s/overlays/{mainnet,testnet,devnet}/` — Kustomize overlay per network with `nameSuffix`, image pin, and network-specific patches

Image naming: `registry.digitalocean.com/aztlan-containers/<service>-{network}:{git-sha}` + `:latest`

The old Skaffold workflows (`aztecscan-prod*.yml`) are **not removed** — they continue running in parallel as a safety net.

## Docs

- `docs/ci-cd-migration.md` — status table updated to ✅ Done for all 8 services
- `docs/ci-cd-migration-impl-plan.md` — implementation plan added for reference