### PR TITLE
feat(explorer-ui-v2): mobile fixes, UX polish, and loading skeletons

### DIFF
--- a/services/explorer-ui-v2/src/components/common/index.ts
+++ b/services/explorer-ui-v2/src/components/common/index.ts
@@ -8,5 +8,6 @@ export * from "./etherscan-address-link";
 export * from "./fee-payment-method-badge";
 export * from "./hash-cell";
 export * from "./pagination";
+export * from "./skeleton";
 export * from "./status-pill";
 export * from "./token-etherscan-link";

--- a/services/explorer-ui-v2/src/components/common/skeleton.tsx
+++ b/services/explorer-ui-v2/src/components/common/skeleton.tsx
@@ -1,0 +1,60 @@
+import { type FC } from "react";
+
+interface SkeletonProps {
+  /** CSS width value, e.g. "60%", "120px". Defaults to "100%". */
+  width?: string;
+  /** CSS height value. Defaults to "1em". */
+  height?: string;
+  className?: string;
+}
+
+/** Single shimmer placeholder bar. */
+export const Skeleton: FC<SkeletonProps> = ({
+  width = "100%",
+  height = "1em",
+  className,
+}) => (
+  <span
+    className={className ? `skeleton ${className}` : "skeleton"}
+    style={{ width, height }}
+    aria-hidden="true"
+  />
+);
+
+interface SkeletonRowsProps {
+  /** Number of shimmer rows to render. Defaults to 10. */
+  count?: number;
+  /**
+   * CSS grid-template-columns value that controls column widths.
+   * Should match the real row's grid so the skeleton looks right.
+   * Defaults to a generic two-column stretch.
+   */
+  columns?: string;
+  /** Number of skeleton cells per row. Defaults to 3. */
+  cells?: number;
+}
+
+/**
+ * Renders `count` shimmer rows styled like `.row` list items.
+ * Drop inside any `.rows` container while data is loading.
+ */
+export const SkeletonRows: FC<SkeletonRowsProps> = ({
+  count = 10,
+  columns = "minmax(0,1fr) 100px 80px",
+  cells = 3,
+}) => (
+  <>
+    {Array.from({ length: count }, (_, i) => (
+      <div
+        key={i}
+        className="row skeleton-row"
+        style={{ gridTemplateColumns: columns }}
+        aria-hidden="true"
+      >
+        {Array.from({ length: cells }, (__, j) => (
+          <Skeleton key={j} width={j === 0 ? "70%" : "60%"} height="12px" />
+        ))}
+      </div>
+    ))}
+  </>
+);

--- a/services/explorer-ui-v2/src/pages/blocks/index.tsx
+++ b/services/explorer-ui-v2/src/pages/blocks/index.tsx
@@ -4,6 +4,7 @@ import { type FC, useMemo, useState } from "react";
 import {
   HashCell,
   Pagination,
+  SkeletonRows,
   StatusPill,
   TokenEtherscanLink,
 } from "~/components/common";
@@ -46,7 +47,7 @@ export const BlocksPage: FC = () => {
   const [page, setPage] = useState(0);
   const backendStatusFilter = statusFilter === "all" ? undefined : statusFilter;
 
-  const { data: blocks } = usePaginatedTableBlocks(
+  const { data: blocks, isPending: blocksLoading } = usePaginatedTableBlocks(
     page,
     PAGE_SIZE,
     backendStatusFilter,
@@ -228,10 +229,15 @@ export const BlocksPage: FC = () => {
               </Link>
             );
           })}
