### PR TITLE
fix: L1 deposit backfill resilience, zero-balance snapshots, and FPC relationship display

### DIFF
--- a/services/aztec-listener/src/svcs/poller/pollers/block_poller/handle-proven-block-txs.ts
+++ b/services/aztec-listener/src/svcs/poller/pollers/block_poller/handle-proven-block-txs.ts
@@ -143,9 +143,14 @@ export const handleProvenTransactions = async (block: L2Block) => {
           return;
         }
         const { addr, sourceTxHash, balance } = result;
+        const balanceBigInt = balance.toBigInt();
+        if (balanceBigInt === 0n) {
+          logger.debug(`⏭️ Skipping zero balance for ${addr}`);
+          return;
+        }
         await publishMessage("CONTRACT_INSTANCE_BALANCE_EVENT", {
           contractAddress: addr,
-          balance: balance.toBigInt().toString(),
+          balance: balanceBigInt.toString(),
           timestamp: new Date().getTime(),
           sourceTxHash,
           feeRecipient: block.header.globalVariables.feeRecipient.toString(),

--- a/services/ethereum-listener/src/network-client/contracts/callbacks/rollup.ts
+++ b/services/ethereum-listener/src/network-client/contracts/callbacks/rollup.ts
@@ -93,8 +93,9 @@ type OnLogsWrapper<
 
 const l2BlockProposedOnLogs: OnLogsWrapper<L2BlockProposedEventParameters> =
   (wrapperArgs) => async (logs) => {
-    try {
-      await asyncForEach(logs, async (log) => {
+    let failureCount = 0;
+    await asyncForEach(logs, async (log) => {
+      try {
         await emit.l2BlockProposed(
           chicmozL1L2BlockProposedSchema.parse({
             l1ContractAddress: log.address,
@@ -108,18 +109,26 @@ const l2BlockProposedOnLogs: OnLogsWrapper<L2BlockProposedEventParameters> =
           }),
         );
         wrapperArgs.updateHeight(log.blockNumber);
-      });
-      await wrapperArgs.storeHeight();
-    } catch (e) {
-      logger.error(`🎓 Rollup blockProposed: ${(e as Error).stack}`);
-      throw e;
+      } catch (e) {
+        failureCount++;
+        logger.error(
+          `🎓 Rollup blockProposed failed for block ${log.blockNumber}: ${(e as Error).message}`,
+        );
+      }
+    });
+    await wrapperArgs.storeHeight();
+    if (failureCount > 0) {
+      logger.warn(
+        `🎓 Rollup blockProposed batch completed with ${failureCount}/${logs.length} failures`,
+      );
     }
   };
 
 const l2BlockVerifiedOnLogs: OnLogsWrapper<L2ProofVerifiedEventParameters> =
   (wrapperArgs) => async (logs) => {
-    try {
-      await asyncForEach(logs, async (log) => {
+    let failureCount = 0;
+    await asyncForEach(logs, async (log) => {
+      try {
         await emit.l2ProofVerified(
           chicmozL1L2ProofVerifiedSchema.parse({
             l1ContractAddress: log.address,
@@ -133,18 +142,26 @@ const l2BlockVerifiedOnLogs: OnLogsWrapper<L2ProofVerifiedEventParameters> =
           }),
         );
         wrapperArgs.updateHeight(log.blockNumber);
-      });
-      await wrapperArgs.storeHeight();
-    } catch (e) {
-      logger.error(`🎩 Rollup proofVerified: ${(e as Error).stack}`);
-      throw e;
+      } catch (e) {
+        failureCount++;
+        logger.error(
+          `🎩 Rollup proofVerified failed for block ${log.blockNumber}: ${(e as Error).message}`,
+        );
+      }
+    });
+    await wrapperArgs.storeHeight();
+    if (failureCount > 0) {
+      logger.warn(
+        `🎩 Rollup proofVerified batch completed with ${failureCount}/${logs.length} failures`,
+      );
     }
   };
 
 const depositOnLogs: OnLogsWrapper<DepositEventParameters> =
   (wrapperArgs) => async (logs) => {
-    try {
-      await asyncForEach(logs, async (log) => {
+    let failureCount = 0;
+    await asyncForEach(logs, async (log) => {
+      try {
         if (log.args.attester === undefined) {
           throw new Error("attester is undefined");
         }
@@ -153,19 +170,27 @@ const depositOnLogs: OnLogsWrapper<DepositEventParameters> =
           blockNumber: log.blockNumber,
         });
         wrapperArgs.updateHeight(log.blockNumber);
-      });
-      await wrapperArgs.storeHeight();
-    } catch (e) {
-      logger.error(`🏛 Rollup deposit: ${(e as Error).stack}`);
-      throw e;
+      } catch (e) {
+        failureCount++;
+        logger.error(
+          `🏛 Rollup deposit failed for block ${log.blockNumber}: ${(e as Error).message}`,
+        );
+      }
+    });
+    await wrapperArgs.storeHeight();
+    if (failureCount > 0) {
+      logger.warn(
+        `🏛 Rollup deposit batch completed with ${failureCount}/${logs.length} failures`,
+      );
     }
   };
 
 const withdrawInitiatedOnLogs: OnLogsWrapper<
   WithdrawInitiatedEventParameters
 > = (wrapperArgs) => async (logs) => {
-  try {
-    await asyncForEach(logs, async (log) => {
+  let failureCount = 0;
+  await asyncForEach(logs, async (log) => {
+    try {
       if (log.args.attester === undefined) {
         throw new Error("attester is undefined");
       }
@@ -174,19 +199,27 @@ const withdrawInitiatedOnLogs: OnLogsWrapper<
         blockNumber: log.blockNumber,
       });
       wrapperArgs.updateHeight(log.blockNumber);
-    });
-    await wrapperArgs.storeHeight();
-  } catch (e) {
-    logger.error(`🖨 Rollup withdrawInitiated: ${(e as Error).stack}`);
-    throw e;
+    } catch (e) {
+      failureCount++;
+      logger.error(
+        `🖨 Rollup withdrawInitiated failed for block ${log.blockNumber}: ${(e as Error).message}`,
+      );
+    }
+  });
+  await wrapperArgs.storeHeight();
+  if (failureCount > 0) {
+    logger.warn(
+      `🖨 Rollup withdrawInitiated batch completed with ${failureCount}/${logs.length} failures`,
+    );
   }
 };
 
 const withdrawFinalisedOnLogs: OnLogsWrapper<
   WithdrawFinalisedEventParameters
 > = (wrapperArgs) => async (logs) => {
-  try {
-    await asyncForEach(logs, async (log) => {
+  let failureCount = 0;
+  await asyncForEach(logs, async (log) => {
+    try {
       if (log.args.attester === undefined) {
         throw new Error("attester is undefined");
       }
@@ -195,18 +228,26 @@ const withdrawFinalisedOnLogs: OnLogsWrapper<
         blockNumber: log.blockNumber,
       });
       wrapperArgs.updateHeight(log.blockNumber);
-    });
-    await wrapperArgs.storeHeight();
-  } catch (e) {
-    logger.error(`💃 Rollup withdrawFinalised: ${(e as Error).stack}`);
-    throw e;
+    } catch (e) {
+      failureCount++;
+      logger.error(
+        `💃 Rollup withdrawFinalised failed for block ${log.blockNumber}: ${(e as Error).message}`,
+      );
+    }
+  });
+  await wrapperArgs.storeHeight();
+  if (failureCount > 0) {
+    logger.warn(
+      `💃 Rollup withdrawFinalised batch completed with ${failureCount}/${logs.length} failures`,
+    );
   }
 };
 
 const slashedOnLogs: OnLogsWrapper<SlashedEventParameters> =
   (wrapperArgs) => async (logs) => {
-    try {
-      await asyncForEach(logs, async (log) => {
+    let failureCount = 0;
+    await asyncForEach(logs, async (log) => {
+      try {
         if (log.args.attester === undefined) {
           throw new Error("attester is undefined");
         }
@@ -215,11 +256,18 @@ const slashedOnLogs: OnLogsWrapper<SlashedEventParameters> =
           blockNumber: log.blockNumber,
         });
         wrapperArgs.updateHeight(log.blockNumber);
-      });
-      await wrapperArgs.storeHeight();
-    } catch (e) {
-      logger.error(`⚔ Rollup slashed: ${(e as Error).stack}`);
-      throw e;
+      } catch (e) {
+        failureCount++;
+        logger.error(
+          `⚔ Rollup slashed failed for block ${log.blockNumber}: ${(e as Error).message}`,
+        );
+      }
+    });
+    await wrapperArgs.storeHeight();
+    if (failureCount > 0) {
+      logger.warn(
+        `⚔ Rollup slashed batch completed with ${failureCount}/${logs.length} failures`,
+      );
     }
   };
 
