### PR TITLE
feat: expose native L2 tips health

### DIFF
--- a/PLAN1.md
+++ b/PLAN1.md
@@ -1,0 +1,69 @@
+# PLAN1: Native Tips Health Endpoint, Docs, and Tests
+
+## Goal
+
+Complete the additive native L2 tips rollout by making tip state observable and documented before relying on it operationally.
+
+## Scope
+
+- Add a read-only API endpoint for latest stored L2 tips.
+- Expose freshness/degraded state clearly.
+- Add OpenAPI/docs for `nativeStatus` and tips.
+- Add focused tests for native tip storage and status derivation.
+
+## Proposed changes
+
+### Explorer API
+
+- Add endpoint, for example:
+  - `GET /l2/tips`
+  - or include in an existing network-health endpoint if one is preferred.
+- Response should include:
+  - `tips`
+  - `observedAt`
+  - `stale: boolean`
+  - `stalenessMs`
+  - `degraded: boolean`
+  - `degradedReason?: string`
+  - `source.rpcNodeName?`
+  - `source.aztecNodeVersion?`
+- Add an env-backed stale threshold, e.g. `L2_TIPS_STALE_AFTER_MS`, with a conservative default.
+- Update OpenAPI response schemas.
+
+### Docs/API contract
+
+- Document that `nativeStatus` is additive and preferred for display.
+- Document that legacy `finalizationStatus` remains for compatibility until a later PR.
+- Document Aztec v4 caveat: upstream `finalized` may equal `proven`.
+- Add product wording for `checkpointed` and `unknown`.
+
+### Tests
+
+- Unit-test `deriveNativeStatus`:
+  - no tips => `unknown`
+  - stale/degraded tips => `unknown`
+  - proposed/checkpointed/proven/finalized thresholds
+  - orphaned block => `unknown`
+  - height above proposed => `unknown`
+  - v4 `finalized === proven` case
+- Unit-test `upsertTips` boundary validation:
+  - matching boundary block
+  - missing boundary block
+  - mismatched boundary hash
+- Add a lightweight route test for the tips endpoint.
+
+## Out of scope
+
+- Removing legacy finalization status.
+- Cadenced catchup.
+- Disabling eternal catchup.
+
+## Verification
+
+- `yarn build:packages`
+- focused `explorer-api` tests for tips/status logic
+- `yarn lint` or service/package lint as appropriate
+
+## Risk
+
+Low. This is additive/read-only and improves observability before later removals.

