### PR TITLE
feat(explorer-ui-v2): timestamps, tooltips & header hints for public call requests table

### DIFF
--- a/packages/types/src/aztec/l2TxEffect.ts
+++ b/packages/types/src/aztec/l2TxEffect.ts
@@ -33,6 +33,12 @@ export const publicCallRequestSchema = z.object({
     .string()
     .nullish()
     .transform((v) => v ?? undefined),
+  // Transaction birth timestamp (ms epoch). Joined from tx_effect at query time.
+  // Absent when the tx is still pending (not yet in a block).
+  timestamp: z
+    .number()
+    .nullish()
+    .transform((v) => v ?? undefined),
 });
 
 // L2-to-L1 message emitted by a pending transaction (plaintext, available pre-execution).

--- a/services/explorer-api/src/svcs/database/controllers/l2Public-call/get.ts
+++ b/services/explorer-api/src/svcs/database/controllers/l2Public-call/get.ts
@@ -2,6 +2,7 @@ import { getDb as db } from "@chicmoz-pkg/postgres-helper";
 import { HexString, type PublicCallRequest } from "@chicmoz-pkg/types";
 import { desc, eq, inArray } from "drizzle-orm";
 import { l2TxPublicCallRequest } from "../../../database/schema/l2public-call/index.js";
