### PR TITLE
Add native L2 status regression coverage

### DIFF
--- a/FUTURE-WORK.md
+++ b/FUTURE-WORK.md
@@ -2,16 +2,7 @@
 
 ## Remaining correctness work
 
-- Add a regression test for the cache overlay path: cached block-detail and
-  table responses must recompute `nativeStatus` from fresh `/l2/tips` state
-  instead of serving stale `unknown` after a degraded/catchup window recovers.
-- Add focused tests for native status derivation:
-  - `deriveNativeStatus` for proposed, checkpointed, proven, finalized, unknown, and orphaned blocks.
-  - missing boundary block behavior.
-  - boundary hash mismatch behavior.
-  - Aztec v4 behavior where upstream `finalized` may equal `proven`.
 - Add focused tests for L2 tips storage and transport:
-  - `upsertTips` happy path.
   - stale/degraded health output.
   - `L2_TIPS_EVENT` publication, consumption, and websocket forwarding.
 - Add catchup/reconciliation tests:
@@ -24,13 +15,12 @@
 
 ## Remaining product/API cleanup
 
-- Rename remaining compatibility-oriented client/hook names such as `useBlocksByFinalizationStatus` and `/by-status` call sites to native-status terminology.
-- Update public docs/OpenAPI/SDK examples so consumers understand:
+- Update SDK examples so consumers understand:
   - `nativeStatus` is the product-facing block status.
   - `finalizationStatus` is legacy compatibility data and should not drive UI display.
   - `checkpointed` is a native Aztec L2 tip bucket.
   - on Aztec v4, upstream `finalized` may equal `proven`.
-- Add explicit deprecation notes for `finalizationStatus` in public response docs and SDK docs.
+- Add explicit deprecation notes for `finalizationStatus` in SDK docs.
 
 ## Remaining operational improvements
 

--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ Get a list of blocks with pagination.
 - `page`: Page number (default: 1)
 - `limit`: Items per page (default: 10)
 - `sort`: Sort direction (asc/desc)
-- `finalizationStatus`: Filter by finalization status
+- `status`: Filter by product-facing native block status (`proposed`, `checkpointed`, `proven`, `finalized`, `unknown`, `orphaned`) where supported.
 
 **Response**:
 
@@ -498,6 +498,7 @@ Get a list of blocks with pagination.
       "hash": "0x...",
       "timestamp": "2023-01-01T00:00:00Z",
       "transactionCount": 5,
+      "nativeStatus": "proven",
       "finalizationStatus": "L2_NODE_SEEN_PROVEN"
     }
   ],
@@ -531,6 +532,7 @@ Get details of a specific block.
     "transactionHashes": ["0x...", "0x..."],
     "version": "1.0.0"
   },