--- a/PLAN2.md
+++ b/PLAN2.md
@@ -1,0 +1,105 @@
+# PLAN2: Cadenced Catchup, Metrics, Limiter, and Deduplication
+
+## Goal
+
+Turn startup-only Explorer-driven catchup into a reliable reconciliation loop that can continuously repair missing Explorer blocks without relying on eternal full-chain replay.
+
+## Scope
+
+- Add cadenced missing-block reconciliation in `explorer-api`.
+- Add bounded/open-gap tracking.
+- Add request metrics/logs.
+- Add listener-side limiter/deduplication for request-driven catchup.
+- Add tip-boundary-mismatch repair requests.
+
+## Proposed changes
+
+### Explorer API reconciliation service
+
+- Add a service started from `explorer-api` startup after DB/Kafka init.
+- Config:
+  - `L2_BLOCK_RECONCILIATION_ENABLED=true`
+  - `L2_BLOCK_RECONCILIATION_INTERVAL_MS`
+  - `L2_BLOCK_RECONCILIATION_SCAN_WINDOW`
+  - `L2_BLOCK_RECONCILIATION_MAX_BLOCKS`
+- On each cadence:
+  - determine safe upper bound from stored `l2_tips.proposed.number` if available
+  - scan a recent bounded window for missing non-orphan heights
+  - publish `L2_BLOCK_RANGE_REQUEST_EVENT` with `reason: "cadence"`
+- Keep startup reconciliation, but share code with cadence reconciliation.
+
+### Open gap tracking
+
+- Either add a small DB table for open gaps or maintain a conservative recompute-from-DB approach initially.
+- If adding DB state, track:
+  - `from`, `to`
+  - `reason`
+  - `firstSeenAt`, `lastRequestedAt`
+  - `attemptCount`
+  - `lastFailureReason?`
+- Avoid scanning the entire historical chain every interval.
+
+### Tip-boundary mismatch repair
+
+- When stored tips are degraded because a boundary block is missing/mismatched, request a small repair window around the boundary.
+- Publish with `reason: "tip_boundary_mismatch"`.
+- Let existing Explorer block/reorg handling decide canonical/orphan state.
+
+### Listener fulfillment improvements
+
+- Add dedicated limiter/queue for `L2_BLOCK_RANGE_REQUEST_EVENT` handling.
+- Deduplicate in-flight requests by `networkId + from + to + reason`.
+- Keep hard caps:
+  - max ranges per request
+  - max blocks per request
+  - max request age
+  - max range width
+- Continue clamping upper bounds to current Aztec node proposed/proven tips.
+- Never let historical repair starve live head polling.
+
+### Metrics/logging
+
+Add structured logs/metrics for:
+
+- request created
+- request reason
+- requested ranges/count
+- fulfilled blocks
+- failed heights/ranges
+- request latency
+- skipped stale/invalid requests
+- deduped requests
+- remaining open gaps
+
+Optional: add `L2_BLOCK_RANGE_RESPONSE_EVENT` if dashboards need explicit response correlation.
+
+## Tests
+
+- Unit-test missing-range detection:
+  - no gaps
+  - single gap
+  - contiguous gaps
+  - split ranges
+  - upper-bound clamping
+  - max-block cap
+- Unit-test listener validation/clamping/dedup logic.
+- Integration-test request -> catchup event -> Explorer stores block.
+- Regression-test that live polling still runs independently of request catchup.
+
+## Out of scope
+
+- Removing eternal catchup.
+- Removing env vars.
+- Removing legacy finalization status.
+
+## Verification
+
+- focused tests for Explorer gap detection
+- focused tests for listener fulfillment
+- `yarn build:packages`
+- service-level lint/build for `explorer-api` and `aztec-listener`
+- devnet/testnet observation before production enablement
+
+## Risk
+
+Medium. This changes background behavior and can increase Aztec RPC/Kafka load if misconfigured. Keep conservative defaults and bounded requests.

--- a/PLAN3.md
+++ b/PLAN3.md
@@ -1,0 +1,71 @@
+# PLAN3: Disable Eternal Catchup by Default
+
+## Goal
+
+Make request-driven reconciliation the primary repair path and demote eternal catchup to an explicit fallback/disaster-recovery mechanism.
+
+## Preconditions
+
+- PLAN2 has shipped and been observed in devnet/testnet and ideally production.
+- Metrics show cadenced reconciliation closes normal missing-block gaps.
+- No recurring unrepaired gaps that only eternal catchup fixes.
+
+## Scope
+
+- Disable eternal catchup by default in production configuration.
+- Keep a deliberate manual/full-sweep mode for disaster recovery.
+- Preserve an easy rollback path.
+
+## Proposed changes
+
+### Aztec listener config
+
+- Change default behavior so eternal catchup is off unless explicitly enabled.
+- Prefer renaming semantics in a follow-up-safe way:
+  - current: `AZTEC_DISABLE_ETERNAL_CATCHUP`
+  - future clearer option: `AZTEC_ENABLE_FULL_SWEEP_CATCHUP`
+- For this PR, avoid breaking existing deployments unless intentionally coordinated.
+
+### Kubernetes/env configuration
+
+- Set production/testnet/devnet config explicitly so behavior is obvious.
+- Keep rollback simple:
+  - set env var to re-enable eternal catchup if request-driven reconciliation underperforms.
+
+### Operational docs
+
+- Document when to use full-sweep catchup:
+  - disaster recovery
+  - suspected historical gaps beyond reconciliation window
+  - Kafka retention/consumer offset incidents
+- Document expected normal path:
+  - Explorer detects missing ranges
+  - Explorer publishes bounded requests
+  - listener publishes catchup blocks
+
+### Logging
+
+- Log at startup whether eternal/full-sweep catchup is enabled.
+- If disabled, log that request-driven reconciliation is expected to be the primary repair path.
+
+## Tests
+
+- Unit-test/env parse behavior for enabled/disabled modes.
+- Verify listener does not call eternal catchup when disabled.
+- Verify manual/full-sweep mode still works when enabled.
+
+## Out of scope
+
+- Removing the env var entirely.
+- Removing forced-start env vars.
+- Removing legacy finalization status.
+
+## Verification
+
+- service-level tests/build for `aztec-listener`
+- inspect rendered k8s manifests for expected env values
+- deploy to devnet/testnet first and watch reconciliation metrics
+
+## Risk
+
+Medium. This changes a safety-net behavior. Only ship after PLAN2 has enough metrics and observation.