+import { txEffect } from "../../../database/schema/l2block/body.js";
 
 const selectColumns = {
   txHash: l2TxPublicCallRequest.txHash,
@@ -13,6 +14,7 @@ const selectColumns = {
   functionSelector: l2TxPublicCallRequest.functionSelector,
   contractName: l2TxPublicCallRequest.contractName,
   functionName: l2TxPublicCallRequest.functionName,
+  timestamp: txEffect.txBirthTimestamp,
 };
 
 export const getPublicCallRequestsByTxHash = async (
@@ -21,6 +23,7 @@ export const getPublicCallRequestsByTxHash = async (
   const res = await db()
     .select(selectColumns)
     .from(l2TxPublicCallRequest)
+    .leftJoin(txEffect, eq(l2TxPublicCallRequest.txHash, txEffect.txHash))
     .where(eq(l2TxPublicCallRequest.txHash, txHash));
 
   return res as PublicCallRequest[];
@@ -35,6 +38,7 @@ export const getPublicCallRequestsByTxHashes = async (
   const rows = await db()
     .select(selectColumns)
     .from(l2TxPublicCallRequest)
+    .leftJoin(txEffect, eq(l2TxPublicCallRequest.txHash, txEffect.txHash))
     .where(inArray(l2TxPublicCallRequest.txHash, txHashes));
 
   const result = new Map<HexString, PublicCallRequest[]>();
@@ -52,6 +56,7 @@ export const getPublicCallRequestsByContractAddress = async (
   const res = await db()
     .select(selectColumns)
     .from(l2TxPublicCallRequest)
+    .leftJoin(txEffect, eq(l2TxPublicCallRequest.txHash, txEffect.txHash))
     .where(eq(l2TxPublicCallRequest.contractAddress, contractAddress))
     .orderBy(desc(l2TxPublicCallRequest.txHash));
 
@@ -64,6 +69,7 @@ export const getPublicCallRequestsBySenderAddress = async (
   const res = await db()
     .select(selectColumns)
     .from(l2TxPublicCallRequest)
+    .leftJoin(txEffect, eq(l2TxPublicCallRequest.txHash, txEffect.txHash))
     .where(eq(l2TxPublicCallRequest.msgSender, msgSender))
     .orderBy(desc(l2TxPublicCallRequest.txHash));
 

--- a/services/explorer-api/src/svcs/http-server/routes/controllers/public-call.ts
+++ b/services/explorer-api/src/svcs/http-server/routes/controllers/public-call.ts
@@ -22,6 +22,7 @@ const publicCallRequestSchema = {
     functionSelector: { type: "string", nullable: true },
     contractName: { type: "string", nullable: true },
     functionName: { type: "string", nullable: true },
+    timestamp: { type: "number", nullable: true },
   },
 };
 

--- a/services/explorer-ui-v2/src/components/data/public-call-requests-table.tsx
+++ b/services/explorer-ui-v2/src/components/data/public-call-requests-table.tsx
@@ -1,12 +1,28 @@
 import { type PublicCallRequest } from "@chicmoz-pkg/types";
 import { type FC } from "react";
 import { ContractInstanceLink, L2AddressLink } from "~/components/common";
+import { ageStr, toIsoUtc } from "~/lib/utils";
 
 const callTypeTone: Record<PublicCallRequest["callType"], string> = {
   non_revertible: "ok",
   revertible: "purple",
   teardown: "warn",
 };
+
+const callTypeTooltip: Record<PublicCallRequest["callType"], string> = {
+  non_revertible:
+    "During execution this call was non-revertible — its state changes persist regardless of later call outcomes",
+  revertible:
+    "During execution this call was revertible — its state changes could have been rolled back if a later call failed",
+  teardown:
+    "Final cleanup phase — runs after main execution, used for fee refunds and teardown",
+};
+
+const CALL_TYPE_HEADER_TOOLTIP =
+  "Execution model of this public call, set at tx submission. Non-revertible calls persist even if later phases fail; revertible calls can be rolled back; teardown is final cleanup.";
+
+const STATIC_HEADER_TOOLTIP =
+  "Whether this call is read-only. Static calls cannot modify state.";
 
 interface Props {
   data: PublicCallRequest[] | undefined;
@@ -39,8 +55,31 @@ export const PublicCallRequestsTable: FC<Props> = ({
         <div>Contract</div>
         <div>Contract name</div>
         <div>Function</div>
-        <div>Call type</div>
-        <div className="right">Static</div>
+        <div>
+          <span className="header-tip">
+            Call type{" "}
+            <span
+              className="header-tip-q"
+              style={{ color: "var(--ink-3)", cursor: "help" }}
+              title={CALL_TYPE_HEADER_TOOLTIP}
+            >
+              ?
+            </span>
+          </span>
+        </div>
+        <div className="right">
+          <span className="header-tip">
+            Static{" "}
+            <span
+              className="header-tip-q"
+              style={{ color: "var(--ink-3)", cursor: "help" }}
+              title={STATIC_HEADER_TOOLTIP}
+            >
+              ?
+            </span>
+          </span>
+        </div>
+        <div className="right">Timestamp</div>
       </div>
       {data.map((r, i) => (
         <div key={`${r.contractAddress}-${i}`} className={`trow ${colsClass}`}>
@@ -57,15 +96,42 @@ export const PublicCallRequestsTable: FC<Props> = ({
           </span>
           <span style={{ color: "var(--ink-2)" }}>{fnLabel(r)}</span>
           <span>
-            <span className={`tag-chip tag-chip-${callTypeTone[r.callType]}`}>
+            <span
+              className={`tag-chip tag-chip-${callTypeTone[r.callType]}`}
+              title={callTypeTooltip[r.callType]}
+              style={{ cursor: "help" }}
+            >
               {r.callType.replace(/_/g, " ")}
             </span>
           </span>
           <span className="num">
             {r.isStaticCall ? (
-              <span className="tag-chip tag-chip-purple">yes</span>
+              <span
+                className="tag-chip tag-chip-purple"
+                title="Read-only call — does not modify state"
+                style={{ cursor: "help" }}
+              >
+                yes
+              </span>
             ) : (
-              <span className="mute">no</span>
+              <span
+                className="mute"
+                title="This call may modify state"
+                style={{ cursor: "help" }}
+              >
+                no
+              </span>
+            )}
+          </span>
+          <span className="age" style={{ textAlign: "right" }}>
+            {r.timestamp ? (
+              <span title={toIsoUtc(r.timestamp)} style={{ cursor: "help" }}>
+                {ageStr(r.timestamp)}
+              </span>
+            ) : (
+              <span className="mute" title="Transaction not yet confirmed" style={{ cursor: "help" }}>
+                pending
+              </span>
             )}
           </span>
         </div>

--- a/services/explorer-ui-v2/src/styles/pages.css
+++ b/services/explorer-ui-v2/src/styles/pages.css
@@ -3659,10 +3659,18 @@
  * PUBLIC CALL REQUESTS table + L2->L1 messages table
  * ==================================================================== */
 .pcr-cols {
-  grid-template-columns: 1fr 1fr 140px 180px 110px 60px;
+  grid-template-columns: 1fr 1fr 140px 180px 110px 60px 110px;
 }
 .pcr-cols-narrow {
-  grid-template-columns: 1fr 140px 180px 110px 60px;
+  grid-template-columns: 1fr 140px 180px 110px 60px 110px;
+}
+
+/* Hide the ? in column headers until hover */
+.header-tip-q {
+  opacity: 0;
+}
+.header-tip:hover .header-tip-q {
+  opacity: 1;
 }
 
 .l2l1-cols {


### PR DESCRIPTION
## What

Improvements to the public call requests table on the address-details page:

### Timestamps
- Added a **Timestamp** column to the public calls table showing relative time ("5d 2h ago", "12m 4s ago") with **absolute UTC timestamp on hover**
- If the tx is still pending (no timestamp available), shows "pending" in muted text
- Timestamps come from a `LEFT JOIN tx_effect` on `tx_hash` at query time — no schema migration needed

### Tooltips
- **Call type pills** now have hover tooltips explaining each value in past tense ("During execution this call was revertible…")
- **Static indicators** (yes/no) now have hover tooltips ("Read-only call — does not modify state")
- **Column headers** ("Call type" and "Static") show a `?` on hover with a general explanation of what the column means

### Visual cues
- All tooltip targets show `cursor: help` on hover
- The header `?` is hidden by default (`opacity: 0`) and reveals on hover of the header text

## Files changed

| Layer | File | Change |
|---|---|---|
| Types | `packages/types/src/aztec/l2TxEffect.ts` | Add optional `timestamp` to `publicCallRequestSchema` |
| DB | `services/explorer-api/.../l2Public-call/get.ts` | LEFT JOIN `tx_effect` on `tx_hash` → `txBirthTimestamp` as `timestamp` |
| API | `services/explorer-api/.../public-call.ts` | Add `timestamp` to OpenAPI response schema |
| UI | `explorer-ui-v2/.../public-call-requests-table.tsx` | Timestamp column, tooltips, header `?` hints |
| CSS | `explorer-ui-v2/src/styles/pages.css` | Widen grid columns + `.header-tip` hover styles |

## Verification
- `yarn build:packages` ✓
- `yarn build` (explorer-ui-v2, runs `tsc -b && vite build`) ✓
- `yarn tsc` (explorer-api) ✓