-          {(!blocks || sortedBlocks.length === 0) && (
-            <div className="empty-state">
-              {blocks ? "no blocks found" : "loading blocks..."}
-            </div>
+          {blocksLoading && (
+            <SkeletonRows
+              count={PAGE_SIZE}
+              columns="100px minmax(0,1fr) 40px 112px minmax(0,80px) 80px"
+              cells={6}
+            />
+          )}
+          {(!blocksLoading && (!blocks || sortedBlocks.length === 0)) && (
+            <div className="empty-state">no blocks found</div>
           )}
         </div>
         <Pagination

--- a/services/explorer-ui-v2/src/pages/landing/index.tsx
+++ b/services/explorer-ui-v2/src/pages/landing/index.tsx
@@ -23,10 +23,10 @@ import { HeroTip } from "./hero-tip";
 import { LatestLists } from "./latest-lists";
 
 export const Landing: FC = () => {
-  const { data: tableBlocks } = useLatestTableBlocks();
+  const { data: tableBlocks, isPending: blocksLoading } = useLatestTableBlocks();
   const { data: provenBlocks } = useLatestTableBlocksByStatus("proven");
   const { data: finalizedBlocks } = useLatestTableBlocksByStatus("finalized");
-  const { data: tableTxs } = useLatestTableTxEffects();
+  const { data: tableTxs, isPending: txsLoading } = useLatestTableTxEffects();
   const { data: pendingTxs } = usePendingTxs();
   const { data: droppedTxs24h } = useDroppedTxsLast24h();
   const { data: reorgs } = useReorgs();
@@ -102,6 +102,8 @@ export const Landing: FC = () => {
         feeJuiceDecimals={feeJuiceDecimals}
         feeJuiceSymbol={feeJuiceSymbol}
         feeJuiceAddress={feeJuiceAddress}
+        isLoadingBlocks={blocksLoading}
+        isLoadingTxs={txsLoading}
       />
 
       <ChainInfoBand

--- a/services/explorer-ui-v2/src/pages/landing/latest-lists.tsx
+++ b/services/explorer-ui-v2/src/pages/landing/latest-lists.tsx
@@ -1,7 +1,7 @@
 import { type UiBlockTable, type UiTxEffectTable } from "@chicmoz-pkg/types";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { type FC, type KeyboardEvent, type MouseEvent } from "react";
-import { HashCell, StatusPill, TokenEtherscanLink } from "~/components/common";
+import { HashCell, SkeletonRows, StatusPill, TokenEtherscanLink } from "~/components/common";
 import { blockStatusToDisplay } from "~/lib/block-status";
 import { ageStr, fmtNum, formatFees } from "~/lib/utils";
 
@@ -11,6 +11,8 @@ interface Props {
   feeJuiceDecimals: number;
   feeJuiceSymbol: string;
   feeJuiceAddress?: string;
+  isLoadingBlocks?: boolean;
+  isLoadingTxs?: boolean;
 }
 
 interface LatestTxRowProps {
@@ -85,6 +87,8 @@ export const LatestLists: FC<Props> = ({
   feeJuiceDecimals,
   feeJuiceSymbol,
   feeJuiceAddress,
+  isLoadingBlocks,
+  isLoadingTxs,
 }) => (
   <div className="split">
     <div className="panel">
@@ -104,6 +108,13 @@ export const LatestLists: FC<Props> = ({
         <div style={{ textAlign: "right" }}>Age</div>
       </div>
       <div className="rows">
+        {isLoadingBlocks && blocks.length === 0 && (
+          <SkeletonRows
+            count={10}
+            columns="100px minmax(0,1fr) 40px 112px 80px"
+            cells={5}
+          />
+        )}
         {blocks.map((b) => {
           const status = blockStatusToDisplay(b.nativeStatus, b.orphan);
           const ts = Number(b.timestamp);
@@ -127,7 +138,7 @@ export const LatestLists: FC<Props> = ({
             </Link>
           );
         })}
-        {blocks.length === 0 && (
+        {!isLoadingBlocks && blocks.length === 0 && (
           <div className="empty-state">waiting for blocks…</div>
         )}
       </div>
@@ -149,6 +160,13 @@ export const LatestLists: FC<Props> = ({
         <div style={{ textAlign: "right" }}>Age</div>
       </div>
       <div className="rows">
+        {isLoadingTxs && txs.length === 0 && (
+          <SkeletonRows
+            count={10}
+            columns="minmax(0,1fr) 100px 110px 80px"
+            cells={4}
+          />
+        )}
         {txs.map((t) => (
           <LatestTxRow
             key={t.txHash}
@@ -158,7 +176,7 @@ export const LatestLists: FC<Props> = ({
             feeJuiceAddress={feeJuiceAddress}
           />
         ))}
-        {txs.length === 0 && (
+        {!isLoadingTxs && txs.length === 0 && (
           <div className="empty-state">waiting for transactions…</div>
         )}
       </div>

--- a/services/explorer-ui-v2/src/pages/validators/index.tsx
+++ b/services/explorer-ui-v2/src/pages/validators/index.tsx
@@ -3,6 +3,7 @@ import { type FC, useMemo, useState } from "react";
 import {
   AddressEtherscanLink,
   Pagination,
+  SkeletonRows,
   StatusPill,
   TokenEtherscanLink,
 } from "~/components/common";
@@ -36,7 +37,7 @@ const PAGE_SIZE = 20;
 
 export const ValidatorsPage: FC = () => {
   const navigate = useNavigate();
-  const { data: validators } = useL1L2Validators();
+  const { data: validators, isPending: validatorsLoading } = useL1L2Validators();
   const { data: totals } = useValidatorTotals();
   const { data: chainInfo } = useChainInfo();
   const stakingAssetDecimals = chainInfo?.stakingAssetDecimals ?? 18;
@@ -263,6 +264,13 @@ export const ValidatorsPage: FC = () => {
           </div>
         </div>
         <div>
+          {validatorsLoading && (
+            <SkeletonRows
+              count={PAGE_SIZE}
+              columns="40px minmax(0,1fr) 160px 90px 90px 90px"
+              cells={6}
+            />
+          )}
           {paged.map((v, i) => {
             const status = validatorStatusToDisplay(v.status);
             return (
@@ -328,9 +336,9 @@ export const ValidatorsPage: FC = () => {
               </div>
             );
           })}
-          {paged.length === 0 && (
+          {!validatorsLoading && paged.length === 0 && (
             <div className="empty-state">
-              {validators ? "no validators match" : "loading validators…"}
+              {validators ? "no validators match" : "no validators found"}
             </div>
           )}
         </div>

--- a/services/explorer-ui-v2/src/styles/pages.css
+++ b/services/explorer-ui-v2/src/styles/pages.css
@@ -662,10 +662,12 @@
 }
 .detail-header h1 {
   font-family: var(--mono);
-  font-size: 44px;
+  font-size: clamp(24px, 5vw, 44px);
   color: var(--ink-1);
   margin: 0 0 10px 0;
   letter-spacing: -0.02em;
+  overflow-wrap: anywhere;
+  min-width: 0;
 }
 .detail-header h1 .pfx {
   color: var(--ink-3);
@@ -1809,7 +1811,7 @@
     grid-template-columns: 1fr;
   }
   .detail-header h1 {
-    font-size: 32px;
+    font-size: clamp(20px, 4vw, 32px);
   }
   .kv,
   .kv.wide,
@@ -1845,6 +1847,21 @@
   }
   .console-head {
     font-size: 10px;
+  }
+  /* Prevent console-head comment from being clipped on narrow screens */
+  .console-head .comment {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: unset;
+  }
+  /* Search: shorten placeholder so it doesn't visually bleed */
+  .search input::placeholder {
+    font-size: 10px;
+  }
+  /* stats-strip inner variant: collapse to 2-col just like the outer strip */
+  .stats-strip.inner {
+    grid-template-columns: repeat(2, 1fr);
+    grid-auto-flow: row;
   }
 }
 

--- a/services/explorer-ui-v2/src/styles/shared.css
+++ b/services/explorer-ui-v2/src/styles/shared.css
@@ -1049,3 +1049,43 @@
 .etherscan-link svg {
   flex-shrink: 0;
 }
+
+/* ===== skeleton shimmer ===== */
+@keyframes shimmer {
+  0% {
+    background-position: -200% center;
+  }
+  100% {
+    background-position: 200% center;
+  }
+}
+
+.skeleton {
+  display: inline-block;
+  border-radius: 4px;
+  background: linear-gradient(
+    90deg,
+    var(--bg-3) 25%,
+    var(--bg-2) 50%,
+    var(--bg-3) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.6s ease-in-out infinite;
+  /* prevent text content from being visible if accidentally given children */
+  color: transparent;
+  user-select: none;
+}
+
+/* Skeleton rows are real .row nodes with shimmer cells inside.
+   Pointer events disabled so they can't be accidentally clicked. */
+.skeleton-row {
+  pointer-events: none;
+  /* fade out each row slightly more than the previous to give a natural
+     trailing-off effect without JavaScript */
+}
+.skeleton-row:nth-child(n + 6) {
+  opacity: 0.7;
+}
+.skeleton-row:nth-child(n + 9) {
+  opacity: 0.4;
+}

--- a/services/explorer-ui-v2/src/styles/shared.css
+++ b/services/explorer-ui-v2/src/styles/shared.css
@@ -631,6 +631,8 @@
 .kv .v {
   color: var(--ink-1);
   word-break: break-all;
+  overflow-wrap: anywhere;
+  min-width: 0;
 }
 .kv .v a {
   color: var(--purple);
@@ -748,6 +750,11 @@
   border-bottom: 1px solid var(--line);
   padding: 0 18px;
   background: var(--bg-2);
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  /* hide scrollbar on non-hover so it's unobtrusive */
+  scrollbar-width: thin;
+  scrollbar-color: var(--line) transparent;
 }
 .tabs button {
   background: transparent;
@@ -761,6 +768,8 @@
   cursor: pointer;
   border-bottom: 2px solid transparent;
   margin-bottom: -1px;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 .tabs button:hover {
   color: var(--ink-1);
@@ -900,6 +909,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 8px;
   padding: 12px 18px;
   font-family: var(--mono);
   font-size: 11px;
@@ -907,6 +918,7 @@
 }
 .pagination .pages {
   display: flex;
+  flex-wrap: wrap;
   gap: 4px;
 }
 .pagination button {


### PR DESCRIPTION
## Summary

UX and mobile improvements for `explorer-ui-v2`.

### Mobile fixes
- **Filter buttons** (`/blocks`): `flex-wrap: wrap` on `.filter-group` so buttons don't overflow on narrow screens
- **Info tile text** (`/contracts`, `/`): `overflow-wrap: break-word` + `min-width: 0` on stat strip values
- **Sticky footer**: `#root` flex column + `min-height: 100dvh`; `.footer` uses `margin-top: auto` (works for both short and long pages, uses `dvh` for iOS Safari)

### CSS polish (shared.css / pages.css)
- **Tabs** (`.tabs`): `overflow-x: auto` + `flex-shrink: 0` + `white-space: nowrap` on buttons — tabs scroll horizontally on mobile instead of overflowing
- **Pagination**: `flex-wrap: wrap` on `.pagination` and `.pages` — page buttons wrap on narrow screens
- **kv-grid values**: `overflow-wrap: anywhere` + `min-width: 0` on `.kv .v` — long hashes in detail panels always break correctly
- **detail-header h1**: `clamp(24px, 5vw, 44px)` + `overflow-wrap: anywhere` — hash titles scale with viewport
- **ConsoleHead comment** (≤720px): `white-space: normal` so comment text wraps instead of being clipped
- **Search placeholder** (≤720px): `font-size: 10px` so placeholder text fits on small screens
- **`stats-strip.inner`** (≤720px): collapses to 2-col with `grid-auto-flow: row`

### Loading skeletons
- New `Skeleton` and `SkeletonRows` components (`src/components/common/skeleton.tsx`)
- CSS shimmer animation using `--bg-3`/`--bg-2` tokens — works in both dark and light themes
- Skeleton rows fade out progressively (rows 6+, 9+) for a natural trailing-off effect
- Wired into `/blocks`, `/validators`, and landing page latest-lists panels
- Replaces the previous loading text fallbacks (`"loading blocks..."`, `"loading validators…"`)

## Files changed
- `src/styles/pages.css` — mobile breakpoints, detail-header, meta/stats-strip
- `src/styles/shared.css` — tabs, pagination, kv-grid, shimmer keyframes
- `src/components/common/skeleton.tsx` — new component
- `src/components/common/index.ts` — barrel export
- `src/pages/blocks/index.tsx` — skeleton rows while loading
- `src/pages/validators/index.tsx` — skeleton rows while loading
- `src/pages/landing/index.tsx` — pass `isPending` to LatestLists
- `src/pages/landing/latest-lists.tsx` — skeleton rows while loading