--- a/PLAN4.md
+++ b/PLAN4.md
@@ -1,0 +1,70 @@
+# PLAN4: Remove Legacy Catchup Env Knobs
+
+## Goal
+
+Remove old operator knobs that are no longer needed once Explorer-driven reconciliation and explicit full-sweep recovery are proven.
+
+## Preconditions
+
+- PLAN2 and PLAN3 have shipped.
+- Cadenced reconciliation is stable.
+- Full-sweep/manual recovery has a clear replacement command/config.
+- Operators no longer rely on forced-start or ignore-processed-height behavior for normal recovery.
+
+## Scope
+
+Remove or replace:
+
+- `IGNORE_PROCESSED_HEIGHT`
+- `AZTEC_LISTEN_FOR_PROPOSED_BLOCKS_FORCED_START_FROM_HEIGHT`
+- `AZTEC_LISTEN_FOR_PROVEN_BLOCKS_FORCED_START_FROM_HEIGHT`
+- Possibly `AZTEC_DISABLE_ETERNAL_CATCHUP`, if replaced by clearer full-sweep config.
+
+## Proposed changes
+
+### Code cleanup
+
+- Remove env parsing for unused catchup knobs from `services/aztec-listener/src/environment.ts`.
+- Remove startup config printing for removed vars.
+- Remove forced-start plumbing from poller startup if no replacement path needs it.
+- Remove ignore-processed-height behavior from height initialization/storage logic if still present.
+
+### Replacement operator path
+
+- If operators still need a manual repair path, prefer one explicit action:
+  - publish manual `L2_BLOCK_RANGE_REQUEST_EVENT`, or
+  - enable a clearly named full-sweep/manual mode temporarily.
+- Document exact command/process for manual gap repair.
+
+### Kubernetes/docs cleanup
+
+- Remove deleted env vars from:
+  - service base overlays
+  - local/staging/production manifests
+  - README/env docs
+  - CI/CD migration docs if still relevant
+- Make sure no deployment references removed variables.
+
+## Tests
+
+- Build `aztec-listener` after env removal.
+- Search repo for removed env names; only historical changelog references should remain, if any.
+- Verify default listener startup still initializes heights and follows live head.
+- Verify manual range request remains the documented replacement.
+
+## Out of scope
+
+- Removing legacy finalization status.
+- Removing L1 metadata ingestion.
+- Changing normal block polling semantics beyond env cleanup.
+
+## Verification
+
+- `yarn build:packages`
+- `aztec-listener` lint/build/test
+- repo-wide search for removed env names
+- render/check k8s manifests if available
+
+## Risk
+
+Medium. This removes operator escape hatches. Do it only after replacement operational workflows are documented and tested.

