### PR TITLE
feat(aztec-listener): snapshot fee-juice balance for all unique addresses per proven block

### DIFF
--- a/services/aztec-listener/migrations/0004_add_initiator_and_msg_senders.sql
+++ b/services/aztec-listener/migrations/0004_add_initiator_and_msg_senders.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "txs_table" ADD COLUMN "initiator" varchar;--> statement-breakpoint
+ALTER TABLE "txs_table" ADD COLUMN "additional_msg_senders" varchar;

--- a/services/aztec-listener/migrations/meta/_journal.json
+++ b/services/aztec-listener/migrations/meta/_journal.json
@@ -33,7 +33,7 @@
     {
       "idx": 4,
       "version": "7",
-      "when": 1747353600000,
+      "when": 1778679122753,
       "tag": "0004_add_initiator_and_msg_senders",
       "breakpoints": true
     }

--- a/services/aztec-listener/migrations/meta/_journal.json
+++ b/services/aztec-listener/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1753714930792,
       "tag": "0003_youthful_black_widow",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1747353600000,
+      "tag": "0004_add_initiator_and_msg_senders",
+      "breakpoints": true
     }
   ]
 }

--- a/services/aztec-listener/src/svcs/database/schema.ts
+++ b/services/aztec-listener/src/svcs/database/schema.ts
@@ -28,6 +28,12 @@ export type TxState = (typeof txStateValues)[number];
 export const txsTable = pgTable("txs_table", {
   txHash: varchar("tx_hash").notNull().$type<HexString>().primaryKey(),
   feePayer: generateAztecAddressColumn("fee_payer").notNull(),
+  // The outermost initiator of the tx (msgSender of first non-revertible public call).
+  // NULL for private-only txs.
+  initiator: generateAztecAddressColumn("initiator").$type<string | undefined>(),
+  // Comma-separated list of unique msgSender addresses from all public call requests,
+  // excluding feePayer and initiator. NULL when there are no additional senders.
+  additionalMsgSenders: varchar("additional_msg_senders").$type<string | undefined>(),
   birthTimestamp: generateTimestampColumn("birth_timestamp")
     .notNull()
     .default(sql`EXTRACT(EPOCH FROM NOW()) * 1000`),

--- a/services/aztec-listener/src/svcs/database/txs.controller.ts
+++ b/services/aztec-listener/src/svcs/database/txs.controller.ts
@@ -4,22 +4,40 @@ import { and, eq, inArray } from "drizzle-orm";
 import { logger } from "../../logger.js";
 import { txsTable, TxState } from "./schema.js";
 
+const buildTxRow = (pendingTx: ChicmozL2PendingTx, txState: TxState) => {
+  const excludedAddresses = new Set(
+    [pendingTx.feePayer, pendingTx.initiator].filter(Boolean),
+  );
+  const additionalSenders = [
+    ...new Set(
+      (pendingTx.publicCallRequests ?? [])
+        .map((r) => r.msgSender)
+        .filter((addr) => !excludedAddresses.has(addr)),
+    ),
+  ];
+
+  return {
+    txHash: pendingTx.txHash,
+    feePayer: pendingTx.feePayer,
+    initiator: pendingTx.initiator ?? undefined,
+    additionalMsgSenders:
+      additionalSenders.length > 0 ? additionalSenders.join(",") : undefined,
+    birthTimestamp: pendingTx.birthTimestamp,
+    txState,
+  };
+};
+
 export const storeOrUpdate = async (
   pendingTx: ChicmozL2PendingTx,
   txState: TxState,
 ) => {
+  const row = buildTxRow(pendingTx, txState);
   await db()
     .insert(txsTable)
-    .values({
-      ...pendingTx,
-      txState,
-    })
+    .values(row)
     .onConflictDoUpdate({
       target: txsTable.txHash,
-      set: {
-        ...pendingTx,
-        txState,
-      },
+      set: row,
     });
 };
 
@@ -32,10 +50,26 @@ export const getTxs = async (
     "proven",
   ],
 ) => {
-  return await db()
+  const rows = await db()
     .select()
     .from(txsTable)
     .where(inArray(txsTable.txState, statesWhitelist));
+
+  return rows.map((row) => ({
+    ...row,
+    initiator: row.initiator ?? undefined,
+    additionalMsgSenders: row.additionalMsgSenders ?? undefined,
+  }));
+};
+
+export const storeOrUpdateState = async (
+  txHash: HexString,
+  txState: TxState,
+) => {
+  await db()
+    .update(txsTable)
+    .set({ txState })
+    .where(eq(txsTable.txHash, txHash));
 };
 
 export const deleteTx = async (txHash: HexString, txState?: TxState) => {

--- a/services/aztec-listener/src/svcs/database/txs.controller.ts
+++ b/services/aztec-listener/src/svcs/database/txs.controller.ts
@@ -4,31 +4,46 @@ import { and, eq, inArray } from "drizzle-orm";
 import { logger } from "../../logger.js";
 import { txsTable, TxState } from "./schema.js";
 
-const buildTxRow = (pendingTx: ChicmozL2PendingTx, txState: TxState) => {
+type StoredTxMetadata = {
+  additionalMsgSenders?: string;
+};
+
+const buildTxRow = (
+  pendingTx: ChicmozL2PendingTx & StoredTxMetadata,
+  txState: TxState,
+) => {
   const excludedAddresses = new Set(
     [pendingTx.feePayer, pendingTx.initiator].filter(Boolean),
   );
-  const additionalSenders = [
-    ...new Set(
-      (pendingTx.publicCallRequests ?? [])
-        .map((r) => r.msgSender)
-        .filter((addr) => !excludedAddresses.has(addr)),
-    ),
-  ];
+  const additionalMsgSenders =
+    pendingTx.publicCallRequests === undefined
+      ? pendingTx.additionalMsgSenders
+      : (() => {
+          const additionalSenders = [
+            ...new Set(
+              pendingTx.publicCallRequests
+                .map((r) => r.msgSender)
+                .filter((addr) => !excludedAddresses.has(addr)),
+            ),
+          ];
+
+          return additionalSenders.length > 0
+            ? additionalSenders.join(",")
+            : undefined;
+        })();
 
   return {
     txHash: pendingTx.txHash,
     feePayer: pendingTx.feePayer,
     initiator: pendingTx.initiator ?? undefined,
-    additionalMsgSenders:
-      additionalSenders.length > 0 ? additionalSenders.join(",") : undefined,
+    additionalMsgSenders,
     birthTimestamp: pendingTx.birthTimestamp,
     txState,
   };
 };
 
 export const storeOrUpdate = async (
-  pendingTx: ChicmozL2PendingTx,
+  pendingTx: ChicmozL2PendingTx & StoredTxMetadata,
   txState: TxState,
 ) => {
   const row = buildTxRow(pendingTx, txState);

--- a/services/aztec-listener/src/svcs/poller/pollers/block_poller/handle-proven-block-txs.ts
+++ b/services/aztec-listener/src/svcs/poller/pollers/block_poller/handle-proven-block-txs.ts
@@ -1,9 +1,33 @@
 import { L2Block } from "@aztec/aztec.js/block";
+import { AztecAddress } from "@aztec/aztec.js/addresses";
 import { logger } from "../../../../logger.js";
 import { txsController } from "../../../database/index.js";
 import { publishMessage } from "../../../message-bus/index.js";
 import { getBalanceOf } from "../../network-client/index.js";
-import { AztecAddress } from "@aztec/aztec.js/addresses";
+
+type StoredTx = Awaited<ReturnType<typeof txsController.getTxs>>[number];
+
+// Collect all unique addresses across all proven txs in the block.
+// Maps address → first txHash that introduced it (used as sourceTxHash).
+const collectUniqueAddresses = (provenTxs: StoredTx[]): Map<string, string> => {
+  const addressToTxHash = new Map<string, string>();
+
+  for (const tx of provenTxs) {
+    const candidates: (string | null | undefined)[] = [
+      tx.feePayer,
+      tx.initiator,
+      ...(tx.additionalMsgSenders ? tx.additionalMsgSenders.split(",") : []),
+    ];
+
+    for (const addr of candidates) {
+      if (addr && !addressToTxHash.has(addr)) {
+        addressToTxHash.set(addr, tx.txHash);
+      }
+    }
+  }
+
+  return addressToTxHash;
+};
 
 export const handleProvenTransactions = async (block: L2Block) => {
   try {
@@ -43,25 +67,52 @@ export const handleProvenTransactions = async (block: L2Block) => {
       `🎯 Found ${provenPendingTxs.length} proven pending txs in block ${blockNumber}`,
     );
 
-    for (const provenTx of provenPendingTxs) {
-      try {
-        const feePayerAddress = AztecAddress.fromString(provenTx.feePayer);
+    // Step 1 — collect all unique addresses across the entire block
+    const addressToTxHash = collectUniqueAddresses(provenPendingTxs);
+    logger.info(
+      `📋 Fetching fee-juice balances for ${addressToTxHash.size} unique addresses in block ${blockNumber}`,
+    );
 
-        const balance = await getBalanceOf(blockNumber, feePayerAddress);
+    // Step 2 — fetch all balances in parallel
+    const balanceResults = await Promise.allSettled(
+      [...addressToTxHash.entries()].map(async ([addr, sourceTxHash]) => {
+        const balance = await getBalanceOf(
+          blockNumber,
+          AztecAddress.fromString(addr),
+        );
+        return { addr, sourceTxHash, balance };
+      }),
+    );
 
+    // Step 3 — publish Kafka events for successful balance fetches
+    await Promise.all(
+      balanceResults.map(async (result) => {
+        if (result.status === "rejected") {
+          logger.error(`Failed to fetch balance: ${String(result.reason)}`);
+          return;
+        }
+        const { addr, sourceTxHash, balance } = result.value;
         await publishMessage("CONTRACT_INSTANCE_BALANCE_EVENT", {
-          contractAddress: provenTx.feePayer,
+          contractAddress: addr,
           balance: balance.toBigInt().toString(),
           timestamp: new Date().getTime(),
-          sourceTxHash: provenTx.txHash,
+          sourceTxHash,
         });
+        logger.info(`💰 Snapshotted balance for ${addr}`);
+      }),
+    );
 
-        await txsController.storeOrUpdate(provenTx, "proven");
-        logger.info(`✅ Updated tx ${provenTx.txHash} to proven state`);
-      } catch (error) {
-        logger.error(`Error processing proven tx ${provenTx.txHash}:`, error);
-      }
-    }
+    // Step 4 — update tx states in parallel
+    await Promise.all(
+      provenPendingTxs.map(async (provenTx) => {
+        try {
+          await txsController.storeOrUpdateState(provenTx.txHash, "proven");
+          logger.info(`✅ Updated tx ${provenTx.txHash} to proven state`);
+        } catch (error) {
+          logger.error(`Error updating tx ${provenTx.txHash} state:`, error);
+        }
+      }),
+    );
   } catch (error) {
     logger.error("Error handling proven transactions:", error);
   }

--- a/services/aztec-listener/src/svcs/poller/pollers/block_poller/handle-proven-block-txs.ts
+++ b/services/aztec-listener/src/svcs/poller/pollers/block_poller/handle-proven-block-txs.ts
@@ -6,6 +6,20 @@ import { publishMessage } from "../../../message-bus/index.js";
 import { getBalanceOf } from "../../network-client/index.js";
 
 type StoredTx = Awaited<ReturnType<typeof txsController.getTxs>>[number];
+type BalanceFetchSuccess = {
+  status: "fulfilled";
+  addr: string;
+  sourceTxHash: string;
+  balance: Awaited<ReturnType<typeof getBalanceOf>>;
+};
+type BalanceFetchFailure = {
+  status: "rejected";
+  addr: string;
+  sourceTxHash: string;
+  reason: unknown;
+};
+
+const BALANCE_FETCH_CONCURRENCY = 8;
 
 // Collect all unique addresses across all proven txs in the block.
 // Maps address → first txHash that introduced it (used as sourceTxHash).
@@ -27,6 +41,49 @@ const collectUniqueAddresses = (provenTxs: StoredTx[]): Map<string, string> => {
   }
 
   return addressToTxHash;
+};
+
+const fetchBalances = async (
+  blockNumber: bigint,
+  addressToTxHash: Map<string, string>,
+) => {
+  const entries = [...addressToTxHash.entries()];
+  const results: Array<BalanceFetchSuccess | BalanceFetchFailure> = [];
+  let nextIndex = 0;
+
+  await Promise.all(
+    Array.from(
+      { length: Math.min(BALANCE_FETCH_CONCURRENCY, entries.length) },
+      async () => {
+        while (nextIndex < entries.length) {
+          const currentIndex = nextIndex++;
+          const [addr, sourceTxHash] = entries[currentIndex];
+
+          try {
+            const balance = await getBalanceOf(
+              blockNumber,
+              AztecAddress.fromString(addr),
+            );
+            results[currentIndex] = {
+              status: "fulfilled",
+              addr,
+              sourceTxHash,
+              balance,
+            };
+          } catch (reason) {
+            results[currentIndex] = {
+              status: "rejected",
+              addr,
+              sourceTxHash,
+              reason,
+            };
+          }
+        }
+      },
+    ),
+  );
+
+  return results;
 };
 
 export const handleProvenTransactions = async (block: L2Block) => {
@@ -73,25 +130,19 @@ export const handleProvenTransactions = async (block: L2Block) => {
       `📋 Fetching fee-juice balances for ${addressToTxHash.size} unique addresses in block ${blockNumber}`,
     );
 
-    // Step 2 — fetch all balances in parallel
-    const balanceResults = await Promise.allSettled(
-      [...addressToTxHash.entries()].map(async ([addr, sourceTxHash]) => {
-        const balance = await getBalanceOf(
-          blockNumber,
-          AztecAddress.fromString(addr),
-        );
-        return { addr, sourceTxHash, balance };
-      }),
-    );
+    // Step 2 — fetch balances with bounded concurrency
+    const balanceResults = await fetchBalances(blockNumber, addressToTxHash);
 
     // Step 3 — publish Kafka events for successful balance fetches
     await Promise.all(
       balanceResults.map(async (result) => {
         if (result.status === "rejected") {
-          logger.error(`Failed to fetch balance: ${String(result.reason)}`);
+          logger.error(
+            `Failed to fetch balance for ${result.addr} (sourceTxHash: ${result.sourceTxHash}, block: ${blockNumber.toString()}): ${String(result.reason)}`,
+          );
           return;
         }
-        const { addr, sourceTxHash, balance } = result.value;
+        const { addr, sourceTxHash, balance } = result;
         await publishMessage("CONTRACT_INSTANCE_BALANCE_EVENT", {
           contractAddress: addr,
           balance: balance.toBigInt().toString(),

--- a/services/explorer-ui-v2/src/pages/address-details/index.tsx
+++ b/services/explorer-ui-v2/src/pages/address-details/index.tsx
@@ -1,18 +1,52 @@
-import { useParams } from "@tanstack/react-router";
-import { type FC, useMemo } from "react";
+import { Link, useParams } from "@tanstack/react-router";
+import { type FC, useMemo, useState } from "react";
 import { ConsoleHead, Shell } from "~/components/layout";
 import { PublicCallRequestsTable } from "~/components/data/public-call-requests-table";
-import { usePublicCallRequestsBySender } from "~/hooks/api";
-import { fmtNum, truncateHashString } from "~/lib/utils";
+import { TokenEtherscanLink } from "~/components/common";
+import {
+  usePublicCallRequestsBySender,
+  useContractInstanceBalance,
+  useContractInstanceBalanceHistory,
+  useChainInfo,
+} from "~/hooks/api";
+import {
+  ageStr,
+  fmtNum,
+  formatFees,
+  getFeeJuiceSymbol,
+  truncateHashString,
+} from "~/lib/utils";
+
+type Tab = "calls" | "balance";
 
 export const AddressDetailsPage: FC = () => {
   const { address = "" } = useParams({ strict: false });
 
-  const {
-    data: publicCallRequests,
-    isLoading,
-    error,
-  } = usePublicCallRequestsBySender(address);
+  const { data: publicCallRequests, isLoading, error } = usePublicCallRequestsBySender(address);
+  const { data: balance } = useContractInstanceBalance(address);
+  const { data: history } = useContractInstanceBalanceHistory(address);
+  const { data: chainInfo } = useChainInfo();
+
+  const [tab, setTab] = useState<Tab>("calls");
+
+  const feeJuiceDecimals = chainInfo?.feeJuiceDecimals ?? 18;
+  const feeJuiceSymbol = getFeeJuiceSymbol(chainInfo?.feeJuiceSymbol);
+  const feeJuiceAddress = chainInfo?.l1ContractAddresses?.feeJuiceAddress;
+
+  const balanceValue =
+    balance?.balance !== undefined && balance.balance !== null
+      ? formatFees(balance.balance, feeJuiceDecimals)
+      : "—";
+
+  const maxBal = history?.length
+    ? Number(history.reduce((m, h) => (h.balance > m ? h.balance : m), history[0].balance))
+    : 0;
+
+  const latest = history?.[history.length - 1];
+  const prev24 = history?.[Math.max(0, history.length - 25)];
+  const delta = latest && prev24 ? latest.balance - prev24.balance : 0n;
+  const deltaAbs = delta < 0n ? -delta : delta;
+  const deltaValue = formatFees(deltaAbs, feeJuiceDecimals);
 
   const stats = useMemo(() => {
     const calls = publicCallRequests ?? [];
@@ -35,11 +69,31 @@ export const AddressDetailsPage: FC = () => {
       />
 
       <div className="detail-header">
-        <div className="kicker">L2 address · public call activity</div>
+        <div className="kicker">L2 address · account</div>
         <h1 className="hash-sized">{address}</h1>
       </div>
 
       <div className="stats-strip">
+        <div className="sc">
+          <div className="lbl">Fee Juice balance</div>
+          <div className="val">
+            {balanceValue}
+            {balance?.balance !== undefined && (
+              <TokenEtherscanLink
+                symbol={feeJuiceSymbol}
+                address={feeJuiceAddress}
+                className="u"
+              />
+            )}
+          </div>
+          <div className="sub">
+            {delta === 0n
+              ? "no change · 24h"
+              : delta > 0n
+                ? `+${deltaValue} · 24h`
+                : `-${deltaValue} · 24h`}
+          </div>
+        </div>
         <div className="sc">
           <div className="lbl">Total calls</div>
           <div className="val">{fmtNum(stats.totalCalls)}</div>
@@ -58,20 +112,121 @@ export const AddressDetailsPage: FC = () => {
       </div>
 
       <div className="panel">
-        <div className="panel-head">
-          <h3>
-            Public call requests
+        <div className="tabs">
+          <button
+            className={tab === "calls" ? "on" : ""}
+            onClick={() => setTab("calls")}
+          >
+            Public calls
             <span className="c">{stats.totalCalls}</span>
-          </h3>
+          </button>
+          <button
+            className={tab === "balance" ? "on" : ""}
+            onClick={() => setTab("balance")}
+          >
+            Fee Juice
+            <span className="c">{history?.length ?? 0}</span>
+          </button>
         </div>
-        {isLoading ? (
-          <div className="empty-state">loading address activity…</div>
-        ) : error ? (
-          <div className="empty-state" style={{ color: "var(--red)" }}>
-            failed to load: {error.message}
-          </div>
-        ) : (
-          <PublicCallRequestsTable data={publicCallRequests} omitSender />
+
+        {/* Tab: Public calls */}
+        {tab === "calls" && (
+          <>
+            {isLoading ? (
+              <div className="empty-state">loading address activity…</div>
+            ) : error ? (
+              <div className="empty-state" style={{ color: "var(--red)" }}>
+                failed to load: {error.message}
+              </div>
+            ) : (
+              <PublicCallRequestsTable data={publicCallRequests} omitSender />
+            )}
+          </>
+        )}
+
+        {/* Tab: Fee Juice balance + history */}
+        {tab === "balance" && (
+          <>
+            {/* Sparkbar */}
+            <div className="balance-block">
+              <div className="balance-big">
+                {balanceValue}
+                {balance?.balance !== undefined && (
+                  <TokenEtherscanLink
+                    symbol={feeJuiceSymbol}
+                    address={feeJuiceAddress}
+                    className="u"
+                  />
+                )}
+              </div>
+              <div className="balance-sub">
+                {delta === 0n
+                  ? "no change · 24h"
+                  : delta > 0n
+                    ? `+${deltaValue} · 24h`
+                    : `-${deltaValue} · 24h`}{" "}
+                · {history?.length ?? 0} snapshots
+              </div>
+              {history && history.length > 1 && maxBal > 0 && (
+                <>
+                  <div className="spark">
+                    {history.map((b, i) => (
+                      <div
+                        key={i}
+                        className="bar"
+                        style={{ height: `${(Number(b.balance) / maxBal) * 100}%` }}
+                        title={`${formatFees(b.balance, feeJuiceDecimals)} ${feeJuiceSymbol} · ${ageStr(b.timestamp)}`}
+                      />
+                    ))}
+                  </div>
+                  <div className="spark-axis">
+                    <span>oldest</span>
+                    <span>·</span>
+                    <span>now</span>
+                  </div>
+                </>
+              )}
+            </div>
+
+            {/* Balance history table */}
+            <div className="hist-head">
+              <div>Balance ({feeJuiceSymbol})</div>
+              <div>Tx</div>
+              <div className="right">Timestamp</div>
+              <div className="right">Age</div>
+            </div>
+            {(history ?? [])
+              .slice()
+              .reverse()
+              .map((h, i) => (
+                <div key={i} className="hist-row">
+                  <span className="num" style={{ textAlign: "left", color: "var(--ink-1)" }}>
+                    {formatFees(h.balance, feeJuiceDecimals)}
+                    <TokenEtherscanLink
+                      symbol={feeJuiceSymbol}
+                      address={feeJuiceAddress}
+                      className="u"
+                    />
+                  </span>
+                  <span className="hash">
+                    {h.sourceTxHash ? (
+                      <Link to="/tx-effects/$hash" params={{ hash: h.sourceTxHash }}>
+                        {truncateHashString(h.sourceTxHash, 8, 6)}
+                      </Link>
+                    ) : (
+                      <span style={{ color: "var(--ink-3)" }}>—</span>
+                    )}
+                  </span>
+                  <span className="num">
+                    {new Date(h.timestamp).toISOString().slice(0, 19).replace("T", " ")}
+                  </span>
+                  <span className="age">{ageStr(h.timestamp)}</span>
+                </div>
+              ))}
+            {(!history || history.length === 0) && (
+              <div className="empty-state">no fee juice balance history</div>
+            )}
+          </>
         )}
       </div>
     </Shell>

--- a/services/explorer-ui-v2/src/pages/address-details/index.tsx
+++ b/services/explorer-ui-v2/src/pages/address-details/index.tsx
@@ -18,6 +18,7 @@ import {
 } from "~/lib/utils";
 
 type Tab = "calls" | "balance";
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 export const AddressDetailsPage: FC = () => {
   const { address = "" } = useParams({ strict: false });
@@ -38,15 +39,49 @@ export const AddressDetailsPage: FC = () => {
       ? formatFees(balance.balance, feeJuiceDecimals)
       : "—";
 
-  const maxBal = history?.length
-    ? Number(history.reduce((m, h) => (h.balance > m ? h.balance : m), history[0].balance))
-    : 0;
-
   const latest = history?.[history.length - 1];
-  const prev24 = history?.[Math.max(0, history.length - 25)];
-  const delta = latest && prev24 ? latest.balance - prev24.balance : 0n;
+  const comparisonPoint = useMemo(() => {
+    if (!history || history.length < 2 || !latest) {
+      return undefined;
+    }
+
+    const cutoff = latest.timestamp - DAY_MS;
+
+    for (let i = history.length - 2; i >= 0; i--) {
+      if (history[i].timestamp <= cutoff) {
+        return history[i];
+      }
+    }
+
+    return history[0];
+  }, [history, latest]);
+  const delta = latest && comparisonPoint ? latest.balance - comparisonPoint.balance : 0n;
   const deltaAbs = delta < 0n ? -delta : delta;
   const deltaValue = formatFees(deltaAbs, feeJuiceDecimals);
+  const deltaLabel =
+    comparisonPoint && latest
+      ? latest.timestamp - comparisonPoint.timestamp >= DAY_MS
+        ? "24h"
+        : "available history"
+      : "latest snapshot";
+  const deltaSummary =
+    latest && comparisonPoint
+      ? delta === 0n
+        ? `no change · ${deltaLabel}`
+        : delta > 0n
+          ? `+${deltaValue} · ${deltaLabel}`
+          : `-${deltaValue} · ${deltaLabel}`
+      : "no history yet";
+  const maxBal = history?.length
+    ? history.reduce((m, h) => (h.balance > m ? h.balance : m), history[0].balance)
+    : 0n;
+  const getBarHeight = (balanceAmount: bigint) => {
+    if (maxBal <= 0n) {
+      return 0;
+    }
+
+    return Number((balanceAmount * 10000n) / maxBal) / 100;
+  };
 
   const stats = useMemo(() => {
     const calls = publicCallRequests ?? [];
@@ -86,13 +121,7 @@ export const AddressDetailsPage: FC = () => {
               />
             )}
           </div>
-          <div className="sub">
-            {delta === 0n
-              ? "no change · 24h"
-              : delta > 0n
-                ? `+${deltaValue} · 24h`
-                : `-${deltaValue} · 24h`}
-          </div>
+          <div className="sub">{deltaSummary}</div>
         </div>
         <div className="sc">
           <div className="lbl">Total calls</div>
@@ -159,22 +188,15 @@ export const AddressDetailsPage: FC = () => {
                   />
                 )}
               </div>
-              <div className="balance-sub">
-                {delta === 0n
-                  ? "no change · 24h"
-                  : delta > 0n
-                    ? `+${deltaValue} · 24h`
-                    : `-${deltaValue} · 24h`}{" "}
-                · {history?.length ?? 0} snapshots
-              </div>
-              {history && history.length > 1 && maxBal > 0 && (
+              <div className="balance-sub">{deltaSummary} · {history?.length ?? 0} snapshots</div>
+              {history && history.length > 1 && maxBal > 0n && (
                 <>
                   <div className="spark">
                     {history.map((b, i) => (
                       <div
                         key={i}
                         className="bar"
-                        style={{ height: `${(Number(b.balance) / maxBal) * 100}%` }}
+                        style={{ height: `${getBarHeight(b.balance)}%` }}
                         title={`${formatFees(b.balance, feeJuiceDecimals)} ${feeJuiceSymbol} · ${ageStr(b.timestamp)}`}
                       />
                     ))}


### PR DESCRIPTION
## Summary

- **Previously:** only the `feePayer` of a proven tx had their fee-juice balance snapshotted
- **Now:** `feePayer`, `initiator`, and all distinct `msgSender` addresses from public call requests are all snapshotted — deduplicated across the entire block with parallel RPC fetches
- This unblocks the address page in the explorer UI showing fee-juice balance history for any address

## Changes

### `services/aztec-listener`

**`src/svcs/database/schema.ts`**
- Added `initiator` (nullable varchar) and `additional_msg_senders` (nullable varchar, comma-separated) columns to `txsTable`

**`src/svcs/database/txs.controller.ts`**
- `storeOrUpdate` now persists `initiator` and `additionalMsgSenders` extracted from `publicCallRequests` at pending-tx time
- `getTxs` maps `null → undefined` so the rest of the codebase stays typed against `ChicmozL2PendingTx`
- New `storeOrUpdateState` helper for lean state-only updates (used at proven time)

**`src/svcs/poller/pollers/block_poller/handle-proven-block-txs.ts`**
- Replaced per-tx sequential loop with a block-level batch approach:
  1. Collect all unique addresses across all proven txs → `Map<address, firstTxHash>`
  2. Fetch all balances in parallel via `Promise.allSettled`
  3. Publish `CONTRACT_INSTANCE_BALANCE_EVENT` for each address in parallel
  4. Update tx states in parallel

**`migrations/0004_add_initiator_and_msg_senders.sql`**
- Adds `initiator` and `additional_msg_senders` columns to `txs_table`

### `docs/fee-juice-balance-history.md`
- Research notes covering the full data flow, gaps identified, and implementation options considered

## No changes needed in
- `packages/message-registry` — reuses existing `CONTRACT_INSTANCE_BALANCE_EVENT`
- `services/explorer-api` — existing Kafka consumer, DB table, and `/balance/history` endpoint handle any address automatically