@@ -257,8 +305,9 @@ const getValidatorStateAndEmitUpdates = async ({
 
 const depositToAztecPublicOnLogs: OnLogsWrapper<DepositToAztecPublicEventParameters> =
   (wrapperArgs) => async (logs) => {
-    try {
-      await asyncForEach(logs, async (log) => {
+    let failureCount = 0;
+    await asyncForEach(logs, async (log) => {
+      try {
         const { to, amount, secretHash, key, index } = log.args;
         if (
           to === undefined ||
@@ -306,11 +355,18 @@ const depositToAztecPublicOnLogs: OnLogsWrapper<DepositToAztecPublicEventParamet
           }),
         );
         wrapperArgs.updateHeight(log.blockNumber);
-      });
-      await wrapperArgs.storeHeight();
-    } catch (e) {
-      logger.error(`🧃 FeeJuicePortal depositToAztecPublic: ${(e as Error).stack}`);
-      throw e;
+      } catch (e) {
+        failureCount++;
+        logger.error(
+          `🧃 FeeJuicePortal depositToAztecPublic failed for tx ${log.transactionHash}:${log.logIndex}: ${(e as Error).message}`,
+        );
+      }
+    });
+    await wrapperArgs.storeHeight();
+    if (failureCount > 0) {
+      logger.warn(
+        `🧃 FeeJuicePortal depositToAztecPublic batch completed with ${failureCount}/${logs.length} failures`,
+      );
     }
   };
 

--- a/services/explorer-api/src/svcs/database/controllers/contract-instance-balance/get-balance.ts
+++ b/services/explorer-api/src/svcs/database/controllers/contract-instance-balance/get-balance.ts
@@ -16,7 +16,12 @@ export const getLatestContractInstanceBalance = async (
   const result = await db()
     .select()
     .from(contractInstanceBalance)
-    .where(eq(contractInstanceBalance.contractAddress, contractAddress))
+    .where(
+      and(
+        eq(contractInstanceBalance.contractAddress, contractAddress),
+        gt(contractInstanceBalance.balance, "0"),
+      ),
+    )
     .orderBy(desc(contractInstanceBalance.timestamp))
     .limit(1);
 
@@ -74,7 +79,12 @@ export const getContractInstanceBalanceHistory = async (
   const result = await db()
     .select()
     .from(contractInstanceBalance)
-    .where(eq(contractInstanceBalance.contractAddress, contractAddress))
+    .where(
+      and(
+        eq(contractInstanceBalance.contractAddress, contractAddress),
+        gt(contractInstanceBalance.balance, "0"),
+      ),
+    )
     .orderBy(contractInstanceBalance.timestamp)
     .limit(1000);
 

--- a/services/explorer-api/src/svcs/database/controllers/l2TxEffect/fpc.ts
+++ b/services/explorer-api/src/svcs/database/controllers/l2TxEffect/fpc.ts
@@ -1,0 +1,50 @@
+import { getDb as db } from "@chicmoz-pkg/postgres-helper";
+import { and, eq, ne } from "drizzle-orm";
+import { txEffect } from "../../../database/schema/l2block/index.js";
+
+/**
+ * Find distinct Fee Paying Contract (FPC) addresses that have paid fees for
+ * transactions initiated by the given address.
+ * An FPC is identified by feePayer !== initiator and feePaymentMethod === "fpc".
+ */
+export const getFeePayersForAddress = async (
+  address: string,
+): Promise<string[]> => {
+  const result = await db()
+    .selectDistinct({ feePayer: txEffect.feePayer })
+    .from(txEffect)
+    .where(
+      and(
+        eq(txEffect.initiator, address),
+        ne(txEffect.feePayer, address),
+        eq(txEffect.feePaymentMethod, "fpc"),
+      ),
+    );
+
+  return result
+    .map((row) => row.feePayer)
+    .filter((addr): addr is string => addr !== null);
+};
+
+/**
+ * Find distinct addresses that the given FPC has sponsored (paid fees for).
+ * An FPC is identified by feePayer !== initiator and feePaymentMethod === "fpc".
+ */
+export const getSponsoredAddressesForFpc = async (
+  fpcAddress: string,
+): Promise<string[]> => {
+  const result = await db()
+    .selectDistinct({ initiator: txEffect.initiator })
+    .from(txEffect)
+    .where(
+      and(
+        eq(txEffect.feePayer, fpcAddress),
+        ne(txEffect.initiator, fpcAddress),
+        eq(txEffect.feePaymentMethod, "fpc"),
+      ),
+    );
+
+  return result
+    .map((row) => row.initiator)
+    .filter((addr): addr is string => addr !== null);
+};

--- a/services/explorer-api/src/svcs/database/controllers/l2TxEffect/index.ts
+++ b/services/explorer-api/src/svcs/database/controllers/l2TxEffect/index.ts
@@ -1,2 +1,3 @@
 export * from "./get-tx-effect.js";
 export * from "./stats.js";
+export * from "./fpc.js";

--- a/services/explorer-api/src/svcs/http-server/routes/controllers/fpc-relationships.ts
+++ b/services/explorer-api/src/svcs/http-server/routes/controllers/fpc-relationships.ts
@@ -1,0 +1,78 @@
+import asyncHandler from "express-async-handler";
+import { OpenAPIObject } from "openapi3-ts/oas31";
+import {
+  getFeePayersForAddress,
+  getSponsoredAddressesForFpc,
+} from "../../../database/controllers/l2TxEffect/index.js";
+import { getContractInstanceFpcRelationshipsSchema } from "../paths_and_validation.js";
+import { dbWrapper } from "./utils/index.js";
+
+export const openapi_GET_L2_CONTRACT_INSTANCE_FPC_RELATIONSHIPS: OpenAPIObject["paths"] =
+  {
+    "/l2/contract-instances/{address}/fpc-relationships": {
+      get: {
+        tags: ["L2", "contract-instances"],
+        summary:
+          "Get Fee Paying Contract (FPC) relationships for an address",
+        description:
+          "Returns which FPCs pay fees for this address, and (if the address is itself an FPC) which addresses it sponsors.",
+        parameters: [
+          {
+            name: "address",
+            in: "path",
+            required: true,
+            schema: {
+              type: "string",
+              pattern: "^0x[a-fA-F0-9]+$",
+            },
+          },
+        ],
+        responses: {
+          "200": {
+            description: "FPC relationships for the address",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    feePayers: {
+                      type: "array",
+                      items: { type: "string" },
+                      description:
+                        "FPC addresses that pay fees for this address",
+                    },
+                    sponsoredAddresses: {
+                      type: "array",
+                      items: { type: "string" },
+                      description:
+                        "Addresses for which this FPC pays fees (only populated when the address is an FPC)",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+export const GET_L2_CONTRACT_INSTANCE_FPC_RELATIONSHIPS = asyncHandler(
+  async (req, res) => {
+    const {
+      params: { address },
+    } = getContractInstanceFpcRelationshipsSchema.parse(req);
+
+    const data = await dbWrapper.get(
+      ["l2", "contract-instance", address, "fpc-relationships"],
+      async () => {
+        const [feePayers, sponsoredAddresses] = await Promise.all([
+          getFeePayersForAddress(address),
+          getSponsoredAddressesForFpc(address),
+        ]);
+        return JSON.stringify({ feePayers, sponsoredAddresses });
+      },
+    );
+    res.status(200).json(JSON.parse(data));
+  },
+);

--- a/services/explorer-api/src/svcs/http-server/routes/controllers/index.ts
+++ b/services/explorer-api/src/svcs/http-server/routes/controllers/index.ts
@@ -9,6 +9,7 @@ export * from "./contract-instance-balance.js";
 export * from "./contract-instances.js";
 export * from "./dropped-tx.js";
 export * from "./fee-recipients.js";
+export * from "./fpc-relationships.js";
 export * from "./l2-tips.js";
 export * from "./l1/contract-events.js";
 export * from "./l1/fee-juice-portal-deposits.js";

--- a/services/explorer-api/src/svcs/http-server/routes/index.ts
+++ b/services/explorer-api/src/svcs/http-server/routes/index.ts
@@ -55,6 +55,7 @@ export const openApiPaths: OpenAPIObject["paths"] = {
   ...controller.openapi_GET_L2_CONTRACT_INSTANCE,
   ...controller.openapi_GET_L2_CONTRACT_INSTANCE_BALANCE,
   ...controller.openapi_GET_L2_CONTRACT_INSTANCE_BALANCE_HISTORY,
+  ...controller.openapi_GET_L2_CONTRACT_INSTANCE_FPC_RELATIONSHIPS,
   ...controller.openapi_GET_L2_CONTRACT_INSTANCES_WITH_BALANCE,
   ...controller.openapi_GET_L2_CONTRACT_INSTANCES,
   ...controller.openapi_GET_L2_CONTRACT_INSTANCES_WITH_AZTEC_SCAN_NOTES,
@@ -294,6 +295,10 @@ export const init = ({ router }: { router: Router }) => {
   router.get(
     paths.contractInstanceBalanceHistory,
     controller.GET_L2_CONTRACT_INSTANCE_BALANCE_HISTORY,
+  );
+  router.get(
+    paths.contractInstanceFpcRelationships,
+    controller.GET_L2_CONTRACT_INSTANCE_FPC_RELATIONSHIPS,
   );
   router.get(paths.contractInstances, controller.GET_L2_CONTRACT_INSTANCES);
 

--- a/services/explorer-api/src/svcs/http-server/routes/paths_and_validation.ts
+++ b/services/explorer-api/src/svcs/http-server/routes/paths_and_validation.ts
@@ -77,6 +77,7 @@ export const paths = {
   contractInstance: `/l2/contract-instances/:${address}`,
   contractInstanceBalance: `/l2/contract-instances/:${address}/balance`,
   contractInstanceBalanceHistory: `/l2/contract-instances/:${address}/balance/history`,
+  contractInstanceFpcRelationships: `/l2/contract-instances/:${address}/fpc-relationships`,
   contractInstancesWithBalance: "/l2/contract-instances/with-balance",
   contractInstances: "/l2/contract-instances",
 
@@ -352,6 +353,10 @@ export const getFeeJuicePortalDepositsByAddressSchema = z.object({
 });
 
 export const getContractInstanceBalanceSchema = z.object({
+  params: getContractInstanceSchema.shape.params,
+});
+
+export const getContractInstanceFpcRelationshipsSchema = z.object({
   params: getContractInstanceSchema.shape.params,
 });
 

--- a/services/explorer-ui-v2/src/api/contract.ts
+++ b/services/explorer-ui-v2/src/api/contract.ts
@@ -44,6 +44,15 @@ export type ChicmozL2ContractInstanceWithAztecScanNotes = z.infer<
   typeof contractInstancesWithAztecScanNotesSchema
 >;
 
+const contractInstanceFpcRelationshipsSchema = z.object({
+  feePayers: z.array(z.string()),
+  sponsoredAddresses: z.array(z.string()),
+});
+
+export type ContractInstanceFpcRelationships = z.infer<
+  typeof contractInstanceFpcRelationshipsSchema
+>;
+
 export const ContractL2API = {
   getContractClass: async ({
     classId,
@@ -148,6 +157,17 @@ export const ContractL2API = {
     );
     return validateResponse(
       chicmozContractInstanceBalanceSchema.array(),
+      response.data,
+    );
+  },
+  getContractInstanceFpcRelationships: async (
+    address: string,
+  ): Promise<ContractInstanceFpcRelationships> => {
+    const response = await client.get(
+      aztecExplorer.getL2ContractInstanceFpcRelationships(address),
+    );
+    return validateResponse(
+      contractInstanceFpcRelationshipsSchema,
       response.data,
     );
   },

--- a/services/explorer-ui-v2/src/hooks/api/contract.ts
+++ b/services/explorer-ui-v2/src/hooks/api/contract.ts
@@ -9,6 +9,7 @@ import { type UseQueryResult, useQuery } from "@tanstack/react-query";
 import {
   type ChicmozL2ContractInstanceWithAztecScanNotes,
   type ContractClassSourceResponse,
+  type ContractInstanceFpcRelationships,
   ContractL2API,
 } from "~/api";
 import {
@@ -167,6 +168,18 @@ export const useContractInstanceBalanceHistory = (
     enabled: !!address,
     retry: false,
     staleTime: 30_000,
+  });
+};
+
+export const useContractInstanceFpcRelationships = (
+  address: string,
+): UseQueryResult<ContractInstanceFpcRelationships, Error> => {
+  return useQuery<ContractInstanceFpcRelationships, Error>({
+    queryKey: queryKeyGenerator.contractInstanceFpcRelationships(address),
+    queryFn: () => ContractL2API.getContractInstanceFpcRelationships(address),
+    enabled: !!address,
+    retry: false,
+    staleTime: 60_000,
   });
 };
 

--- a/services/explorer-ui-v2/src/hooks/api/utils.ts
+++ b/services/explorer-ui-v2/src/hooks/api/utils.ts
@@ -127,6 +127,10 @@ export const queryKeyGenerator = {
     "contractInstanceBalanceHistory",
     address,
   ],
+  contractInstanceFpcRelationships: (address: string) => [
+    "contractInstanceFpcRelationships",
+    address,
+  ],
   latestContractInstances: ["latestContractInstances"],
   contractInstancesWithAztecScanNotes: ["contractInstancesWithAztecScanNotes"],
   paginatedContractInstances: (

--- a/services/explorer-ui-v2/src/pages/address-details/index.tsx
+++ b/services/explorer-ui-v2/src/pages/address-details/index.tsx
@@ -12,6 +12,7 @@ import {
   usePublicCallRequestsBySender,
   useContractInstanceBalance,
   useContractInstanceBalanceHistory,
+  useContractInstanceFpcRelationships,
   useChainInfo,
   useL1FeeJuicePortalDepositsByAddress,
 } from "~/hooks/api";
@@ -46,6 +47,7 @@ export const AddressDetailsPage: FC = () => {
   } = usePublicCallRequestsBySender(address);
   const { data: balance } = useContractInstanceBalance(address);
   const { data: history } = useContractInstanceBalanceHistory(address);
+  const { data: fpcRelationships } = useContractInstanceFpcRelationships(address);
   const { data: chainInfo } = useChainInfo();
   const { data: deposits } = useL1FeeJuicePortalDepositsByAddress(address);
 
@@ -157,7 +159,36 @@ export const AddressDetailsPage: FC = () => {
           <div className="lbl">Fee Juice balance</div>
           <div className="val">
             {balanceValue ?? (
-              <span style={{ color: "var(--ink-3)", cursor: "help" }} title="If there is no balance it's because we did not manage to take a snapshot at that time">?</span>
+              fpcRelationships && fpcRelationships.feePayers.length > 0 ? (
+                <span style={{ color: "var(--ink-3)" }}>
+                  via{" "}
+                  {fpcRelationships.feePayers.slice(0, 3).map((fpc, i) => (
+                    <span key={fpc}>
+                      {i > 0 && ", "}
+                      <Link
+                        to="/address/$address"
+                        params={{ address: fpc }}
+                        className="hash"
+                        style={{ fontSize: "0.85em" }}
+                      >
+                        {truncateHashString(fpc, 6, 4)}
+                      </Link>
+                    </span>
+                  ))}
+                  {fpcRelationships.feePayers.length > 3 && (
+                    <span style={{ color: "var(--ink-3)" }}>
+                      {" "}+{fpcRelationships.feePayers.length - 3} more
+                    </span>
+                  )}
+                </span>
+              ) : (
+                <span
+                  style={{ color: "var(--ink-3)", cursor: "help" }}
+                  title="This address does not hold any Fee Juice. Fees may be paid by a Fee Paying Contract (FPC)."
+                >
+                  ?
+                </span>
+              )
             )}
             {balance?.balance !== undefined && (
               <TokenEtherscanLink
@@ -168,6 +199,32 @@ export const AddressDetailsPage: FC = () => {
             )}
           </div>
           <div className="sub">{deltaSummary}</div>
+          {fpcRelationships && fpcRelationships.sponsoredAddresses.length > 0 && (
+            <div
+              className="sub"
+              style={{ marginTop: 6, color: "var(--ink-2)", fontSize: "0.8em" }}
+            >
+              Pays fees for:{" "}
+              {fpcRelationships.sponsoredAddresses.slice(0, 5).map((addr, i) => (
+                <span key={addr}>
+                  {i > 0 && ", "}
+                  <Link
+                    to="/address/$address"
+                    params={{ address: addr }}
+                    className="hash"
+                    style={{ fontSize: "0.85em" }}
+                  >
+                    {truncateHashString(addr, 6, 4)}
+                  </Link>
+                </span>
+              ))}
+              {fpcRelationships.sponsoredAddresses.length > 5 && (
+                <span style={{ color: "var(--ink-3)" }}>
+                  {" "}+{fpcRelationships.sponsoredAddresses.length - 5} more
+                </span>
+              )}
+            </div>
+          )}
         </div>
         <div className="sc">
           <div className="lbl">Total calls</div>

--- a/services/explorer-ui-v2/src/pages/contract-instance/index.tsx
+++ b/services/explorer-ui-v2/src/pages/contract-instance/index.tsx
@@ -18,6 +18,7 @@ import {
   useContractInstance,
   useContractInstanceBalance,
   useContractInstanceBalanceHistory,
+  useContractInstanceFpcRelationships,
   useChainInfo,
   useL2ToL1MsgsByContract,
   usePublicCallRequestsByContract,
@@ -46,6 +47,7 @@ export const ContractInstancePage: FC = () => {
   const { data: instance, isLoading } = useContractInstance(address);
   const { data: balance } = useContractInstanceBalance(address);
   const { data: history } = useContractInstanceBalanceHistory(address);
+  const { data: fpcRelationships } = useContractInstanceFpcRelationships(address);
   const { data: chainInfo } = useChainInfo();
   const { data: publicCalls } = usePublicCallRequestsByContract(address);
   const { data: l2ToL1Msgs } = useL2ToL1MsgsByContract(address);
@@ -185,7 +187,26 @@ export const ContractInstancePage: FC = () => {
           </span>
           <span className="meta-line">
             fee balance {balanceValue ?? (
-              <span style={{ color: "var(--ink-3)", cursor: "help" }} title="If there is no balance it's because we did not manage to take a snapshot at that time">?</span>
+              fpcRelationships && fpcRelationships.feePayers.length > 0 ? (
+                <span style={{ color: "var(--ink-3)" }}>
+                  via{" "}
+                  {fpcRelationships.feePayers.slice(0, 3).map((fpc, i) => (
+                    <span key={fpc}>
+                      {i > 0 && ", "}
+                      <Link
+                        to="/address/$address"
+                        params={{ address: fpc }}
+                        className="hash"
+                        style={{ fontSize: "0.85em" }}
+                      >
+                        {truncateHashString(fpc, 6, 4)}
+                      </Link>
+                    </span>
+                  ))}
+                </span>
+              ) : (
+                <span style={{ color: "var(--ink-3)", cursor: "help" }} title="This address does not hold any Fee Juice. Fees may be paid by a Fee Paying Contract (FPC).">?</span>
+              )
             )}
             <TokenEtherscanLink
               symbol={feeJuiceSymbol}
@@ -391,7 +412,30 @@ export const ContractInstancePage: FC = () => {
           <div className="balance-block">
             <div className="balance-big">
               {balanceValue ?? (
-                <span style={{ color: "var(--ink-3)", cursor: "help" }} title="If there is no balance it's because we did not manage to take a snapshot at that time">?</span>
+                fpcRelationships && fpcRelationships.feePayers.length > 0 ? (
+                  <span style={{ color: "var(--ink-3)", fontSize: "0.5em" }}>
+                    fees via{" "}
+                    {fpcRelationships.feePayers.slice(0, 3).map((fpc, i) => (
+                      <span key={fpc}>
+                        {i > 0 && ", "}
+                        <Link
+                          to="/address/$address"
+                          params={{ address: fpc }}
+                          className="hash"
+                        >
+                          {truncateHashString(fpc, 6, 4)}
+                        </Link>
+                      </span>
+                    ))}
+                    {fpcRelationships.feePayers.length > 3 && (
+                      <span style={{ color: "var(--ink-3)" }}>
+                        {" "}+{fpcRelationships.feePayers.length - 3} more
+                      </span>
+                    )}
+                  </span>
+                ) : (
+                  <span style={{ color: "var(--ink-3)", cursor: "help" }} title="This address does not hold any Fee Juice. Fees may be paid by a Fee Paying Contract (FPC).">?</span>
+                )
               )}
               <TokenEtherscanLink
                 symbol={feeJuiceSymbol}
@@ -407,6 +451,29 @@ export const ContractInstancePage: FC = () => {
                   : `-${deltaValue} · 24h`}{" "}
               · {history?.length ?? 0} snapshots
             </div>
+            {fpcRelationships && fpcRelationships.sponsoredAddresses.length > 0 && (
+              <div className="balance-sub" style={{ color: "var(--ink-2)" }}>
+                Pays fees for:{" "}
+                {fpcRelationships.sponsoredAddresses.slice(0, 5).map((addr, i) => (
+                  <span key={addr}>
+                    {i > 0 && ", "}
+                    <Link
+                      to="/address/$address"
+                      params={{ address: addr }}
+                      className="hash"
+                      style={{ fontSize: "0.85em" }}
+                    >
+                      {truncateHashString(addr, 6, 4)}
+                    </Link>
+                  </span>
+                ))}
+                {fpcRelationships.sponsoredAddresses.length > 5 && (
+                  <span style={{ color: "var(--ink-3)" }}>
+                    {" "}+{fpcRelationships.sponsoredAddresses.length - 5} more
+                  </span>
+                )}
+              </div>
+            )}
             {history && history.length > 1 && maxBal > 0 && (
               <>
                 <div className="spark">

--- a/services/explorer-ui-v2/src/service/constants.ts
+++ b/services/explorer-ui-v2/src/service/constants.ts
@@ -44,6 +44,8 @@ export const aztecExplorer = {
     `/l2/contract-instances/${address}/balance`,
   getL2ContractInstanceBalanceHistory: (address: string) =>
     `/l2/contract-instances/${address}/balance/history`,
+  getL2ContractInstanceFpcRelationships: (address: string) =>
+    `/l2/contract-instances/${address}/fpc-relationships`,
   getL2ContractInstances: "/l2/contract-instances",
   getL2ContractInstancesWithAztecScanNotes:
     "/l2/contract-instances/with-aztec-scan-notes",


### PR DESCRIPTION
## Summary

Fixes two issues discovered on mainnet where addresses using Fee Paying Contracts (FPCs) showed confusing "0 AZTEC" balances, and L1 deposit backfill was fragile.

## Changes

### fix(ethereum-listener): make event callbacks resilient to individual failures (743c1af)
Each structured event callback previously wrapped the entire batch in a single try/catch. If any individual event failed, the batch threw, `storeHeight()` was never called, and the height tracker never advanced. Now try/catch is inside the `asyncForEach` loop so individual failures are logged with exact context and the batch always commits its progress.

### fix(aztec-listener): skip publishing zero-balance snapshots (7fdb83)
Most addresses from proven transactions genuinely hold zero FeeJuice. Balances of 0n are now skipped at publish time.

### fix(explorer-api): filter zero-balance entries from queries (d53808)
`getLatestContractInstanceBalance` and `getContractInstanceBalanceHistory` now filter zero balances, returning null instead of "0".

### feat(explorer-api): FPC relationship endpoint (2e8393)
New `GET /l2/contract-instances/{address}/fpc-relationships` returns which FPCs pay fees for an address and vice versa.

### feat(explorer-ui-v2): FPC relationship display (b62557)
- Balance tooltip updated: "This address does not hold any Fee Juice. Fees may be paid by a Fee Paying Contract (FPC)."
- FPC-backed addresses show "via [FPC link]" instead of "?"
- FPC addresses show "Pays fees for: [addr1], [addr2]..."

## Verification
- TypeScript compilation clean for all affected services
- Live mainnet: FPC 0x3030c7... sponsors Token Vault Bridge 0x268fdc...