+  "nativeStatus": "proven",
   "finalizationStatus": "L2_NODE_SEEN_PROVEN",
   "l1Data": {
     "rollupContractAddress": "0x...",
@@ -543,8 +545,8 @@ Get details of a specific block.
 
 Block responses may include both:
 
-- `nativeStatus`: additive Aztec-native display status derived from `AztecNode.getL2Tips()` snapshots. Prefer this for product display when present.
-- `finalizationStatus`: legacy compatibility status. This remains available until a later migration removes the old finalization-status path.
+- `nativeStatus`: product-facing Aztec-native display status derived from `AztecNode.getL2Tips()` snapshots. Use this for UI and consumer-facing status labels.
+- `finalizationStatus`: **deprecated** legacy compatibility status. It remains available until a later migration removes the old finalization-status path, but consumers should not use it to drive product display.
 
 Native status values:
 

--- a/packages/types/src/aztec/l2Block.ts
+++ b/packages/types/src/aztec/l2Block.ts
@@ -34,7 +34,10 @@ export const LAST_FINALIZATION_STATUS =
 
 export const chicmozL2BlockFinalizationStatusSchema = z
   .nativeEnum(ChicmozL2BlockFinalizationStatus)
-  .default(0);
+  .default(0)
+  .describe(
+    "Deprecated legacy compatibility status. Prefer nativeStatus for product display.",
+  );
 
 export const chicmozL2NativeBlockStatusSchema = z.enum([
   "proposed",
@@ -42,7 +45,9 @@ export const chicmozL2NativeBlockStatusSchema = z.enum([
   "proven",
   "finalized",
   "unknown",
-]);
+]).describe(
+  "Aztec-native block display status derived from current L2 tips. On Aztec v4, finalized may equal proven upstream.",
+);
 
 export type ChicmozL2NativeBlockStatus = z.infer<
   typeof chicmozL2NativeBlockStatusSchema

--- a/packages/types/src/aztec/ui.ts
+++ b/packages/types/src/aztec/ui.ts
@@ -22,8 +22,12 @@ export const uiBlockTableSchema = z.object({
   height: z.coerce.bigint().nonnegative(),
   timestamp: frTimestampSchema,
   txEffectsLength: z.number(),
-  blockStatus: chicmozL2BlockFinalizationStatusSchema,
-  nativeStatus: chicmozL2NativeBlockStatusSchema.optional(),
+  blockStatus: chicmozL2BlockFinalizationStatusSchema.describe(
+    "Deprecated legacy finalization status kept for compatibility; do not drive UI display from this field.",
+  ),
+  nativeStatus: chicmozL2NativeBlockStatusSchema
+    .describe("Product-facing Aztec-native block status derived from L2 tips.")
+    .optional(),
   // True when the block has been reorged out. The row should still be shown
   // (the design has an "orphaned" filter chip) but the StatusPill must
   // collapse to "orphaned" rather than its pre-orphan finalization status.

--- a/services/explorer-api/package.json
+++ b/services/explorer-api/package.json
@@ -34,7 +34,7 @@
     "pg": "8.11.3",
     "redis": "4.6.13",
     "uuid": "10.0.0",
-    "zod": "^3.23.8"
+    "zod": "3.23.8"
   },
   "devDependencies": {
     "@types/auto-bind": "2.1.0",
@@ -57,7 +57,8 @@
     "eslint-plugin-n": "15.0.0 || 16.0.0 ",
     "eslint-plugin-promise": "6.0.0",
     "supertest": "6.3.3",
-    "typescript": "5.8.3"
+    "typescript": "5.8.3",
+    "vitest": "3.2.4"
   },
   "scripts": {
     "prebuild": "rm -rf build; mkdir build",
@@ -69,7 +70,10 @@
     "migrate": "yarn node build/scripts/migrate.js",
     "start": "yarn node --unhandled-rejections=strict --enable-source-maps build/src/index.js",
     "lint": "yarn run lint-base --ext .ts .",
-    "lint-base": "yarn run g:lint"
+    "lint-base": "yarn run g:lint",
+    "test": "vitest run",
+    "test-once": "vitest run",
+    "test:watch": "vitest"
   },
   "type": "module"
 }

--- a/services/explorer-api/src/svcs/database/controllers/l2block/get-block.ts
+++ b/services/explorer-api/src/svcs/database/controllers/l2block/get-block.ts
@@ -122,10 +122,10 @@ export const getBlock = async (
 };
 
 /**
- * Deprecated compatibility endpoint: returns representative native-tip boundary
- * blocks instead of reading the retired finalization-status table.
+ * Deprecated public path compatibility: returns representative native-tip
+ * boundary blocks instead of reading the retired finalization-status table.
  */
-export const getBlocksByFinalizationStatus = async (
+export const getBlocksByNativeStatus = async (
   options: BlockQueryOptions = {},
 ): Promise<ChicmozL2BlockLight[]> => {
   const tips = await getTips();

--- a/services/explorer-api/src/svcs/http-server/routes/controllers/blocks.ts
+++ b/services/explorer-api/src/svcs/http-server/routes/controllers/blocks.ts
@@ -148,22 +148,22 @@ export const GET_BLOCKS = asyncHandler(async (req, res) => {
   res.status(200).json(await parseWithFreshNativeStatuses(blocksData));
 });
 
-export const openapi_GET_BLOCKS_BY_FINALIZATION_STATUS: OpenAPIObject["paths"] =
+export const openapi_GET_BLOCKS_BY_NATIVE_STATUS: OpenAPIObject["paths"] =
   {
     "/l2/blocks/by-status": {
       get: {
         tags: ["L2", "blocks"],
-        summary: "Get one block for each finalization status",
+        summary: "Get representative blocks for native L2 status buckets",
         responses: blockResponseArray,
       },
     },
   };
 
-export const GET_BLOCKS_BY_FINALIZATION_STATUS = asyncHandler(
+export const GET_BLOCKS_BY_NATIVE_STATUS = asyncHandler(
   async (_req, res) => {
     const blocksData = await dbWrapper.getLatest(
       ["l2", "blocks", "by-status"],
-      () => db.l2Block.getBlocksByFinalizationStatus(),
+      () => db.l2Block.getBlocksByNativeStatus(),
     );
     res.status(200).json(await parseWithFreshNativeStatuses(blocksData));
   },

--- a/services/explorer-api/src/svcs/http-server/routes/controllers/utils/open-api-responses.ts
+++ b/services/explorer-api/src/svcs/http-server/routes/controllers/utils/open-api-responses.ts
@@ -61,6 +61,12 @@ const getResponse = (zodSchema: z.ZodType<any, any>, name?: string) => {
 
 const cleanedBlockSchema = chicmozL2BlockLightSchema.extend({
   height: z.string(), // Convert height from BigInt to string
+  finalizationStatus: chicmozL2BlockLightSchema.shape.finalizationStatus.describe(
+    "Deprecated legacy compatibility status; prefer nativeStatus for product display.",
+  ),
+  nativeStatus: chicmozL2BlockLightSchema.shape.nativeStatus.describe(
+    "Product-facing Aztec-native block status derived from current L2 tips. `checkpointed` is a native L2 tip bucket; on Aztec v4, upstream `finalized` may equal `proven`.",
+  ),
   proposedOnL1: z
     .object({
       l1ContractAddress: z.string(),

--- a/services/explorer-api/src/svcs/http-server/routes/index.ts
+++ b/services/explorer-api/src/svcs/http-server/routes/index.ts
@@ -12,7 +12,7 @@ export const openApiPaths: OpenAPIObject["paths"] = {
   ...controller.openapi_GET_LATEST_BLOCK,
   ...controller.openapi_GET_BLOCK,
   ...controller.openapi_GET_BLOCKS, // TODO: rename to L2_GET_BLOCKS?
-  ...controller.openapi_GET_BLOCKS_BY_FINALIZATION_STATUS,
+  ...controller.openapi_GET_BLOCKS_BY_NATIVE_STATUS,
   ...controller.openapi_GET_ORPHANED_BLOCKS,
   ...controller.openapi_GET_ORPHANED_BLOCKS_LIMITED,
   ...controller.openapi_GET_REORGS,
@@ -156,8 +156,8 @@ export const init = ({ router }: { router: Router }) => {
   router.get(paths.latestHeight, controller.GET_LATEST_HEIGHT);
   router.get(paths.latestBlock, controller.GET_LATEST_BLOCK);
   router.get(
-    paths.blocksByStatus,
-    controller.GET_BLOCKS_BY_FINALIZATION_STATUS,
+    paths.blocksByNativeStatus,
+    controller.GET_BLOCKS_BY_NATIVE_STATUS,
   );
   router.get(paths.orphanedBlocks, controller.GET_ORPHANED_BLOCKS);
   router.get(

--- a/services/explorer-api/src/svcs/http-server/routes/paths_and_validation.ts
+++ b/services/explorer-api/src/svcs/http-server/routes/paths_and_validation.ts
@@ -31,7 +31,7 @@ export const paths = {
   latestBlock: "/l2/blocks/latest",
   block: `/l2/blocks/:${heightOrHash}`,
   blocks: "/l2/blocks",
-  blocksByStatus: "/l2/blocks/by-status",
+  blocksByNativeStatus: "/l2/blocks/by-status",
   orphanedBlocks: "/l2/blocks/orphaned",
   orphanedBlocksLimited: "/l2/blocks/orphans",
   reorgs: "/l2/reorgs",

--- a/services/explorer-api/tests/unit/l2-tips-native-status.test.ts
+++ b/services/explorer-api/tests/unit/l2-tips-native-status.test.ts
@@ -1,0 +1,238 @@
+import type { L2TipsEvent } from "@chicmoz-pkg/message-registry";
+import type { ChicmozL2Tips, HexString } from "@chicmoz-pkg/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const state = {
+    selectRows: [] as Array<Array<{ hash?: string } | Record<string, unknown>>>,
+    insertValues: [] as unknown[],
+    conflictUpdates: [] as unknown[],
+  };
+
+  const limit = vi.fn(() => Promise.resolve(state.selectRows.shift() ?? []));
+  const where = vi.fn(() => ({ limit }));
+  const from = vi.fn(() => ({ where }));
+  const select = vi.fn(() => ({ from }));
+
+  const onConflictDoUpdate = vi.fn((args: unknown) => {
+    state.conflictUpdates.push(args);
+    return Promise.resolve();
+  });
+  const values = vi.fn((insertValues: unknown) => {
+    state.insertValues.push(insertValues);
+    return { onConflictDoUpdate };
+  });
+  const insert = vi.fn(() => ({ values }));
+
+  return {
+    db: { insert, select },
+    from,
+    limit,
+    onConflictDoUpdate,
+    select,
+    state,
+    values,
+    warn: vi.fn(),
+    where,
+  };
+});
+
+vi.mock("@chicmoz-pkg/postgres-helper", () => ({
+  getDb: () => mocks.db,
+}));
+
+vi.mock("../../src/environment.js", () => ({
+  L2_NETWORK_ID: "SANDBOX",
+}));
+
+vi.mock("../../src/logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: mocks.warn,
+  },
+}));
+
+const { deriveNativeStatus, upsertTips } = await import(
+  "../../src/svcs/database/controllers/l2/tips.js"
+);
+const { parseWithFreshNativeStatuses } = await import(
+  "../../src/svcs/http-server/routes/controllers/utils/native-status-overlay.js"
+);
+
+const hash = (n: number): HexString =>
+  `0x${n.toString(16).padStart(2, "0")}` ;
+
+const tips: ChicmozL2Tips = {
+  proposed: { number: 100, hash: hash(100) },
+  checkpointed: {
+    block: { number: 80, hash: hash(80) },
+    checkpoint: { number: 8, hash: hash(8) },
+  },
+  proven: {
+    block: { number: 60, hash: hash(60) },
+    checkpoint: { number: 6, hash: hash(6) },
+  },
+  finalized: {
+    block: { number: 40, hash: hash(40) },
+    checkpoint: { number: 4, hash: hash(4) },
+  },
+};
+
+const storedTips = {
+  ...tips,
+  observedAt: 123,
+  source: { rpcNodeName: "aztec-node-a", aztecNodeVersion: "4.2.0" },
+};
+
+const tipsEvent: L2TipsEvent = {
+  tips,
+  observedAt: 123,
+  source: { rpcNodeName: "aztec-node-a", aztecNodeVersion: "4.2.0" },
+};
+
+const l2TipsRow = {
+  l2NetworkId: "SANDBOX",
+  proposedBlockNumber: tips.proposed.number,
+  proposedBlockHash: tips.proposed.hash,
+  proposedCheckpointBlockNumber: null,
+  proposedCheckpointBlockHash: null,
+  proposedCheckpointNumber: null,
+  proposedCheckpointHash: null,
+  checkpointedBlockNumber: tips.checkpointed.block.number,
+  checkpointedBlockHash: tips.checkpointed.block.hash,
+  checkpointedCheckpointNumber: tips.checkpointed.checkpoint.number,
+  checkpointedCheckpointHash: tips.checkpointed.checkpoint.hash,
+  provenBlockNumber: tips.proven.block.number,
+  provenBlockHash: tips.proven.block.hash,
+  provenCheckpointNumber: tips.proven.checkpoint.number,
+  provenCheckpointHash: tips.proven.checkpoint.hash,
+  finalizedBlockNumber: tips.finalized.block.number,
+  finalizedBlockHash: tips.finalized.block.hash,
+  finalizedCheckpointNumber: tips.finalized.checkpoint.number,
+  finalizedCheckpointHash: tips.finalized.checkpoint.hash,
+  observedAt: 123,
+  aztecNodeName: "aztec-node-a",
+  aztecNodeVersion: "4.2.0",
+  degradedReason: null,
+};
+
+beforeEach(() => {
+  mocks.state.selectRows = [];
+  mocks.state.insertValues = [];
+  mocks.state.conflictUpdates = [];
+  mocks.warn.mockClear();
+  mocks.select.mockClear();
+  mocks.from.mockClear();
+  mocks.where.mockClear();
+  mocks.limit.mockClear();
+  mocks.values.mockClear();
+  mocks.onConflictDoUpdate.mockClear();
+});
+
+describe("deriveNativeStatus", () => {
+  it.each([
+    [30, "finalized"],
+    [50, "proven"],
+    [70, "checkpointed"],
+    [90, "proposed"],
+    [101, "unknown"],
+  ] as const)("derives %s as %s from native L2 tips", (height, status) => {
+    expect(
+      deriveNativeStatus({ hash: hash(height), height: BigInt(height) }, storedTips),
+    ).toBe(status);
+  });
+
+  it("treats missing, degraded, unsafe, above-tip, and orphaned blocks as unknown", () => {
+    expect(deriveNativeStatus({ hash: hash(1), height: 1n }, null)).toBe("unknown");
+    expect(
+      deriveNativeStatus(
+        { hash: hash(1), height: 1n },
+        { ...storedTips, degradedReason: "proposed boundary block 100 is missing" },
+      ),
+    ).toBe("unknown");
+    expect(
+      deriveNativeStatus(
+        { hash: hash(1), height: 1n, orphan: { timestamp: 1, hasOrphanedParent: false } },
+        storedTips,
+      ),
+    ).toBe("unknown");
+    expect(
+      deriveNativeStatus({ hash: hash(1), height: BigInt(Number.MAX_SAFE_INTEGER) + 1n }, storedTips),
+    ).toBe("unknown");
+  });
+
+  it("handles Aztec v4 tips where finalized and proven are equal", () => {
+    expect(
+      deriveNativeStatus(
+        { hash: hash(60), height: 60n },
+        { ...storedTips, finalized: storedTips.proven },
+      ),
+    ).toBe("finalized");
+  });
+});
+
+describe("upsertTips", () => {
+  it("stores healthy tips when all boundary blocks exist and hashes match", async () => {
+    mocks.state.selectRows = [
+      [{ hash: tips.finalized.block.hash }],
+      [{ hash: tips.proven.block.hash }],
+      [{ hash: tips.checkpointed.block.hash }],
+      [{ hash: tips.proposed.hash }],
+    ];
+
+    await upsertTips(tipsEvent);
+
+    expect(mocks.state.insertValues).toHaveLength(1);
+    expect(mocks.state.insertValues[0]).toMatchObject({
+      degradedReason: null,
+      finalizedBlockNumber: 40,
+      l2NetworkId: "SANDBOX",
+      proposedBlockNumber: 100,
+    });
+    expect(mocks.state.conflictUpdates).toHaveLength(1);
+    expect(mocks.warn).not.toHaveBeenCalled();
+  });
+
+  it("marks tips degraded when a boundary block is missing", async () => {
+    mocks.state.selectRows = [[]];
+
+    await upsertTips(tipsEvent);
+
+    expect(mocks.state.insertValues[0]).toMatchObject({
+      degradedReason: "finalized boundary block 40 is missing",
+    });
+    expect(mocks.warn).toHaveBeenCalledWith(
+      "L2 tips degraded: finalized boundary block 40 is missing",
+    );
+  });
+
+  it("marks tips degraded when a boundary hash mismatches", async () => {
+    mocks.state.selectRows = [[{ hash: hash(999) }]];
+
+    await upsertTips(tipsEvent);
+
+    expect(mocks.state.insertValues[0]).toMatchObject({
+      degradedReason: `finalized boundary block 40 hash mismatch: db=${hash(999)} tip=${hash(40)}`,
+    });
+  });
+});
+
+describe("native status cache overlay", () => {
+  it("recomputes cached block-detail and table payloads from fresh tips", async () => {
+    mocks.state.selectRows = [[l2TipsRow]];
+    await expect(
+      parseWithFreshNativeStatuses(
+        JSON.stringify({ hash: hash(90), height: "90", nativeStatus: "unknown" }),
+      ),
+    ).resolves.toMatchObject({ nativeStatus: "proposed" });
+
+    mocks.state.selectRows = [[l2TipsRow]];
+    await expect(
+      parseWithFreshNativeStatuses(
+        JSON.stringify([{ blockHash: hash(70), height: "70", nativeStatus: "unknown" }]),
+      ),
+    ).resolves.toEqual([expect.objectContaining({ nativeStatus: "checkpointed" })]);
+  });
+});

--- a/services/explorer-api/tsconfig.json
+++ b/services/explorer-api/tsconfig.json
@@ -97,5 +97,11 @@
     /* Language and Environment */
     "target": "ESNext" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
   },
-  "include": ["src/**/*", "drizzle.config.js", "scripts/**/*"]
+  "include": [
+    "src/**/*",
+    "drizzle.config.js",
+    "scripts/**/*",
+    "tests/**/*",
+    "vitest.config.ts"
+  ]
 }

--- a/services/explorer-api/vitest.config.ts
+++ b/services/explorer-api/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+// Vitest discovers configuration through a default export.
+// eslint-disable-next-line import/no-default-export
+export default defineConfig({
+  test: {
+    exclude: ["build/**", "node_modules/**"],
+  },
+});

--- a/services/explorer-ui-v2/src/api/block.ts
+++ b/services/explorer-ui-v2/src/api/block.ts
@@ -39,8 +39,8 @@ export const BlockAPI = {
     const response = await client.get(aztecExplorer.getTableBlocks, { params });
     return validateResponse(z.array(uiBlockTableSchema), response.data);
   },
-  getBlocksByStatus: async (): Promise<ChicmozL2BlockLight[]> => {
-    const response = await client.get(aztecExplorer.getL2BlocksByStatus);
+  getBlocksByNativeStatus: async (): Promise<ChicmozL2BlockLight[]> => {
+    const response = await client.get(aztecExplorer.getL2BlocksByNativeStatus);
     return validateResponse(z.array(chicmozL2BlockLightSchema), response.data);
   },
   getOrphanedBlocksLimited: async (): Promise<ChicmozL2BlockLight[]> => {

--- a/services/explorer-ui-v2/src/hooks/api/block.ts
+++ b/services/explorer-ui-v2/src/hooks/api/block.ts
@@ -64,13 +64,13 @@ export const useLatestTableBlocksByStatus = (
   });
 };
 
-export const useBlocksByFinalizationStatus = (): UseQueryResult<
+export const useBlocksByNativeStatus = (): UseQueryResult<
   ChicmozL2BlockLight[],
   Error
 > => {
   return useQuery<ChicmozL2BlockLight[], Error>({
-    queryKey: queryKeyGenerator.blocksByStatus,
-    queryFn: () => BlockAPI.getBlocksByStatus(),
+    queryKey: queryKeyGenerator.blocksByNativeStatus,
+    queryFn: () => BlockAPI.getBlocksByNativeStatus(),
     refetchInterval: SLOW_REFETCH_INTERVAL,
   });
 };

--- a/services/explorer-ui-v2/src/hooks/api/utils.ts
+++ b/services/explorer-ui-v2/src/hooks/api/utils.ts
@@ -35,7 +35,7 @@ export const queryKeyGenerator = {
   ) => ["paginatedTableBlocks", page, pageSize, status],
   blockByHeight: (height: string) => ["blockByHeight", height],
   blockByRange: (min: number, max: number) => ["blockRange", min, max],
-  blocksByStatus: ["blocks", "by-status"],
+  blocksByNativeStatus: ["blocks", "by-native-status"],
   orphanedBlocks: ["blocks", "orphaned"],
   reorgs: ["reorgs"],
   l2TipsHealth: ["l2TipsHealth"],

--- a/services/explorer-ui-v2/src/hooks/websocket/message-callbacks.ts
+++ b/services/explorer-ui-v2/src/hooks/websocket/message-callbacks.ts
@@ -44,7 +44,7 @@ export const handleWebSocketMessage = async (
       queryKey: queryKeyGenerator.latestTableBlocks,
     });
     await queryClient.invalidateQueries({
-      queryKey: queryKeyGenerator.blocksByStatus,
+      queryKey: queryKeyGenerator.blocksByNativeStatus,
     });
     await queryClient.invalidateQueries({
       queryKey: queryKeyGenerator.l2TipsHealth,

--- a/services/explorer-ui-v2/src/pages/blocks/index.tsx
+++ b/services/explorer-ui-v2/src/pages/blocks/index.tsx
@@ -11,7 +11,7 @@ import { ConsoleHead, Shell } from "~/components/layout";
 import {
   useAverageFees,
   useAverageTxsPerBlock,
-  useBlocksByFinalizationStatus,
+  useBlocksByNativeStatus,
   useChainInfo,
   useLatestBlock,
   useL2TipsHealth,
@@ -37,7 +37,7 @@ const statusFilters: StatusFilter[] = [
 
 export const BlocksPage: FC = () => {
   const { data: latestBlock } = useLatestBlock();
-  const { data: blocksByStatus } = useBlocksByFinalizationStatus();
+  const { data: blocksByNativeStatus } = useBlocksByNativeStatus();
   const { data: tipsHealth } = useL2TipsHealth();
 
   const { sortKey, sortDir, toggleSort, sortArrow } =
@@ -72,11 +72,11 @@ export const BlocksPage: FC = () => {
   const proposedTipHeight = tipsHealth?.tips.proposed.number ?? latestHeight;
   const provenTipHeight = tipsHealth?.tips.proven.block.number;
   const finalizedTipHeight = tipsHealth?.tips.finalized.block.number;
-  const provenHead = blocksByStatus?.find((b) => {
+  const provenHead = blocksByNativeStatus?.find((b) => {
     const display = blockStatusToDisplay(b.nativeStatus, !!b.orphan);
     return display === "proven" || display === "finalized";
   });
-  const finalized = blocksByStatus?.find(
+  const finalized = blocksByNativeStatus?.find(
     (b) => blockStatusToDisplay(b.nativeStatus, !!b.orphan) === "finalized",
   );
 

--- a/services/explorer-ui-v2/src/service/constants.ts
+++ b/services/explorer-ui-v2/src/service/constants.ts
@@ -6,7 +6,7 @@ export const aztecExplorer = {
   getL2BlockByHash: "/l2/blocks/",
   getL2BlockByHeight: "/l2/blocks/",
   getL2BlocksByHeightRange: "/l2/blocks",
-  getL2BlocksByStatus: "/l2/blocks/by-status",
+  getL2BlocksByNativeStatus: "/l2/blocks/by-status",
   getL2OrphanedBlocks: "/l2/blocks/orphaned",
   getL2OrphanedBlocksLimited: "/l2/blocks/orphans",
   getL2Reorgs: "/l2/reorgs",

--- a/services/explorer-ui/src/api/block.ts
+++ b/services/explorer-ui/src/api/block.ts
@@ -38,8 +38,8 @@ export const BlockAPI = {
 
     return validateResponse(z.array(uiBlockTableSchema), response.data);
   },
-  getBlocksByStatus: async (): Promise<ChicmozL2BlockLight[]> => {
-    const response = await client.get(aztecExplorer.getL2BlocksByStatus);
+  getBlocksByNativeStatus: async (): Promise<ChicmozL2BlockLight[]> => {
+    const response = await client.get(aztecExplorer.getL2BlocksByNativeStatus);
     return validateResponse(z.array(chicmozL2BlockLightSchema), response.data);
   },
   getOrphanedBlocks: async (): Promise<ChicmozL2BlockLight[]> => {

--- a/services/explorer-ui/src/hooks/api/blocks.ts
+++ b/services/explorer-ui/src/hooks/api/blocks.ts
@@ -1,16 +1,16 @@
-import { ChicmozL2BlockLight, ChicmozReorg } from "@chicmoz-pkg/types";
+import type { ChicmozL2BlockLight, ChicmozReorg } from "@chicmoz-pkg/types";
 import { useQuery } from "@tanstack/react-query";
 import { BlockAPI } from "~/api/block";
 import { REFETCH_INTERVAL } from "./utils";
 
 /**
- * Hook to fetch one block for each finalization status
+ * Hook to fetch representative blocks for the native L2 status buckets.
  */
-export const useBlocksByFinalizationStatus = () => {
+export const useBlocksByNativeStatus = () => {
   return useQuery<ChicmozL2BlockLight[], Error>({
-    queryKey: ["blocks", "by-status"],
+    queryKey: ["blocks", "by-native-status"],
     queryFn: async () => {
-      const data = await BlockAPI.getBlocksByStatus();
+      const data = await BlockAPI.getBlocksByNativeStatus();
       return data;
     },
     refetchInterval: REFETCH_INTERVAL,

--- a/services/explorer-ui/src/pages/network-health/index.tsx
+++ b/services/explorer-ui/src/pages/network-health/index.tsx
@@ -1,11 +1,11 @@
 import { useMemo, type FC } from "react";
 import { InfoBadge } from "~/components/info-badge";
 import { useGetLatestTxEffects, useSubTitle } from "~/hooks";
-import { useBlocksByFinalizationStatus, useReorgs } from "~/hooks/api/blocks";
+import { useBlocksByNativeStatus, useReorgs } from "~/hooks/api/blocks";
 import { useValidatorTotals } from "~/hooks/api/l1-l2-validator";
 import { BaseLayout } from "~/layout/base-layout";
 import { BlockProductionSection } from "./block-production-section";
-import { FinalizationStatusSection } from "./finalization-status-section";
+import { NativeStatusSection } from "./native-status-section";
 import { OrphanedBlocksSection } from "./orphaned-blocks-section";
 import { ReorgSection } from "./reorg-section";
 import { ValidatorStatusSection } from "./validator-status-section";
@@ -26,10 +26,10 @@ export const NetworkHealth: FC = () => {
   } = useValidatorTotals();
 
   const {
-    data: blocksByFinalizationStatus,
-    isLoading: blocksByStatusLoading,
-    error: blocksByStatusError,
-  } = useBlocksByFinalizationStatus();
+    data: blocksByNativeStatus,
+    isLoading: blocksByNativeStatusLoading,
+    error: blocksByNativeStatusError,
+  } = useBlocksByNativeStatus();
 
   const {
     data: latestTxEffects,
@@ -96,15 +96,15 @@ export const NetworkHealth: FC = () => {
     return { validatorsTitle: title, validatorsData: data };
   }, [validatorTotals]);
 
-  const blocksByFinalizationStatusData = useMemo(() => {
-    if (!blocksByFinalizationStatus) {
+  const blocksByNativeStatusData = useMemo(() => {
+    if (!blocksByNativeStatus) {
       return "A lot";
     }
 
     let highestBlockHeight = 0n;
     let lowestBlockHeight = 0n;
 
-    for (const block of blocksByFinalizationStatus) {
+    for (const block of blocksByNativeStatus) {
       if (block.height > highestBlockHeight) {
         highestBlockHeight = block.height;
       }
@@ -114,7 +114,7 @@ export const NetworkHealth: FC = () => {
     }
 
     return (highestBlockHeight - lowestBlockHeight).toString();
-  }, [blocksByFinalizationStatus]);
+  }, [blocksByNativeStatus]);
 
   return (
     <BaseLayout>
@@ -144,15 +144,15 @@ export const NetworkHealth: FC = () => {
         />
         <InfoBadge
           title="Unproven Blocks"
-          isLoading={blocksByStatusLoading}
-          error={blocksByStatusError}
-          data={blocksByFinalizationStatusData}
+          isLoading={blocksByNativeStatusLoading}
+          error={blocksByNativeStatusError}
+          data={blocksByNativeStatusData}
         />
       </div>
 
       <BlockProductionSection />
       <ValidatorStatusSection />
-      <FinalizationStatusSection />
+      <NativeStatusSection />
       <ReorgSection />
       <OrphanedBlocksSection />
     </BaseLayout>

--- a/services/explorer-ui/src/pages/network-health/native-status-section.tsx
+++ b/services/explorer-ui/src/pages/network-health/native-status-section.tsx
@@ -2,28 +2,28 @@ import { Link } from "@tanstack/react-router";
 import { useMemo, type FC } from "react";
 import { BlockStatusBadge } from "~/components/block-status-badge";
 import { Loader } from "~/components/loader";
-import { useBlocksByFinalizationStatus } from "~/hooks/api/blocks";
+import { useBlocksByNativeStatus } from "~/hooks/api/blocks";
 import { truncateHashString } from "~/lib/create-hash-string";
 import { routes } from "~/routes/__root";
 import { type BlockWithStatuses } from "./types";
 import { type ChicmozL2NativeBlockStatus } from "@chicmoz-pkg/types";
 
-export const FinalizationStatusSection: FC = () => {
+export const NativeStatusSection: FC = () => {
   const {
-    data: blocksByFinalizationStatus,
-    isLoading: blocksByStatusLoading,
-    error: blocksByStatusError,
-  } = useBlocksByFinalizationStatus();
+    data: blocksByNativeStatus,
+    isLoading: blocksByNativeStatusLoading,
+    error: blocksByNativeStatusError,
+  } = useBlocksByNativeStatus();
 
-  if (blocksByStatusError) {
+  if (blocksByNativeStatusError) {
     console.error(
-      "Error fetching blocks by finalization status:",
-      blocksByStatusError,
+      "Error fetching blocks by native status:",
+      blocksByNativeStatusError,
     );
   }
 
   const blocksWithStatuses = useMemo<BlockWithStatuses[]>(() => {
-    if (!blocksByFinalizationStatus) {
+    if (!blocksByNativeStatus) {
       return [];
     }
 
@@ -35,7 +35,7 @@ export const FinalizationStatusSection: FC = () => {
       "unknown",
     ];
 
-    const sortedBlocks = [...blocksByFinalizationStatus].sort((a, b) => {
+    const sortedBlocks = [...blocksByNativeStatus].sort((a, b) => {
       if (b.height === a.height) {
         return 0;
       }
@@ -58,7 +58,7 @@ export const FinalizationStatusSection: FC = () => {
     }
 
     return result;
-  }, [blocksByFinalizationStatus]);
+  }, [blocksByNativeStatus]);
 
   return (
     <div className="bg-white rounded-lg shadow-lg p-6 mb-8 dark:bg-gray-800">
@@ -67,10 +67,10 @@ export const FinalizationStatusSection: FC = () => {
         Statuses are derived from Aztec native L2 tips. L1 proposal and proof
         events remain available as factual metadata on block detail pages.
       </p>
-      {blocksByStatusLoading ? (
+      {blocksByNativeStatusLoading ? (
         <Loader amount={5} />
-      ) : blocksByStatusError ? (
-        <p>Error loading blocks: {blocksByStatusError.message}</p>
+      ) : blocksByNativeStatusError ? (
+        <p>Error loading blocks: {blocksByNativeStatusError.message}</p>
       ) : blocksWithStatuses.length === 0 ? (
         <p>No blocks available</p>
       ) : (

--- a/services/explorer-ui/src/service/constants.ts
+++ b/services/explorer-ui/src/service/constants.ts
@@ -6,7 +6,7 @@ export const aztecExplorer = {
   getL2BlockByHash: "/l2/blocks/",
   getL2BlockByHeight: "/l2/blocks/",
   getL2BlocksByHeightRange: "/l2/blocks",
-  getL2BlocksByStatus: "/l2/blocks/by-status",
+  getL2BlocksByNativeStatus: "/l2/blocks/by-status",
   getL2OrphanedBlocks: "/l2/blocks/orphaned",
   getL2OrphanedBlocksLimited: "/l2/blocks/orphans",
   getL2Reorgs: "/l2/reorgs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2183,7 +2183,8 @@ __metadata:
     supertest: "npm:6.3.3"
     typescript: "npm:5.8.3"
     uuid: "npm:10.0.0"
-    zod: "npm:^3.23.8"
+    vitest: "npm:3.2.4"
+    zod: "npm:3.23.8"
   languageName: unknown
   linkType: soft
 
@@ -17432,7 +17433,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vitest@npm:^3.2.4":
+"vitest@npm:3.2.4, vitest@npm:^3.2.4":
   version: 3.2.4
   resolution: "vitest@npm:3.2.4"
   dependencies:
@@ -17829,7 +17830,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.23.8":
+"zod@npm:3.23.8, zod@npm:^3.23.8":
   version: 3.23.8
   resolution: "zod@npm:3.23.8"
   checksum: 8f14c87d6b1b53c944c25ce7a28616896319d95bc46a9660fe441adc0ed0a81253b02b5abdaeffedbeb23bdd25a0bf1c29d2c12dd919aef6447652dd295e3e69


### PR DESCRIPTION
## Summary
- add explorer-api Vitest coverage for native L2 status derivation, L2 tips boundary validation, and cached response overlay recomputation
- rename remaining UI/API client references from finalization-status terminology to native-status terminology while keeping the compatibility /by-status path
- document nativeStatus as the product-facing block status and mark finalizationStatus as deprecated legacy compatibility data
- trim completed items from FUTURE-WORK.md

## Verification
- yarn workspace @chicmoz/explorer-api test-once
- yarn workspace @chicmoz/explorer-api lint
- yarn workspace @chicmoz/explorer-api build
- yarn workspace @chicmoz-pkg/types build
- yarn workspace @chicmoz-pkg/types lint
- yarn workspace @chicmoz/explorer-ui build
- yarn workspace @chicmoz/explorer-ui-v2 build
- yarn workspace @chicmoz/explorer-ui-v2 lint

Note: yarn workspace @chicmoz/explorer-ui lint still fails on pre-existing unrelated lint errors in existing UI files.