--- a/PLAN5.md
+++ b/PLAN5.md
@@ -1,0 +1,90 @@
+# PLAN5: Remove Legacy Finalization Status Path
+
+## Goal
+
+Complete the migration to Aztec-native block status by removing the legacy finalization-status model from product-facing flows.
+
+## Preconditions
+
+- Native tips/status have run through a production observation window.
+- API/UI consumers have migrated to `nativeStatus` or tip-derived display.
+- Comparison metrics/logs show native status is safe enough to replace legacy display.
+- L1 proposal/proof events remain available as metadata.
+
+## Scope
+
+- Remove legacy finalization-status storage/use from Explorer display paths.
+- Stop treating L1 rollup events as product-facing status transitions.
+- Remove old finalization update Kafka/websocket fanout once clients no longer need it.
+- Keep L1 proposal/proof data as factual block metadata.
+
+## Proposed changes
+
+### Explorer API
+
+- Stop deriving display status from `ChicmozL2BlockFinalizationStatus`.
+- Keep or migrate response fields carefully:
+  - preferred: `nativeStatus`
+  - optionally keep deprecated `finalizationStatus` for one more release if external clients need time
+- Remove legacy finalization-status DB writes from L1 event handlers.
+- Keep L1 event tables/relations for:
+  - proposed tx hash/block hash/timestamp
+  - proof verified tx hash/block hash/timestamp
+  - prover/archive metadata
+
+### Kafka/websocket
+
+- Remove `L2_BLOCK_FINALIZATION_UPDATE_EVENT` publisher/subscriber path after clients use tips/native status.
+- Keep `L2_TIPS_EVENT` as the status-update broadcast primitive.
+- Prefer UI invalidation/status derivation from tip snapshots over per-block historical fanout.
+
+### UI
+
+- Make native status the only displayed status badge source.
+- Preserve orphan visual priority over native status.
+- Remove legacy badge mapping and legacy status filters.
+- Add/keep native filters:
+  - `proposed`
+  - `checkpointed`
+  - `proven`
+  - `finalized`
+  - `unknown`
+  - `orphaned`
+
+### Database/migrations
+
+- Stop reading/writing old finalization-status tables first.
+- Only drop legacy DB objects in a final migration after rollback risk is acceptable.
+- Consider a two-step approach:
+  1. unused in code, table retained
+  2. later migration drops table/indexes
+
+### Types
+
+- Remove or deprecate `ChicmozL2BlockFinalizationStatus` from public response types only when SDK/API consumers are ready.
+- Keep internal compatibility only if needed for migration.
+
+## Tests
+
+- API tests verify `nativeStatus` exists and legacy status is absent/deprecated as intended.
+- UI tests/screenshots for native status badges and orphan priority.
+- Regression tests that L1 proposal/proof metadata still appears on block detail pages.
+- Websocket tests verify tip updates refresh visible statuses.
+
+## Out of scope
+
+- Removing L1 event ingestion entirely.
+- Changing Aztec listener block polling.
+- Catchup env cleanup, unless PLAN4 has not already done it.
+
+## Verification
+
+- `yarn build:packages`
+- `explorer-api` lint/build/tests
+- `explorer-ui` lint/build/tests
+- websocket service build/tests
+- production canary after deploy: latest blocks, historical blocks, orphaned blocks, L1 metadata, websocket tip updates
+
+## Risk
+
+Medium to high. This is the public compatibility/removal step. Keep rollback easy by separating code-unused and DB-drop phases.

