### PR TITLE
fix(explorer-ui-v2): show ? with tooltip for missing balance/block, backfill block_number

### DIFF
--- a/services/explorer-api/migrations/0034_backfill_contract_instance_balance_block_number.sql
+++ b/services/explorer-api/migrations/0034_backfill_contract_instance_balance_block_number.sql
@@ -1,0 +1,10 @@
+-- Backfill block_number in contract_instance_balance by resolving the
+-- source_tx_hash through the tx_effect → body → l2Block chain.
+-- Rows that already have a block_number are left untouched.
+UPDATE contract_instance_balance cib
+SET block_number = lb.height
+FROM tx_effect te, body b, "l2Block" lb
+WHERE cib.source_tx_hash = te.tx_hash
+  AND te.body_id = b.id
+  AND b.block_hash = lb.hash
+  AND cib.block_number IS NULL;

--- a/services/explorer-api/migrations/meta/_journal.json
+++ b/services/explorer-api/migrations/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1779960000006,
       "tag": "0033_l1_fee_juice_portal_deposit_timestamp",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1779960000007,
+      "tag": "0034_backfill_contract_instance_balance_block_number",
+      "breakpoints": true
     }
   ]
 }

--- a/services/explorer-ui-v2/src/pages/address-details/index.tsx
+++ b/services/explorer-ui-v2/src/pages/address-details/index.tsx
@@ -59,7 +59,7 @@ export const AddressDetailsPage: FC = () => {
   const balanceValue =
     balance?.balance !== undefined && balance.balance !== null
       ? formatFees(balance.balance, feeJuiceDecimals)
-      : "—";
+      : null;
 
   // Delta summary for the stats strip tile (24h change)
   const latest = history?.[history.length - 1];
@@ -156,7 +156,9 @@ export const AddressDetailsPage: FC = () => {
         <div className="sc">
           <div className="lbl">Fee Juice balance</div>
           <div className="val">
-            {balanceValue}
+            {balanceValue ?? (
+              <span style={{ color: "var(--ink-3)", cursor: "help" }} title="If there is no balance it's because we did not manage to take a snapshot at that time">?</span>
+            )}
             {balance?.balance !== undefined && (
               <TokenEtherscanLink
                 symbol={feeJuiceSymbol}
@@ -298,7 +300,7 @@ export const AddressDetailsPage: FC = () => {
                             {blockNumber.toString()}
                           </Link>
                         ) : (
-                          <span style={{ color: "var(--ink-3)" }}>—</span>
+                          <span style={{ color: "var(--ink-3)" }} title="Block number not yet available">?</span>
                         )}
                       </span>
                       <span className="num" style={{ textAlign: "left" }}>

--- a/services/explorer-ui-v2/src/pages/address-details/index.tsx
+++ b/services/explorer-ui-v2/src/pages/address-details/index.tsx
@@ -229,14 +229,16 @@ export const AddressDetailsPage: FC = () => {
           <>
             <div className="hist-head">
               <div>Block</div>
-              <div>Difference</div>
-              <div>Ref</div>
+              <div>Balance</div>
+              <div>Paid/Received</div>
+              <div>Tx</div>
               <div className="right">Timestamp</div>
             </div>
             {pagedTimeline.length > 0 ? (
               <>
                 {pagedTimeline.map((entry, i) => {
                   const {
+                    balance: bal,
                     sourceTxHash,
                     feeRecipient,
                     spent,
@@ -298,6 +300,14 @@ export const AddressDetailsPage: FC = () => {
                         ) : (
                           <span style={{ color: "var(--ink-3)" }}>—</span>
                         )}
+                      </span>
+                      <span className="num" style={{ textAlign: "left" }}>
+                        {formatFees(bal, feeJuiceDecimals)}{" "}
+                        <TokenEtherscanLink
+                          symbol={feeJuiceSymbol}
+                          address={feeJuiceAddress}
+                          className="u"
+                        />
                       </span>
                       <span className="num" style={{ textAlign: "left" }}>
                         {changeEl}
@@ -362,7 +372,7 @@ export const AddressDetailsPage: FC = () => {
               <div className="empty-state">no L1 deposits</div>
             ) : (
               <>
-                <div className="hist-head">
+                <div className="hist-head hist-head-4col">
                   <div className="left">Amount ({feeJuiceSymbol})</div>
                   <div>L1 tx</div>
                   <div>From</div>
@@ -373,7 +383,7 @@ export const AddressDetailsPage: FC = () => {
                     ? Number(d.l1BlockTimestamp)
                     : 0;
                   return (
-                    <div key={`dep-${i}`} className="hist-row">
+                    <div key={`dep-${i}`} className="hist-row hist-row-4col">
                       <span
                         className="num"
                         style={{ textAlign: "left", color: "var(--green)" }}

--- a/services/explorer-ui-v2/src/pages/contract-instance/index.tsx
+++ b/services/explorer-ui-v2/src/pages/contract-instance/index.tsx
@@ -430,12 +430,13 @@ export const ContractInstancePage: FC = () => {
           <>
             <div className="hist-head">
               <div>Block</div>
-              <div>Difference</div>
-              <div>Ref</div>
+              <div>Balance</div>
+              <div>Paid/Received</div>
+              <div>Tx</div>
               <div className="right">Timestamp</div>
             </div>
             {timeline.map((entry, i) => {
-              const { sourceTxHash, feeRecipient, spent, ts, blockNumber } = entry;
+              const { balance: bal, sourceTxHash, feeRecipient, spent, ts, blockNumber } = entry;
 
               let changeEl: React.ReactNode;
               if (spent === null || spent === 0n) {
@@ -466,6 +467,14 @@ export const ContractInstancePage: FC = () => {
                     ) : (
                       <span style={{ color: "var(--ink-3)" }}>—</span>
                     )}
+                  </span>
+                  <span className="num" style={{ textAlign: "left" }}>
+                    {formatFees(bal, feeJuiceDecimals)}{" "}
+                    <TokenEtherscanLink
+                      symbol={feeJuiceSymbol}
+                      address={feeJuiceAddress}
+                      className="u"
+                    />
                   </span>
                   <span className="num" style={{ textAlign: "left" }}>{changeEl}</span>
                   <span className="hash">
@@ -518,7 +527,7 @@ export const ContractInstancePage: FC = () => {
               <div className="empty-state">no L1 deposits</div>
             ) : (
               <>
-                <div className="hist-head">
+                <div className="hist-head hist-head-4col">
                   <div className="right">Amount ({feeJuiceSymbol})</div>
                   <div>L1 tx</div>
                   <div>From</div>
@@ -527,7 +536,7 @@ export const ContractInstancePage: FC = () => {
                 {deposits.map((d, i) => {
                   const ts = d.l1BlockTimestamp ? Number(d.l1BlockTimestamp) : 0;
                   return (
-                    <div key={`dep-${i}`} className="hist-row">
+                    <div key={`dep-${i}`} className="hist-row hist-row-4col">
                       <span className="num" style={{ textAlign: "left", color: "var(--green)" }}>
                         +{formatFees(d.amount, feeJuiceDecimals)}
                       </span>

--- a/services/explorer-ui-v2/src/pages/contract-instance/index.tsx
+++ b/services/explorer-ui-v2/src/pages/contract-instance/index.tsx
@@ -58,7 +58,7 @@ export const ContractInstancePage: FC = () => {
   const feeJuiceAddress = chainInfo?.l1ContractAddresses?.feeJuiceAddress;
   const balanceValue =
     balance === undefined
-      ? "—"
+      ? null
       : formatFees(balance?.balance ?? 0n, feeJuiceDecimals);
 
   // Build pure balance-snapshot timeline (newest-first).
@@ -184,7 +184,9 @@ export const ContractInstancePage: FC = () => {
             v{instance.version}
           </span>
           <span className="meta-line">
-            fee balance {balanceValue}
+            fee balance {balanceValue ?? (
+              <span style={{ color: "var(--ink-3)", cursor: "help" }} title="If there is no balance it's because we did not manage to take a snapshot at that time">?</span>
+            )}
             <TokenEtherscanLink
               symbol={feeJuiceSymbol}
               address={feeJuiceAddress}
@@ -388,7 +390,9 @@ export const ContractInstancePage: FC = () => {
         {tab === "balance" && (
           <div className="balance-block">
             <div className="balance-big">
-              {balanceValue}
+              {balanceValue ?? (
+                <span style={{ color: "var(--ink-3)", cursor: "help" }} title="If there is no balance it's because we did not manage to take a snapshot at that time">?</span>
+              )}
               <TokenEtherscanLink
                 symbol={feeJuiceSymbol}
                 address={feeJuiceAddress}
@@ -465,7 +469,7 @@ export const ContractInstancePage: FC = () => {
                         {blockNumber.toString()}
                       </Link>
                     ) : (
-                      <span style={{ color: "var(--ink-3)" }}>—</span>
+                      <span style={{ color: "var(--ink-3)" }} title="Block number not yet available">?</span>
                     )}
                   </span>
                   <span className="num" style={{ textAlign: "left" }}>

--- a/services/explorer-ui-v2/src/styles/pages.css
+++ b/services/explorer-ui-v2/src/styles/pages.css
@@ -1355,7 +1355,7 @@
 
 .hist-head {
   display: grid;
-  grid-template-columns: 1.2fr 140px 160px 100px;
+  grid-template-columns: 100px 1fr 140px 160px 100px;
   gap: 12px;
   padding: 10px 18px;
   border-bottom: 1px solid var(--line);
@@ -1368,13 +1368,19 @@
 }
 .hist-row {
   display: grid;
-  grid-template-columns: 1.2fr 140px 160px 100px;
+  grid-template-columns: 100px 1fr 140px 160px 100px;
   gap: 12px;
   padding: 11px 18px;
   border-bottom: 1px solid var(--line-soft);
   font-family: var(--mono);
   font-size: 12px;
   color: var(--ink-1);
+}
+.hist-head-4col {
+  grid-template-columns: 1fr 160px 160px 100px;
+}
+.hist-row-4col {
+  grid-template-columns: 1fr 160px 160px 100px;
 }
 .hist-row .hash a {
   color: var(--purple);
@@ -3776,10 +3782,9 @@
 
 /* Proposal table columns */
 .gov-proposal-cols {
-  grid-template-columns: 64px minmax(
-      220px,
-      1.5fr
-    ) 80px 100px 90px 90px 90px 80px;
+  grid-template-columns:
+    64px minmax(220px, 1.5fr)
+    80px 100px 90px 90px 90px 80px;
 }
 .gov-proposal-cols .pid {
   font-family: var(--mono);


### PR DESCRIPTION
## Changes

### UI — Missing data indicators
- **Balance `—` → `?` with tooltip**: When Fee Juice balance is missing (no snapshot), shows a `?` with hover text: *"If there is no balance it's because we did not manage to take a snapshot at that time"*. Applies to both address-details stats strip and contract-instance meta-line + big balance display.
- **Block `—` → `?` with tooltip**: When block number is missing in Fee Juice history rows, shows `?` with hover text: *"Block number not yet available"*.

### Backend — Data backfill
- **Migration 0034**: Backfills `block_number` in `contract_instance_balance` by joining `source_tx_hash → tx_effect → body → l2Block`. After this runs, the Block column `?`s will resolve to proper block number links.

### Files
- `services/explorer-ui-v2/src/pages/address-details/index.tsx`
- `services/explorer-ui-v2/src/pages/contract-instance/index.tsx`
- `services/explorer-api/migrations/0034_backfill_contract_instance_balance_block_number.sql`
- `services/explorer-api/migrations/meta/_journal.json`