--- a/README.md
+++ b/README.md
@@ -539,6 +539,53 @@ Get details of a specific block.
 }
 ```
 
+#### Native L2 status fields
+
+Block responses may include both:
+
+- `nativeStatus`: additive Aztec-native display status derived from `AztecNode.getL2Tips()` snapshots. Prefer this for product display when present.
+- `finalizationStatus`: legacy compatibility status. This remains available until a later migration removes the old finalization-status path.
+
+Native status values:
+
+- `proposed`: block is at or below the latest proposed tip.
+- `checkpointed`: block is at or below the latest checkpointed tip.
+- `proven`: block is at or below the latest proven tip.
+- `finalized`: block is at or below the latest finalized tip. On Aztec v4 this may currently be equal to `proven` upstream.
+- `unknown`: tips are missing, stale/degraded, the block is orphaned, or the block is above the proposed tip.
+
+#### `GET /api/v1/{apiKey}/l2/tips`
+
+Get the latest Aztec-native L2 tips observed by `aztec-listener` and stored by `explorer-api`.
+
+**Response**:
+
+```json
+{
+  "tips": {
+    "proposed": { "number": 123, "hash": "0x..." },
+    "checkpointed": {
+      "block": { "number": 120, "hash": "0x..." },
+      "checkpoint": { "number": 12, "hash": "0x..." }
+    },
+    "proven": {
+      "block": { "number": 118, "hash": "0x..." },
+      "checkpoint": { "number": 11, "hash": "0x..." }
+    },
+    "finalized": {
+      "block": { "number": 118, "hash": "0x..." },
+      "checkpoint": { "number": 11, "hash": "0x..." }
+    }
+  },
+  "observedAt": 1710000000000,
+  "stale": false,
+  "stalenessMs": 1500,
+  "staleAfterMs": 60000,
+  "degraded": false,
+  "source": { "rpcNodeName": "aztec-rpc-1" }
+}
+```
+
 ### Transactions
 
 #### `GET /api/v1/{apiKey}/l2/txs`

--- a/packages/types/src/aztec/l2Block.ts
+++ b/packages/types/src/aztec/l2Block.ts
@@ -79,6 +79,22 @@ export const chicmozL2TipsSchema = z.object({
 
 export type ChicmozL2Tips = z.infer<typeof chicmozL2TipsSchema>;
 
+export const chicmozL2TipsHealthSchema = z.object({
+  tips: chicmozL2TipsSchema,
+  observedAt: z.coerce.number().int().nonnegative(),
+  stale: z.boolean(),
+  stalenessMs: z.coerce.number().int().nonnegative(),
+  staleAfterMs: z.coerce.number().int().positive(),
+  degraded: z.boolean(),
+  degradedReason: z.string().optional(),
+  source: z.object({
+    rpcNodeName: z.string().optional(),
+    aztecNodeVersion: z.string().optional(),
+  }),
+});
+
+export type ChicmozL2TipsHealth = z.infer<typeof chicmozL2TipsHealthSchema>;
+
 export const chicmozL2BlockSchema = z.object({
   hash: hexStringSchema,
   height: z.coerce.bigint().nonnegative(),

--- a/services/explorer-api/src/environment.ts
+++ b/services/explorer-api/src/environment.ts
@@ -22,6 +22,9 @@ export const DB_MAX_BLOCKS = 20;
 export const DB_MAX_TX_EFFECTS = 100;
 export const DB_MAX_CONTRACTS = 20;
 
+export const L2_TIPS_STALE_AFTER_MS =
+  Number(process.env.L2_TIPS_STALE_AFTER_MS) || 60_000;
+
 export const L2_NETWORK_ID: L2NetworkId = l2NetworkIdSchema.parse(
   process.env.L2_NETWORK_ID,
 );

--- a/services/explorer-api/src/svcs/http-server/routes/controllers/index.ts
+++ b/services/explorer-api/src/svcs/http-server/routes/controllers/index.ts
@@ -9,6 +9,7 @@ export * from "./contract-instance-balance.js";
 export * from "./contract-instances.js";
 export * from "./dropped-tx.js";
 export * from "./fee-recipients.js";
+export * from "./l2-tips.js";
 export * from "./l1/contract-events.js";
 export * from "./rpc-nodes.js";
 export * from "./search.js";

--- a/services/explorer-api/src/svcs/http-server/routes/controllers/l2-tips.ts
+++ b/services/explorer-api/src/svcs/http-server/routes/controllers/l2-tips.ts
@@ -1,0 +1,54 @@
+import { type ChicmozL2TipsHealth } from "@chicmoz-pkg/types";
+import asyncHandler from "express-async-handler";
+import { OpenAPIObject } from "openapi3-ts/oas31";
+import { L2_TIPS_STALE_AFTER_MS } from "../../../../environment.js";
+import { controllers as db } from "../../../database/index.js";
+import { l2TipsHealthResponse } from "./utils/index.js";
+
+export const openapi_GET_L2_TIPS: OpenAPIObject["paths"] = {
+  "/l2/tips": {
+    get: {
+      tags: ["l2-chain"],
+      summary: "Get latest Aztec native L2 tips and health state",
+      description:
+        "Returns the latest L2 tip snapshot observed from AztecNode.getL2Tips(). " +
+        "`nativeStatus` is the preferred additive block-display status derived from these tips; " +
+        "legacy `finalizationStatus` remains available for compatibility until a later migration. " +
+        "On Aztec v4, upstream `finalized` may currently equal `proven`. " +
+        "`checkpointed` means the block is at or below the latest checkpointed tip; `unknown` means tips are missing, stale/degraded, orphaned, or the block is above the proposed tip.",
+      responses: l2TipsHealthResponse,
+    },
+  },
+};
+
+const buildTipsHealth = (
+  tips: NonNullable<Awaited<ReturnType<typeof db.l2.tips.getTips>>>,
+): ChicmozL2TipsHealth => {
+  const stalenessMs = Math.max(0, Date.now() - tips.observedAt);
+  const degraded = tips.degradedReason !== undefined;
+  return {
+    tips: {
+      proposed: tips.proposed,
+      proposedCheckpoint: tips.proposedCheckpoint,
+      checkpointed: tips.checkpointed,
+      proven: tips.proven,
+      finalized: tips.finalized,
+    },
+    observedAt: tips.observedAt,
+    stale: stalenessMs >= L2_TIPS_STALE_AFTER_MS,
+    stalenessMs,
+    staleAfterMs: L2_TIPS_STALE_AFTER_MS,
+    degraded,
+    degradedReason: tips.degradedReason,
+    source: tips.source,
+  };
+};
+
+export const GET_L2_TIPS = asyncHandler(async (_req, res) => {
+  const tips = await db.l2.tips.getTips();
+  if (!tips) {
+    res.status(404).send("L2 tips not found");
+    return;
+  }
+  res.status(200).json(buildTipsHealth(tips));
+});

--- a/services/explorer-api/src/svcs/http-server/routes/controllers/utils/open-api-responses.ts
+++ b/services/explorer-api/src/svcs/http-server/routes/controllers/utils/open-api-responses.ts
@@ -14,6 +14,7 @@ import {
   chicmozL2PendingTxSchema,
   chicmozL2PrivateFunctionBroadcastedEventSchema,
   chicmozL2RpcNodeErrorSchema,
+  chicmozL2TipsHealthSchema,
   chicmozL2TxEffectDeluxeSchema,
   chicmozL2UtilityFunctionBroadcastedEventSchema,
   chicmozReorgSchema,
@@ -282,6 +283,11 @@ const cleanedChainInfoSchema = chicmozChainInfoSchema.extend({
 export const chainInfoResponse = getResponse(
   cleanedChainInfoSchema,
   "chainInfo",
+);
+
+export const l2TipsHealthResponse = getResponse(
+  chicmozL2TipsHealthSchema,
+  "l2TipsHealth",
 );
 
 export const chainErrorsResponse = rpcNodeErrorResponseArray;

--- a/services/explorer-api/src/svcs/http-server/routes/index.ts
+++ b/services/explorer-api/src/svcs/http-server/routes/index.ts
@@ -70,6 +70,7 @@ export const openApiPaths: OpenAPIObject["paths"] = {
   ...controller.openapi_GET_L1_CONTRACT_EVENTS_HOURLY_COUNTS,
 
   ...controller.openapi_GET_CHAIN_INFO,
+  ...controller.openapi_GET_L2_TIPS,
   ...controller.openapi_GET_ROLLUP_VERSIONS,
   ...controller.openapi_GET_CHAIN_ERRORS,
 
@@ -303,6 +304,7 @@ export const init = ({ router }: { router: Router }) => {
   router.get(paths.l1ContractEvents, controller.GET_L1_CONTRACT_EVENTS);
 
   router.get(paths.chainInfo, controller.GET_CHAIN_INFO);
+  router.get(paths.l2Tips, controller.GET_L2_TIPS);
   router.get(paths.rollupVersions, controller.GET_ROLLUP_VERSIONS);
   router.get(paths.chainErrors, controller.GET_CHAIN_ERRORS);
 

--- a/services/explorer-api/src/svcs/http-server/routes/paths_and_validation.ts
+++ b/services/explorer-api/src/svcs/http-server/routes/paths_and_validation.ts
@@ -104,6 +104,7 @@ export const paths = {
   l1ContractEventsHourlyCounts: "/l1/contract-events/hourly-counts",
 
   chainInfo: "/l2/info",
+  l2Tips: "/l2/tips",
   rollupVersions: "/l2/rollup-versions",
   chainErrors: "/l2/errors",
   rpcNodes: "/l2/rpc-nodes",


### PR DESCRIPTION
## Summary

Adds an observable native L2 tips health surface for the additive `getL2Tips()` rollout.

### What changed

- Adds `GET /l2/tips` to `explorer-api`.
- Returns the latest stored Aztec-native L2 tips plus health fields:
  - `observedAt`
  - `stale`
  - `stalenessMs`
  - `staleAfterMs`
  - `degraded`
  - `degradedReason`
  - `source`
- Adds `L2_TIPS_STALE_AFTER_MS` with default `60000`.
- Adds shared `chicmozL2TipsHealthSchema` / `ChicmozL2TipsHealth`.
- Wires OpenAPI docs for `/l2/tips`.
- Updates README with the native status contract, legacy `finalizationStatus` compatibility note, Aztec v4 finalized/proven caveat, and `/l2/tips` example.

## Runtime verification

Checked the testnet local API through:

`http://api.testnet.chicmoz.localhost:8080/v1/dev-api-key`

Results:

- `GET /l2/tips` returns `200 OK`.
- Latest observed response had:
  - `stale: false`
  - `degraded: false`
  - `staleAfterMs: 60000`
  - proposed tip `87037`
  - proven/finalized tip `87005`
- `GET /l2/info` returns `200 OK` for `TESTNET` / Ethereum Sepolia `11155111`.
- `GET /l2/latest-height` returns `87037`, matching the current proposed tip from `/l2/tips`.

Checked `ssh quinque` read-only cluster state:

- Minikube container is running.
- Chicmoz namespace deployments are available:
  - `auth-deployment` 1/1
  - `aztec-listener-testnet-deployment` 1/1
  - `ethereum-listener-testnet-deployment` 1/1
  - `explorer-api-testnet-deployment` 1/1
  - `redis-cache` 1/1
  - `websocket-event-publisher-testnet-deployment` 1/1
- Stateful services are running:
  - `kafka-0` 1/1
  - `postgresql-0` 1/1

Notes:

- Explorer API logs show normal startup consumer joins and healthy `/health` probes.
- I saw transient Kafka rebalancing messages during startup and transient tip-degraded warnings when a new tip arrived just before the corresponding block was stored. The latest API health response was clean (`stale: false`, `degraded: false`), so this looks consistent with the intended degraded-mode behavior rather than a current failure.

## Verification commands already run locally

- `yarn build:packages`
- `yarn workspace @chicmoz/explorer-api build`
- `yarn workspace @chicmoz/explorer-api lint`
- `yarn lint:packages`
