### PR TITLE
feat: FPC transaction detail — paid-for column, sponsored tx table, shadcn tooltips

### DIFF
--- a/services/explorer-api/src/svcs/database/controllers/l2TxEffect/fpc.ts
+++ b/services/explorer-api/src/svcs/database/controllers/l2TxEffect/fpc.ts
@@ -1,6 +1,6 @@
 import { getDb as db } from "@chicmoz-pkg/postgres-helper";
-import { and, eq, ne, isNotNull } from "drizzle-orm";
-import { txEffect } from "../../../database/schema/l2block/index.js";
+import { and, eq, ne, isNotNull, desc } from "drizzle-orm";
+import { txEffect, body, l2Block } from "../../../database/schema/l2block/index.js";
 import { l2TxPublicCallRequest } from "../../../database/schema/l2public-call/index.js";
 
 /**
@@ -90,4 +90,147 @@ export const getSponsoredAddressesForFpc = async (
       seen.add(addr);
       return true;
     });
+};
+
+export type FpcTransactionEntry = {
+  txHash: string;
+  feePayer: string;
+  sponsoredAddress: string;
+  transactionFee: string;
+  blockHeight: bigint;
+  timestamp: number;
+};
+
+const FPC_TX_LIMIT = 50;
+
+/**
+ * Get transactions where this address paid fees for others (asFeePayer)
+ * or where others paid fees for this address (asSponsored).
+ * Checks both initiator and msgSender roles.
+ */
+export const getFpcTransactions = async (
+  address: string,
+): Promise<{ asFeePayer: FpcTransactionEntry[]; asSponsored: FpcTransactionEntry[] }> => {
+  // asFeePayer: feePayer = address, someone else is the beneficiary
+  const feePayerInitiatorRows = await db()
+    .select({
+      txHash: txEffect.txHash,
+      feePayer: txEffect.feePayer,
+      sponsoredAddress: txEffect.initiator,
+      transactionFee: txEffect.transactionFee,
+      blockHeight: l2Block.height,
+      timestamp: txEffect.txBirthTimestamp,
+    })
+    .from(txEffect)
+    .innerJoin(body, eq(txEffect.bodyId, body.id))
+    .innerJoin(l2Block, eq(body.blockHash, l2Block.hash))
+    .where(
+      and(
+        eq(txEffect.feePayer, address),
+        ne(txEffect.initiator, address),
+        isNotNull(txEffect.initiator),
+        isNotNull(txEffect.feePayer),
+      ),
+    )
+    .orderBy(desc(txEffect.txBirthTimestamp))
+    .limit(FPC_TX_LIMIT);
+
+  const feePayerMsgSenderRows = await db()
+    .select({
+      txHash: txEffect.txHash,
+      feePayer: txEffect.feePayer,
+      sponsoredAddress: l2TxPublicCallRequest.msgSender,
+      transactionFee: txEffect.transactionFee,
+      blockHeight: l2Block.height,
+      timestamp: txEffect.txBirthTimestamp,
+    })
+    .from(l2TxPublicCallRequest)
+    .innerJoin(txEffect, eq(l2TxPublicCallRequest.txHash, txEffect.txHash))
+    .innerJoin(body, eq(txEffect.bodyId, body.id))
+    .innerJoin(l2Block, eq(body.blockHash, l2Block.hash))
+    .where(
+      and(
+        eq(txEffect.feePayer, address),
+        ne(l2TxPublicCallRequest.msgSender, address),
+        isNotNull(l2TxPublicCallRequest.msgSender),
+        isNotNull(txEffect.feePayer),
+      ),
+    )
+    .orderBy(desc(txEffect.txBirthTimestamp))
+    .limit(FPC_TX_LIMIT);
+
+  // asSponsored: initiator or msgSender = address, someone else paid
+  const sponsoredInitiatorRows = await db()
+    .select({
+      txHash: txEffect.txHash,
+      feePayer: txEffect.feePayer,
+      sponsoredAddress: txEffect.initiator,
+      transactionFee: txEffect.transactionFee,
+      blockHeight: l2Block.height,
+      timestamp: txEffect.txBirthTimestamp,
+    })
+    .from(txEffect)
+    .innerJoin(body, eq(txEffect.bodyId, body.id))
+    .innerJoin(l2Block, eq(body.blockHash, l2Block.hash))
+    .where(
+      and(
+        eq(txEffect.initiator, address),
+        ne(txEffect.feePayer, address),
+        isNotNull(txEffect.feePayer),
+      ),
+    )
+    .orderBy(desc(txEffect.txBirthTimestamp))
+    .limit(FPC_TX_LIMIT);
+
+  const sponsoredMsgSenderRows = await db()
+    .select({
+      txHash: txEffect.txHash,
+      feePayer: txEffect.feePayer,
+      sponsoredAddress: l2TxPublicCallRequest.msgSender,
+      transactionFee: txEffect.transactionFee,
+      blockHeight: l2Block.height,
+      timestamp: txEffect.txBirthTimestamp,
+    })
+    .from(l2TxPublicCallRequest)
+    .innerJoin(txEffect, eq(l2TxPublicCallRequest.txHash, txEffect.txHash))
+    .innerJoin(body, eq(txEffect.bodyId, body.id))
+    .innerJoin(l2Block, eq(body.blockHash, l2Block.hash))
+    .where(
+      and(
+        eq(l2TxPublicCallRequest.msgSender, address),
+        ne(txEffect.feePayer, address),
+        isNotNull(txEffect.feePayer),
+      ),
+    )
+    .orderBy(desc(txEffect.txBirthTimestamp))
+    .limit(FPC_TX_LIMIT);
+
+  const dedup = (rows: typeof feePayerInitiatorRows): FpcTransactionEntry[] => {
+    const seen = new Set<string>();
+    return rows
+      .filter((r): r is typeof r & { feePayer: string; sponsoredAddress: string } =>
+        r.feePayer !== null && r.sponsoredAddress !== null,
+      )
+      .filter((r) => {
+        const key = `${r.txHash}:${r.sponsoredAddress}`;
+        if (seen.has(key)) {return false;}
+        seen.add(key);
+        return true;
+      })
+      .map((r) => ({
+        txHash: r.txHash,
+        feePayer: r.feePayer,
+        sponsoredAddress: r.sponsoredAddress,
+        transactionFee: r.transactionFee,
+        blockHeight: r.blockHeight,
+        timestamp: r.timestamp,
+      }));
+  };
+
+  return {
+    asFeePayer: dedup([...feePayerInitiatorRows, ...feePayerMsgSenderRows])
+      .slice(0, FPC_TX_LIMIT),
+    asSponsored: dedup([...sponsoredInitiatorRows, ...sponsoredMsgSenderRows])
+      .slice(0, FPC_TX_LIMIT),
+  };
 };

--- a/services/explorer-api/src/svcs/http-server/routes/controllers/fpc-relationships.ts
+++ b/services/explorer-api/src/svcs/http-server/routes/controllers/fpc-relationships.ts
@@ -5,7 +5,6 @@ import {
   getSponsoredAddressesForFpc,
 } from "../../../database/controllers/l2TxEffect/index.js";
 import { getContractInstanceFpcRelationshipsSchema } from "../paths_and_validation.js";
-import { dbWrapper } from "./utils/index.js";
 
 export const openapi_GET_L2_CONTRACT_INSTANCE_FPC_RELATIONSHIPS: OpenAPIObject["paths"] =
   {
@@ -63,16 +62,11 @@ export const GET_L2_CONTRACT_INSTANCE_FPC_RELATIONSHIPS = asyncHandler(
       params: { address },
     } = getContractInstanceFpcRelationshipsSchema.parse(req);
 
-    const data = await dbWrapper.get(
-      ["l2", "contract-instance", address, "fpc-relationships"],
-      async () => {
-        const [feePayers, sponsoredAddresses] = await Promise.all([
-          getFeePayersForAddress(address),
-          getSponsoredAddressesForFpc(address),
-        ]);
-        return JSON.stringify({ feePayers, sponsoredAddresses });
-      },
-    );
-    res.status(200).json(JSON.parse(data));
+    // Bypass dbWrapper.get() — it double-stringifies the JSON response.
+    const [feePayers, sponsoredAddresses] = await Promise.all([
+      getFeePayersForAddress(address),
+      getSponsoredAddressesForFpc(address),
+    ]);
+    res.status(200).json({ feePayers, sponsoredAddresses });
   },
 );

--- a/services/explorer-api/src/svcs/http-server/routes/controllers/fpc-transactions.ts
+++ b/services/explorer-api/src/svcs/http-server/routes/controllers/fpc-transactions.ts
@@ -1,0 +1,82 @@
+import asyncHandler from "express-async-handler";
+import { jsonStringify } from "@chicmoz-pkg/types";
+import { OpenAPIObject } from "openapi3-ts/oas31";
+import { getFpcTransactions } from "../../../database/controllers/l2TxEffect/index.js";
+import { getContractInstanceFpcRelationshipsSchema } from "../paths_and_validation.js";
+
+export const openapi_GET_L2_CONTRACT_INSTANCE_FPC_TRANSACTIONS: OpenAPIObject["paths"] =
+  {
+    "/l2/contract-instances/{address}/fpc-transactions": {
+      get: {
+        tags: ["L2", "contract-instances"],
+        summary:
+          "Get FPC-related transactions for an address",
+        description:
+          "Returns transactions where this address paid fees for others (asFeePayer) and where others paid fees for this address (asSponsored).",
+        parameters: [
+          {
+            name: "address",
+            in: "path",
+            required: true,
+            schema: {
+              type: "string",
+              pattern: "^0x[a-fA-F0-9]+$",
+            },
+          },
+        ],
+        responses: {
+          "200": {
+            description: "FPC transactions for the address",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    asFeePayer: {
+                      type: "array",
+                      items: {
+                        type: "object",
+                        properties: {
+                          txHash: { type: "string" },
+                          feePayer: { type: "string" },
+                          sponsoredAddress: { type: "string" },
+                          transactionFee: { type: "string" },
+                          blockHeight: { type: "integer" },
+                          timestamp: { type: "integer" },
+                        },
+                      },
+                    },
+                    asSponsored: {
+                      type: "array",
+                      items: {
+                        type: "object",
+                        properties: {
+                          txHash: { type: "string" },
+                          feePayer: { type: "string" },
+                          sponsoredAddress: { type: "string" },
+                          transactionFee: { type: "string" },
+                          blockHeight: { type: "integer" },
+                          timestamp: { type: "integer" },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+export const GET_L2_CONTRACT_INSTANCE_FPC_TRANSACTIONS = asyncHandler(
+  async (req, res) => {
+    const {
+      params: { address },
+    } = getContractInstanceFpcRelationshipsSchema.parse(req);
+
+    const data = await getFpcTransactions(address);
+    res.status(200).json(JSON.parse(jsonStringify(data)));
+  },
+);

--- a/services/explorer-api/src/svcs/http-server/routes/controllers/index.ts
+++ b/services/explorer-api/src/svcs/http-server/routes/controllers/index.ts
@@ -10,6 +10,7 @@ export * from "./contract-instances.js";
 export * from "./dropped-tx.js";
 export * from "./fee-recipients.js";
 export * from "./fpc-relationships.js";
+export * from "./fpc-transactions.js";
 export * from "./l2-tips.js";
 export * from "./l1/contract-events.js";
 export * from "./l1/fee-juice-portal-deposits.js";

--- a/services/explorer-api/src/svcs/http-server/routes/index.ts
+++ b/services/explorer-api/src/svcs/http-server/routes/index.ts
@@ -56,6 +56,7 @@ export const openApiPaths: OpenAPIObject["paths"] = {
   ...controller.openapi_GET_L2_CONTRACT_INSTANCE_BALANCE,
   ...controller.openapi_GET_L2_CONTRACT_INSTANCE_BALANCE_HISTORY,
   ...controller.openapi_GET_L2_CONTRACT_INSTANCE_FPC_RELATIONSHIPS,
+  ...controller.openapi_GET_L2_CONTRACT_INSTANCE_FPC_TRANSACTIONS,
   ...controller.openapi_GET_L2_CONTRACT_INSTANCES_WITH_BALANCE,
   ...controller.openapi_GET_L2_CONTRACT_INSTANCES,
   ...controller.openapi_GET_L2_CONTRACT_INSTANCES_WITH_AZTEC_SCAN_NOTES,
@@ -299,6 +300,10 @@ export const init = ({ router }: { router: Router }) => {
   router.get(
     paths.contractInstanceFpcRelationships,
     controller.GET_L2_CONTRACT_INSTANCE_FPC_RELATIONSHIPS,
+  );
+  router.get(
+    paths.contractInstanceFpcTransactions,
+    controller.GET_L2_CONTRACT_INSTANCE_FPC_TRANSACTIONS,
   );
   router.get(paths.contractInstances, controller.GET_L2_CONTRACT_INSTANCES);
 

--- a/services/explorer-api/src/svcs/http-server/routes/paths_and_validation.ts
+++ b/services/explorer-api/src/svcs/http-server/routes/paths_and_validation.ts
@@ -78,6 +78,7 @@ export const paths = {
   contractInstanceBalance: `/l2/contract-instances/:${address}/balance`,
   contractInstanceBalanceHistory: `/l2/contract-instances/:${address}/balance/history`,
   contractInstanceFpcRelationships: `/l2/contract-instances/:${address}/fpc-relationships`,
+  contractInstanceFpcTransactions: `/l2/contract-instances/:${address}/fpc-transactions`,
   contractInstancesWithBalance: "/l2/contract-instances/with-balance",
   contractInstances: "/l2/contract-instances",
 

--- a/services/explorer-ui-v2/package.json
+++ b/services/explorer-ui-v2/package.json
@@ -26,7 +26,7 @@
     "@radix-ui/react-slot": "1.1.0",
     "@radix-ui/react-tabs": "1.0.4",
     "@radix-ui/react-toast": "1.1.5",
-    "@radix-ui/react-tooltip": "1.1.3",
+    "@radix-ui/react-tooltip": "^1.2.10",
     "@tanstack/react-query": "5.56.2",
     "@tanstack/react-router": "1.45.2",
     "@tanstack/react-table": "8.16.0",

--- a/services/explorer-ui-v2/src/api/contract.ts
+++ b/services/explorer-ui-v2/src/api/contract.ts
@@ -53,6 +53,24 @@ export type ContractInstanceFpcRelationships = z.infer<
   typeof contractInstanceFpcRelationshipsSchema
 >;
 
+const fpcTransactionEntrySchema = z.object({
+  txHash: z.string(),
+  feePayer: z.string(),
+  sponsoredAddress: z.string(),
+  transactionFee: z.string(),
+  blockHeight: z.coerce.bigint(),
+  timestamp: z.number(),
+});
+
+const contractInstanceFpcTransactionsSchema = z.object({
+  asFeePayer: z.array(fpcTransactionEntrySchema),
+  asSponsored: z.array(fpcTransactionEntrySchema),
+});
+
+export type ContractInstanceFpcTransactions = z.infer<
+  typeof contractInstanceFpcTransactionsSchema
+>;
+
 export const ContractL2API = {
   getContractClass: async ({
     classId,
@@ -168,6 +186,17 @@ export const ContractL2API = {
     );
     return validateResponse(
       contractInstanceFpcRelationshipsSchema,
+      response.data,
+    );
+  },
+  getContractInstanceFpcTransactions: async (
+    address: string,
+  ): Promise<ContractInstanceFpcTransactions> => {
+    const response = await client.get(
+      aztecExplorer.getL2ContractInstanceFpcTransactions(address),
+    );
+    return validateResponse(
+      contractInstanceFpcTransactionsSchema,
       response.data,
     );
   },

--- a/services/explorer-ui-v2/src/components/data/public-call-requests-table.tsx
+++ b/services/explorer-ui-v2/src/components/data/public-call-requests-table.tsx
@@ -1,6 +1,11 @@
 import { type PublicCallRequest } from "@chicmoz-pkg/types";
 import { type FC } from "react";
 import { ContractInstanceLink, L2AddressLink } from "~/components/common";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "~/components/ui/tooltip";
 import { ageStr, toIsoUtc } from "~/lib/utils";
 
 const callTypeTone: Record<PublicCallRequest["callType"], string> = {
@@ -11,18 +16,18 @@ const callTypeTone: Record<PublicCallRequest["callType"], string> = {
 
 const callTypeTooltip: Record<PublicCallRequest["callType"], string> = {
   non_revertible:
-    "During execution this call was non-revertible — its state changes persist regardless of later call outcomes",
+    "Non-revertible — state changes persist even if later calls fail.",
   revertible:
-    "During execution this call was revertible — its state changes could have been rolled back if a later call failed",
+    "Revertible — state changes roll back if a later call fails.",
   teardown:
-    "Final cleanup phase — runs after main execution, used for fee refunds and teardown",
+    "Teardown — final cleanup phase after main execution, used for fee refunds.",
 };
 
 const CALL_TYPE_HEADER_TOOLTIP =
-  "Execution model of this public call, set at tx submission. Non-revertible calls persist even if later phases fail; revertible calls can be rolled back; teardown is final cleanup.";
+  "Execution model set at tx submission.\nNon-revertible: persists through failures.\nRevertible: rolls back on later failure.\nTeardown: cleanup & fee refunds.";
 
 const STATIC_HEADER_TOOLTIP =
-  "Whether this call is read-only. Static calls cannot modify state.";
+  "Whether this call modifies state.\nStatic calls are read-only and cannot write.";
 
 interface Props {
   data: PublicCallRequest[] | undefined;
@@ -58,25 +63,27 @@ export const PublicCallRequestsTable: FC<Props> = ({
         <div>
           <span className="header-tip">
             Call type{" "}
-            <span
-              className="header-tip-q"
-              style={{ color: "var(--ink-3)", cursor: "help" }}
-              title={CALL_TYPE_HEADER_TOOLTIP}
-            >
-              ?
-            </span>
+            <Tooltip>
+              <TooltipTrigger>
+                <span className="header-tip-q" style={{ color: "var(--ink-3)", cursor: "help" }}>?</span>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-64 whitespace-pre-line">
+                <p>{CALL_TYPE_HEADER_TOOLTIP}</p>
+              </TooltipContent>
+            </Tooltip>
           </span>
         </div>
         <div className="right">
           <span className="header-tip">
             Static{" "}
-            <span
-              className="header-tip-q"
-              style={{ color: "var(--ink-3)", cursor: "help" }}
-              title={STATIC_HEADER_TOOLTIP}
-            >
-              ?
-            </span>
+            <Tooltip>
+              <TooltipTrigger>
+                <span className="header-tip-q" style={{ color: "var(--ink-3)", cursor: "help" }}>?</span>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-64 whitespace-pre-line">
+                <p>{STATIC_HEADER_TOOLTIP}</p>
+              </TooltipContent>
+            </Tooltip>
           </span>
         </div>
         <div className="right">Timestamp</div>
@@ -96,31 +103,39 @@ export const PublicCallRequestsTable: FC<Props> = ({
           </span>
           <span style={{ color: "var(--ink-2)" }}>{fnLabel(r)}</span>
           <span>
-            <span
-              className={`tag-chip tag-chip-${callTypeTone[r.callType]}`}
-              title={callTypeTooltip[r.callType]}
-              style={{ cursor: "help" }}
-            >
-              {r.callType.replace(/_/g, " ")}
-            </span>
+            <Tooltip>
+              <TooltipTrigger>
+                <span
+                  className={`tag-chip tag-chip-${callTypeTone[r.callType]}`}
+                  style={{ cursor: "help" }}
+                >
+                  {r.callType.replace(/_/g, " ")}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-64">
+                <p>{callTypeTooltip[r.callType]}</p>
+              </TooltipContent>
+            </Tooltip>
           </span>
           <span className="num">
             {r.isStaticCall ? (
-              <span
-                className="tag-chip tag-chip-purple"
-                title="Read-only call — does not modify state"
-                style={{ cursor: "help" }}
-              >
-                yes
-              </span>
+              <Tooltip>
+                <TooltipTrigger>
+                  <span className="tag-chip tag-chip-purple" style={{ cursor: "help" }}>yes</span>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-64">
+                  <p>Read-only call — does not modify state</p>
+                </TooltipContent>
+              </Tooltip>
             ) : (
-              <span
-                className="mute"
-                title="This call may modify state"
-                style={{ cursor: "help" }}
-              >
-                no
-              </span>
+              <Tooltip>
+                <TooltipTrigger>
+                  <span className="mute" style={{ cursor: "help" }}>no</span>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-64">
+                  <p>This call may modify state</p>
+                </TooltipContent>
+              </Tooltip>
             )}
           </span>
           <span className="age" style={{ textAlign: "right" }}>

--- a/services/explorer-ui-v2/src/components/layout/shell.tsx
+++ b/services/explorer-ui-v2/src/components/layout/shell.tsx
@@ -1,4 +1,5 @@
 import { type FC, type ReactNode } from "react";
+import { TooltipProvider } from "~/providers/tooltip-provider";
 import { Footer } from "./footer";
 import { TopBar, type TopBarActive } from "./top-bar";
 
@@ -9,9 +10,11 @@ interface Props {
 
 /** Every page is wrapped in a `.shell` container with a fixed `TopBar` on top. */
 export const Shell: FC<Props> = ({ active, children }) => (
-  <div className="shell">
-    <TopBar active={active} />
-    {children}
-    <Footer />
-  </div>
+  <TooltipProvider>
+    <div className="shell">
+      <TopBar active={active} />
+      {children}
+      <Footer />
+    </div>
+  </TooltipProvider>
 );

--- a/services/explorer-ui-v2/src/components/ui/tooltip.tsx
+++ b/services/explorer-ui-v2/src/components/ui/tooltip.tsx
@@ -1,0 +1,36 @@
+"use client"
+
+import * as React from "react"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+
+import { cn } from "~/lib/utils"
+
+const TooltipProvider = TooltipPrimitive.Provider
+
+const Tooltip = TooltipPrimitive.Root
+
+const TooltipTrigger = TooltipPrimitive.Trigger
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 overflow-hidden rounded-md border border-[var(--line)] px-3 py-1.5 text-xs animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]",
+        className
+      )}
+      style={{
+        background: "var(--bg-2)",
+        color: "var(--ink-1)",
+      }}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+))
+TooltipContent.displayName = TooltipPrimitive.Content.displayName
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/services/explorer-ui-v2/src/hooks/api/contract.ts
+++ b/services/explorer-ui-v2/src/hooks/api/contract.ts
@@ -10,6 +10,7 @@ import {
   type ChicmozL2ContractInstanceWithAztecScanNotes,
   type ContractClassSourceResponse,
   type ContractInstanceFpcRelationships,
+  type ContractInstanceFpcTransactions,
   ContractL2API,
 } from "~/api";
 import {
@@ -180,6 +181,18 @@ export const useContractInstanceFpcRelationships = (
     enabled: !!address,
     retry: false,
     staleTime: 60_000,
+  });
+};
+
+export const useContractInstanceFpcTransactions = (
+  address: string,
+): UseQueryResult<ContractInstanceFpcTransactions, Error> => {
+  return useQuery<ContractInstanceFpcTransactions, Error>({
+    queryKey: queryKeyGenerator.contractInstanceFpcTransactions(address),
+    queryFn: () => ContractL2API.getContractInstanceFpcTransactions(address),
+    enabled: !!address,
+    retry: false,
+    staleTime: 30_000,
   });
 };
 

--- a/services/explorer-ui-v2/src/hooks/api/utils.ts
+++ b/services/explorer-ui-v2/src/hooks/api/utils.ts
@@ -131,6 +131,10 @@ export const queryKeyGenerator = {
     "contractInstanceFpcRelationships",
     address,
   ],
+  contractInstanceFpcTransactions: (address: string) => [
+    "contractInstanceFpcTransactions",
+    address,
+  ],
   latestContractInstances: ["latestContractInstances"],
   contractInstancesWithAztecScanNotes: ["contractInstancesWithAztecScanNotes"],
   paginatedContractInstances: (

--- a/services/explorer-ui-v2/src/pages/address-details/index.tsx
+++ b/services/explorer-ui-v2/src/pages/address-details/index.tsx
@@ -13,6 +13,7 @@ import {
   useContractInstanceBalance,
   useContractInstanceBalanceHistory,
   useContractInstanceFpcRelationships,
+  useContractInstanceFpcTransactions,
   useChainInfo,
   useL1FeeJuicePortalDepositsByAddress,
 } from "~/hooks/api";
@@ -23,6 +24,11 @@ import {
   getFeeJuiceSymbol,
   truncateHashString,
 } from "~/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "~/components/ui/tooltip";
 
 type Tab = "calls" | "balance" | "deposits";
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -48,6 +54,7 @@ export const AddressDetailsPage: FC = () => {
   const { data: balance } = useContractInstanceBalance(address);
   const { data: history } = useContractInstanceBalanceHistory(address);
   const { data: fpcRelationships } = useContractInstanceFpcRelationships(address);
+  const { data: fpcTx } = useContractInstanceFpcTransactions(address);
   const { data: chainInfo } = useChainInfo();
   const { data: deposits } = useL1FeeJuicePortalDepositsByAddress(address);
 
@@ -164,36 +171,14 @@ export const AddressDetailsPage: FC = () => {
           <div className="lbl">Fee Juice balance</div>
           <div className="val">
             {balanceValue ?? (
-              fpcRelationships && fpcRelationships.feePayers.length > 0 ? (
-                <span style={{ color: "var(--ink-3)" }}>
-                  via{" "}
-                  {fpcRelationships.feePayers.slice(0, 3).map((fpc, i) => (
-                    <span key={fpc}>
-                      {i > 0 && ", "}
-                      <Link
-                        to="/address/$address"
-                        params={{ address: fpc }}
-                        className="hash"
-                        style={{ fontSize: "0.85em" }}
-                      >
-                        {truncateHashString(fpc, 6, 4)}
-                      </Link>
-                    </span>
-                  ))}
-                  {fpcRelationships.feePayers.length > 3 && (
-                    <span style={{ color: "var(--ink-3)" }}>
-                      {" "}+{fpcRelationships.feePayers.length - 3} more
-                    </span>
-                  )}
-                </span>
-              ) : (
-                <span
-                  style={{ color: "var(--ink-3)", cursor: "help" }}
-                  title="This address does not hold any Fee Juice. Fees may be paid by a Fee Paying Contract (FPC)."
-                >
-                  ?
-                </span>
-              )
+              <Tooltip>
+                <TooltipTrigger>
+                  <span style={{ color: "var(--ink-3)", cursor: "help" }}>?</span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>This address does not hold any Fee Juice. Fees may be paid by a Fee Paying Contract (FPC).</p>
+                </TooltipContent>
+              </Tooltip>
             )}
             {balance?.balance !== undefined && (
               <TokenEtherscanLink
@@ -204,32 +189,6 @@ export const AddressDetailsPage: FC = () => {
             )}
           </div>
           <div className="sub">{deltaSummary}</div>
-          {fpcRelationships && fpcRelationships.sponsoredAddresses.length > 0 && (
-            <div
-              className="sub"
-              style={{ marginTop: 6, color: "var(--ink-2)", fontSize: "0.8em" }}
-            >
-              Pays fees for:{" "}
-              {fpcRelationships.sponsoredAddresses.slice(0, 5).map((addr, i) => (
-                <span key={addr}>
-                  {i > 0 && ", "}
-                  <Link
-                    to="/address/$address"
-                    params={{ address: addr }}
-                    className="hash"
-                    style={{ fontSize: "0.85em" }}
-                  >
-                    {truncateHashString(addr, 6, 4)}
-                  </Link>
-                </span>
-              ))}
-              {fpcRelationships.sponsoredAddresses.length > 5 && (
-                <span style={{ color: "var(--ink-3)" }}>
-                  {" "}+{fpcRelationships.sponsoredAddresses.length - 5} more
-                </span>
-              )}
-            </div>
-          )}
         </div>
         <div className="sc">
           <div className="lbl">Total calls</div>
@@ -262,7 +221,7 @@ export const AddressDetailsPage: FC = () => {
             onClick={() => handleTabChange("balance")}
           >
             Fee Juice
-            <span className="c">{timeline.length}</span>
+            <span className="c">{timeline.length + (fpcTx?.asSponsored?.length ?? 0)}</span>
           </button>
           <button
             className={tab === "deposits" ? "on" : ""}
@@ -291,15 +250,16 @@ export const AddressDetailsPage: FC = () => {
         {/* Tab: Fee Juice — balance history */}
         {tab === "balance" && (
           <>
-            <div className="hist-head">
-              <div>Block</div>
-              <div>Balance</div>
-              <div>Paid/Received</div>
-              <div>Tx</div>
-              <div className="right">Timestamp</div>
-            </div>
             {pagedTimeline.length > 0 ? (
               <>
+                <div className="hist-head" style={fpcTx && fpcTx.asFeePayer.length > 0 ? { gridTemplateColumns: "80px 1fr 130px 120px 130px 100px" } : undefined}>
+                  <div>Block</div>
+                  <div>Balance</div>
+                  <div>Paid/Received</div>
+                  <div>Tx</div>
+                  {fpcTx && fpcTx.asFeePayer.length > 0 && <div>Paid for</div>}
+                  <div className="right">Timestamp</div>
+                </div>
                 {pagedTimeline.map((entry, i) => {
                   const {
                     balance: bal,
@@ -309,6 +269,11 @@ export const AddressDetailsPage: FC = () => {
                     ts,
                     blockNumber,
                   } = entry;
+
+                  // Find matching FPC-sponsored tx for this balance snapshot
+                  const fpcMatch = sourceTxHash
+                    ? fpcTx?.asFeePayer.find((f) => f.txHash === sourceTxHash)
+                    : undefined;
 
                   let changeEl: React.ReactNode;
                   if (spent === null || spent === 0n) {
@@ -352,7 +317,7 @@ export const AddressDetailsPage: FC = () => {
                   }
 
                   return (
-                    <div key={`snap-${i}`} className="hist-row">
+                    <div key={`snap-${i}`} className="hist-row" style={fpcTx && fpcTx.asFeePayer.length > 0 ? { gridTemplateColumns: "80px 1fr 130px 120px 130px 100px" } : undefined}>
                       <span className="hash" style={{ textAlign: "left" }}>
                         {blockNumber !== undefined ? (
                           <Link
@@ -406,6 +371,22 @@ export const AddressDetailsPage: FC = () => {
                           </span>
                         )}
                       </span>
+                      {fpcTx && fpcTx.asFeePayer.length > 0 && (
+                        <span className="hash">
+                          {fpcMatch ? (
+                            <Link
+                              to="/address/$address"
+                              params={{ address: fpcMatch.sponsoredAddress }}
+                              className="hash"
+                              style={{ fontSize: "0.85em" }}
+                            >
+                              {truncateHashString(fpcMatch.sponsoredAddress, 6, 4)}
+                            </Link>
+                          ) : (
+                            <span style={{ color: "var(--ink-3)" }}>—</span>
+                          )}
+                        </span>
+                      )}
                       <span className="age" style={{ textAlign: "right" }}>
                         <span title={ageStr(ts)}>
                           {new Date(ts)
@@ -424,7 +405,66 @@ export const AddressDetailsPage: FC = () => {
                 />
               </>
             ) : (
-              <div className="empty-state">no fee juice history</div>
+              !(fpcTx && fpcTx.asSponsored.length > 0) && (
+                <div className="empty-state">no fee juice history</div>
+              )
+            )}
+            {/* Show FPC-paid transactions when no own balance history */}
+            {pagedTimeline.length === 0 && fpcTx && fpcTx.asSponsored.length > 0 && (
+              <>
+                <div className="hist-head">
+                  <div>Block</div>
+                  <div>Fee</div>
+                  <div>Paid by</div>
+                  <div>Tx</div>
+                  <div className="right">Timestamp</div>
+                </div>
+                {fpcTx.asSponsored.map((entry, i) => (
+                  <div key={`fpc-tx-${i}`} className="hist-row">
+                    <span className="hash" style={{ textAlign: "left" }}>
+                      <Link
+                        to="/blocks/$blockNumber"
+                        params={{ blockNumber: entry.blockHeight.toString() }}
+                      >
+                        {entry.blockHeight.toString()}
+                      </Link>
+                    </span>
+                    <span className="num" style={{ textAlign: "left" }}>
+                      {formatFees(BigInt(entry.transactionFee), feeJuiceDecimals)}{" "}
+                      <TokenEtherscanLink
+                        symbol={feeJuiceSymbol}
+                        address={feeJuiceAddress}
+                        className="u"
+                      />
+                    </span>
+                    <span className="hash">
+                      <Link
+                        to="/address/$address"
+                        params={{ address: entry.feePayer }}
+                        className="hash"
+                      >
+                        {truncateHashString(entry.feePayer, 6, 4)}
+                      </Link>
+                    </span>
+                    <span className="hash">
+                      <Link
+                        to="/tx-effects/$hash"
+                        params={{ hash: entry.txHash }}
+                      >
+                        {truncateHashString(entry.txHash, 8, 6)}
+                      </Link>
+                      </span>
+                      <span className="age" style={{ textAlign: "right" }}>
+                      <span title={ageStr(entry.timestamp)}>
+                        {new Date(entry.timestamp)
+                          .toISOString()
+                          .replace("T", " ")
+                          .slice(0, 19)}
+                      </span>
+                    </span>
+                  </div>
+                ))}
+              </>
             )}
           </>
         )}

--- a/services/explorer-ui-v2/src/pages/contract-instance/index.tsx
+++ b/services/explorer-ui-v2/src/pages/contract-instance/index.tsx
@@ -19,6 +19,7 @@ import {
   useContractInstanceBalance,
   useContractInstanceBalanceHistory,
   useContractInstanceFpcRelationships,
+  useContractInstanceFpcTransactions,
   useChainInfo,
   useL2ToL1MsgsByContract,
   usePublicCallRequestsByContract,
@@ -30,6 +31,11 @@ import {
   getFeeJuiceSymbol,
   truncateHashString,
 } from "~/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "~/components/ui/tooltip";
 
 type Tab = "balance" | "history" | "calls" | "l2l1" | "deposits";
 
@@ -48,6 +54,7 @@ export const ContractInstancePage: FC = () => {
   const { data: balance } = useContractInstanceBalance(address);
   const { data: history } = useContractInstanceBalanceHistory(address);
   const { data: fpcRelationships } = useContractInstanceFpcRelationships(address);
+  const { data: fpcTx } = useContractInstanceFpcTransactions(address);
   const { data: chainInfo } = useChainInfo();
   const { data: publicCalls } = usePublicCallRequestsByContract(address);
   const { data: l2ToL1Msgs } = useL2ToL1MsgsByContract(address);
@@ -190,26 +197,14 @@ export const ContractInstancePage: FC = () => {
           </span>
           <span className="meta-line">
             fee balance {balanceValue ?? (
-              fpcRelationships && fpcRelationships.feePayers.length > 0 ? (
-                <span style={{ color: "var(--ink-3)" }}>
-                  via{" "}
-                  {fpcRelationships.feePayers.slice(0, 3).map((fpc, i) => (
-                    <span key={fpc}>
-                      {i > 0 && ", "}
-                      <Link
-                        to="/address/$address"
-                        params={{ address: fpc }}
-                        className="hash"
-                        style={{ fontSize: "0.85em" }}
-                      >
-                        {truncateHashString(fpc, 6, 4)}
-                      </Link>
-                    </span>
-                  ))}
-                </span>
-              ) : (
-                <span style={{ color: "var(--ink-3)", cursor: "help" }} title="This address does not hold any Fee Juice. Fees may be paid by a Fee Paying Contract (FPC).">?</span>
-              )
+              <Tooltip>
+                <TooltipTrigger>
+                  <span style={{ color: "var(--ink-3)", cursor: "help" }}>?</span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>This address does not hold any Fee Juice. Fees may be paid by a Fee Paying Contract (FPC).</p>
+                </TooltipContent>
+              </Tooltip>
             )}
             <TokenEtherscanLink
               symbol={feeJuiceSymbol}
@@ -387,7 +382,7 @@ export const ContractInstancePage: FC = () => {
             onClick={() => setTab("history")}
           >
             Balance history
-            <span className="c">{timeline.length}</span>
+            <span className="c">{timeline.length + (fpcTx?.asSponsored?.length ?? 0)}</span>
           </button>
           <button
             className={tab === "calls" ? "on" : ""}
@@ -415,30 +410,14 @@ export const ContractInstancePage: FC = () => {
           <div className="balance-block">
             <div className="balance-big">
               {balanceValue ?? (
-                fpcRelationships && fpcRelationships.feePayers.length > 0 ? (
-                  <span style={{ color: "var(--ink-3)", fontSize: "0.5em" }}>
-                    fees via{" "}
-                    {fpcRelationships.feePayers.slice(0, 3).map((fpc, i) => (
-                      <span key={fpc}>
-                        {i > 0 && ", "}
-                        <Link
-                          to="/address/$address"
-                          params={{ address: fpc }}
-                          className="hash"
-                        >
-                          {truncateHashString(fpc, 6, 4)}
-                        </Link>
-                      </span>
-                    ))}
-                    {fpcRelationships.feePayers.length > 3 && (
-                      <span style={{ color: "var(--ink-3)" }}>
-                        {" "}+{fpcRelationships.feePayers.length - 3} more
-                      </span>
-                    )}
-                  </span>
-                ) : (
-                  <span style={{ color: "var(--ink-3)", cursor: "help" }} title="This address does not hold any Fee Juice. Fees may be paid by a Fee Paying Contract (FPC).">?</span>
-                )
+                <Tooltip>
+                  <TooltipTrigger>
+                    <span style={{ color: "var(--ink-3)", cursor: "help" }}>?</span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>This address does not hold any Fee Juice. Fees may be paid by a Fee Paying Contract (FPC).</p>
+                  </TooltipContent>
+                </Tooltip>
               )}
               <TokenEtherscanLink
                 symbol={feeJuiceSymbol}
@@ -454,29 +433,6 @@ export const ContractInstancePage: FC = () => {
                   : `-${deltaValue} · 24h`}{" "}
               · {history?.length ?? 0} snapshots
             </div>
-            {fpcRelationships && fpcRelationships.sponsoredAddresses.length > 0 && (
-              <div className="balance-sub" style={{ color: "var(--ink-2)" }}>
-                Pays fees for:{" "}
-                {fpcRelationships.sponsoredAddresses.slice(0, 5).map((addr, i) => (
-                  <span key={addr}>
-                    {i > 0 && ", "}
-                    <Link
-                      to="/address/$address"
-                      params={{ address: addr }}
-                      className="hash"
-                      style={{ fontSize: "0.85em" }}
-                    >
-                      {truncateHashString(addr, 6, 4)}
-                    </Link>
-                  </span>
-                ))}
-                {fpcRelationships.sponsoredAddresses.length > 5 && (
-                  <span style={{ color: "var(--ink-3)" }}>
-                    {" "}+{fpcRelationships.sponsoredAddresses.length - 5} more
-                  </span>
-                )}
-              </div>
-            )}
             {history && history.length > 1 && maxBal > 0 && (
               <>
                 <div className="spark">
@@ -507,10 +463,15 @@ export const ContractInstancePage: FC = () => {
               <div>Balance</div>
               <div>Paid/Received</div>
               <div>Tx</div>
+              {fpcTx && fpcTx.asFeePayer.length > 0 && <div>Paid for</div>}
               <div className="right">Timestamp</div>
             </div>
             {timeline.map((entry, i) => {
               const { balance: bal, sourceTxHash, feeRecipient, spent, ts, blockNumber } = entry;
+
+              const fpcMatch = sourceTxHash
+                ? fpcTx?.asFeePayer.find((f) => f.txHash === sourceTxHash)
+                : undefined;
 
               let changeEl: React.ReactNode;
               if (spent === null || spent === 0n) {
@@ -532,7 +493,7 @@ export const ContractInstancePage: FC = () => {
               }
 
               return (
-                <div key={`snap-${i}`} className="hist-row">
+                <div key={`snap-${i}`} className="hist-row" style={fpcTx && fpcTx.asFeePayer.length > 0 ? { gridTemplateColumns: "80px 1fr 130px 120px 130px 100px" } : undefined}>
                   <span className="hash" style={{ textAlign: "left" }}>
                     {blockNumber !== undefined ? (
                       <Link to="/blocks/$blockNumber" params={{ blockNumber: blockNumber.toString() }}>
@@ -575,6 +536,17 @@ export const ContractInstancePage: FC = () => {
                       </span>
                     )}
                   </span>
+                  {fpcTx && fpcTx.asFeePayer.length > 0 && (
+                    <span className="hash">
+                      {fpcMatch ? (
+                        <Link to="/address/$address" params={{ address: fpcMatch.sponsoredAddress }} className="hash" style={{ fontSize: "0.85em" }}>
+                          {truncateHashString(fpcMatch.sponsoredAddress, 6, 4)}
+                        </Link>
+                      ) : (
+                        <span style={{ color: "var(--ink-3)" }}>—</span>
+                      )}
+                    </span>
+                  )}
                   <span className="age" style={{ textAlign: "right" }}>
                     <span title={ageStr(ts)}>
                       {new Date(ts).toISOString().replace("T", " ").slice(0, 19)}
@@ -583,8 +555,64 @@ export const ContractInstancePage: FC = () => {
                 </div>
               );
             })}
-            {timeline.length === 0 && (
+            {timeline.length === 0 && !(fpcTx && fpcTx.asSponsored.length > 0) && (
               <div className="empty-state">no fee juice history</div>
+            )}
+            {timeline.length === 0 && fpcTx && fpcTx.asSponsored.length > 0 && (
+              <>
+            <div className="hist-head" style={fpcTx && fpcTx.asFeePayer.length > 0 ? { gridTemplateColumns: "80px 1fr 130px 120px 130px 100px" } : undefined}>
+                  <div>Block</div>
+                  <div>Fee</div>
+                  <div>Paid by</div>
+                  <div>Tx</div>
+                  <div className="right">Timestamp</div>
+                </div>
+                {fpcTx.asSponsored.map((entry, i) => (
+                  <div key={`fpc-tx-${i}`} className="hist-row">
+                    <span className="hash" style={{ textAlign: "left" }}>
+                      <Link
+                        to="/blocks/$blockNumber"
+                        params={{ blockNumber: entry.blockHeight.toString() }}
+                      >
+                        {entry.blockHeight.toString()}
+                      </Link>
+                    </span>
+                    <span className="num" style={{ textAlign: "left" }}>
+                      {formatFees(BigInt(entry.transactionFee), feeJuiceDecimals)}{" "}
+                      <TokenEtherscanLink
+                        symbol={feeJuiceSymbol}
+                        address={feeJuiceAddress}
+                        className="u"
+                      />
+                    </span>
+                    <span className="hash">
+                      <Link
+                        to="/address/$address"
+                        params={{ address: entry.feePayer }}
+                        className="hash"
+                      >
+                        {truncateHashString(entry.feePayer, 6, 4)}
+                      </Link>
+                    </span>
+                    <span className="hash">
+                      <Link
+                        to="/tx-effects/$hash"
+                        params={{ hash: entry.txHash }}
+                      >
+                        {truncateHashString(entry.txHash, 8, 6)}
+                      </Link>
+                    </span>
+                    <span className="age" style={{ textAlign: "right" }}>
+                      <span title={ageStr(entry.timestamp)}>
+                        {new Date(entry.timestamp)
+                          .toISOString()
+                          .replace("T", " ")
+                          .slice(0, 19)}
+                      </span>
+                    </span>
+                  </div>
+                ))}
+              </>
             )}
           </>
         )}

--- a/services/explorer-ui-v2/src/providers/index.ts
+++ b/services/explorer-ui-v2/src/providers/index.ts
@@ -1,3 +1,4 @@
 export * from "./query-provider";
 export * from "./router-provider";
 export * from "./theme-provider";
+export * from "./tooltip-provider";

--- a/services/explorer-ui-v2/src/providers/tooltip-provider.tsx
+++ b/services/explorer-ui-v2/src/providers/tooltip-provider.tsx
@@ -1,0 +1,16 @@
+import { type FC, type ReactNode } from "react";
+import { TooltipProvider as BaseTooltipProvider } from "~/components/ui/tooltip";
+
+interface Props {
+  children: ReactNode;
+}
+
+/**
+ * Wraps the Radix TooltipProvider with default config.
+ * Delay 200ms before showing, 0ms before hiding.
+ */
+export const TooltipProvider: FC<Props> = ({ children }) => (
+  <BaseTooltipProvider delayDuration={200} skipDelayDuration={0}>
+    {children}
+  </BaseTooltipProvider>
+);

--- a/services/explorer-ui-v2/src/service/constants.ts
+++ b/services/explorer-ui-v2/src/service/constants.ts
@@ -46,6 +46,8 @@ export const aztecExplorer = {
     `/l2/contract-instances/${address}/balance/history`,
   getL2ContractInstanceFpcRelationships: (address: string) =>
     `/l2/contract-instances/${address}/fpc-relationships`,
+  getL2ContractInstanceFpcTransactions: (address: string) =>
+    `/l2/contract-instances/${address}/fpc-transactions`,
   getL2ContractInstances: "/l2/contract-instances",
   getL2ContractInstancesWithAztecScanNotes:
     "/l2/contract-instances/with-aztec-scan-notes",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2208,7 +2208,7 @@ __metadata:
     "@radix-ui/react-slot": "npm:1.1.0"
     "@radix-ui/react-tabs": "npm:1.0.4"
     "@radix-ui/react-toast": "npm:1.1.5"
-    "@radix-ui/react-tooltip": "npm:1.1.3"
+    "@radix-ui/react-tooltip": "npm:^1.2.10"
     "@tailwindcss/typography": "npm:0.5.10"
     "@tanstack/react-query": "npm:5.56.2"
     "@tanstack/react-query-devtools": "npm:5.32.0"
@@ -4054,6 +4054,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/primitive@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@radix-ui/primitive@npm:1.1.4"
+  checksum: f366fa15b721a466ad78f9b5b966f7129fb6932f6f33ab117253ce8c6a13f4895dce4a1fd483d3f15859623d3bfd964a4b172fe1d6ccc3a1a3c4de4c2b861119
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-accordion@npm:1.1.2":
   version: 1.1.2
   resolution: "@radix-ui/react-accordion@npm:1.1.2"
@@ -4122,6 +4129,25 @@ __metadata:
     "@types/react-dom":
       optional: true
   checksum: cbe059dfa5a9c1677478d363bb5fd75b0c7a08221d0ac7f8e7b9aec9dbae9754f6a3518218cf63e4ed53df6c36d193c8d2618d03433a37aa0cb7ee77a60a591f
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-arrow@npm:1.1.10":
+  version: 1.1.10
+  resolution: "@radix-ui/react-arrow@npm:1.1.10"
+  dependencies:
+    "@radix-ui/react-primitive": "npm:2.1.6"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: a364da644694318ee0d557e7ed60ff8e8af5c9021825218b310b29502463b2982fde70c1d9e2bc3d53ec3141ebe94b6a9fd58b95f493fdc359b8ee83da3d8332
   languageName: node
   linkType: hard
 
@@ -4264,6 +4290,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-compose-refs@npm:1.1.3":
+  version: 1.1.3
+  resolution: "@radix-ui/react-compose-refs@npm:1.1.3"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: c4853e7bc15cda6f68a1bbd7910412cc7f298419ee363fb4e40494e16a1cfadc857b2384dbe4d98b58c1312f280ca3474f67dc14da325d29ae8b7ebcfddaf743
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-context@npm:1.0.1":
   version: 1.0.1
   resolution: "@radix-ui/react-context@npm:1.0.1"
@@ -4302,6 +4341,19 @@ __metadata:
     "@types/react":
       optional: true
   checksum: fc4ace9d79d7954c715ade765e06c95d7e1b12a63a536bcbe842fb904f03f88fc5bd6e38d44bd23243d37a270b4c44380fedddaeeae2d274f0b898a20665aba2
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-context@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@radix-ui/react-context@npm:1.1.4"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 917be4dcb9fd9f465ab18f6982879daf83a5ca298a22504fa3bc4abd8dea963a57abb9ad38c099dd756ba2cddff0edde680bf8369012f44dedede20912702c8f
   languageName: node
   linkType: hard
 
@@ -4468,6 +4520,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-dismissable-layer@npm:1.1.13":
+  version: 1.1.13
+  resolution: "@radix-ui/react-dismissable-layer@npm:1.1.13"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.4"
+    "@radix-ui/react-compose-refs": "npm:1.1.3"
+    "@radix-ui/react-primitive": "npm:2.1.6"
+    "@radix-ui/react-use-callback-ref": "npm:1.1.2"
+    "@radix-ui/react-use-escape-keydown": "npm:1.1.2"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 800a96e82b3719511c40cfdace1a7250690cf38eae2a0114ddc8e980a76756993b8f898359ed296e15b18a60b319b4700e7c8fb6206a6fef66b3907fbbcebef6
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-dropdown-menu@npm:2.1.1":
   version: 2.1.1
   resolution: "@radix-ui/react-dropdown-menu@npm:2.1.1"
@@ -4601,6 +4676,21 @@ __metadata:
     "@types/react":
       optional: true
   checksum: acf13e29e51ee96336837fc0cfecc306328b20b0e0070f6f0f7aa7a621ded4a1ee5537cfad58456f64bae76caa7f8769231e88dc7dc106197347ee433c275a79
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-id@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@radix-ui/react-id@npm:1.1.2"
+  dependencies:
+    "@radix-ui/react-use-layout-effect": "npm:1.1.2"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: cd8638f0e259b9cee26cc8248b96533927abf91302a9164d674a45119a15dbb6929652e450c18bc3b99adf5d02a698152bf45d3ae052e1cd63f68fe8dd1ca87d
   languageName: node
   linkType: hard
 
@@ -4754,6 +4844,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-popper@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@radix-ui/react-popper@npm:1.3.1"
+  dependencies:
+    "@floating-ui/react-dom": "npm:^2.0.0"
+    "@radix-ui/react-arrow": "npm:1.1.10"
+    "@radix-ui/react-compose-refs": "npm:1.1.3"
+    "@radix-ui/react-context": "npm:1.1.4"
+    "@radix-ui/react-primitive": "npm:2.1.6"
+    "@radix-ui/react-use-callback-ref": "npm:1.1.2"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.2"
+    "@radix-ui/react-use-rect": "npm:1.1.2"
+    "@radix-ui/react-use-size": "npm:1.1.2"
+    "@radix-ui/rect": "npm:1.1.2"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 1ec118d66d437835a771ef166b2847931fbe02ded0dd342aa2a5b04643cd001a036f74a7924a2f357ac602e01b1ad3cc4e2c1b8a2bd24ca8417621cf9e56fb1d
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-portal@npm:1.0.4":
   version: 1.0.4
   resolution: "@radix-ui/react-portal@npm:1.0.4"
@@ -4791,6 +4909,26 @@ __metadata:
     "@types/react-dom":
       optional: true
   checksum: 7e7130fcb0d99197322cd97987e1d7279b6c264fb6be3d883cbfcd49267740d83ca17b431e0d98848afd6067a13ee823ca396a8b63ae68f18a728cf70398c830
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-portal@npm:1.1.12":
+  version: 1.1.12
+  resolution: "@radix-ui/react-portal@npm:1.1.12"
+  dependencies:
+    "@radix-ui/react-primitive": "npm:2.1.6"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.2"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 9b1bcfdb0577c0972f09c44d9f55fc365ab18f7777cc412fc993e733318cf08c382824ab8d8bc1eb2305b7d2eb8d4e478900b610f8a7f5ea233ffc3cc14d1427
   languageName: node
   linkType: hard
 
@@ -4895,6 +5033,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-presence@npm:1.1.6":
+  version: 1.1.6
+  resolution: "@radix-ui/react-presence@npm:1.1.6"
+  dependencies:
+    "@radix-ui/react-use-layout-effect": "npm:1.1.2"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 8b96ba32eae20162005f7e818b07e1e6e351da03f4753a79403ec58d27c4965e881a506960283fd7ded5b8ecf5ccb6a58bbc1d6799f5254a6cd4e5ae8837e345
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-primitive@npm:1.0.3":
   version: 1.0.3
   resolution: "@radix-ui/react-primitive@npm:1.0.3"
@@ -4950,6 +5107,25 @@ __metadata:
     "@types/react-dom":
       optional: true
   checksum: 1af7a33a86f8bd2467f2300b1bb6ca9af67cae3950953ba543d2a625c17f341dff05d19056ece7b03e5ced8b9f8de99c74f806710ce0da6b9a000f2af063fffe
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-primitive@npm:2.1.6":
+  version: 2.1.6
+  resolution: "@radix-ui/react-primitive@npm:2.1.6"
+  dependencies:
+    "@radix-ui/react-slot": "npm:1.3.0"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 2d497bf05275df598a1435fe0c45d0c4da6647d5ddd692ec77780242cab57819f6acd2c3b56086f202f7998a649697c680daf93e68a08bf3bc660b0155ebd88e
   languageName: node
   linkType: hard
 
@@ -5112,6 +5288,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-slot@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@radix-ui/react-slot@npm:1.3.0"
+  dependencies:
+    "@radix-ui/react-compose-refs": "npm:1.1.3"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 7353520950dcbc5c331f79aeac5bc8efa5130014e8121f85b337996ec5a2cef89f1375ff879b72ba05182de93c1126b22ec328f171edd7a2888c1532d10f74b5
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-tabs@npm:1.0.4":
   version: 1.0.4
   resolution: "@radix-ui/react-tabs@npm:1.0.4"
@@ -5200,6 +5391,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-tooltip@npm:^1.2.10":
+  version: 1.2.10
+  resolution: "@radix-ui/react-tooltip@npm:1.2.10"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.4"
+    "@radix-ui/react-compose-refs": "npm:1.1.3"
+    "@radix-ui/react-context": "npm:1.1.4"
+    "@radix-ui/react-dismissable-layer": "npm:1.1.13"
+    "@radix-ui/react-id": "npm:1.1.2"
+    "@radix-ui/react-popper": "npm:1.3.1"
+    "@radix-ui/react-portal": "npm:1.1.12"
+    "@radix-ui/react-presence": "npm:1.1.6"
+    "@radix-ui/react-primitive": "npm:2.1.6"
+    "@radix-ui/react-slot": "npm:1.3.0"
+    "@radix-ui/react-use-controllable-state": "npm:1.2.3"
+    "@radix-ui/react-visually-hidden": "npm:1.2.6"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 2fd70fbd660ec8d3b13949bb3020166a14394b422ff992b8f5eb50a3f4b17444282f88cba350f22d398e5370c098c986f0236b29ab6e2451d73bf75ae3498fb9
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-use-callback-ref@npm:1.0.1":
   version: 1.0.1
   resolution: "@radix-ui/react-use-callback-ref@npm:1.0.1"
@@ -5225,6 +5446,19 @@ __metadata:
     "@types/react":
       optional: true
   checksum: e954863f3baa151faf89ac052a5468b42650efca924417470efd1bd254b411a94c69c30de2fdbb90187b38cb984795978e12e30423dc41e4309d93d53b66d819
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-callback-ref@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@radix-ui/react-use-callback-ref@npm:1.1.2"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: aa43df8cf54b410f2b0fff817247cee5e4d4560b86d9bff7c17c19441726163c28f09f908e154607e5e6d0a055538c768381b723c9f5d1019807546f352b4cc1
   languageName: node
   linkType: hard
 
@@ -5259,6 +5493,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-use-controllable-state@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@radix-ui/react-use-controllable-state@npm:1.2.3"
+  dependencies:
+    "@radix-ui/react-use-effect-event": "npm:0.0.3"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.2"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 8c551263a2753cebc1d60019d8beb307d20cbb1b9847887a9eed13db5392672c6d5179b7f46a2cbd34a64bda702617670012ebcd32cffeb22f6645fcf5345ee8
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-effect-event@npm:0.0.3":
+  version: 0.0.3
+  resolution: "@radix-ui/react-use-effect-event@npm:0.0.3"
+  dependencies:
+    "@radix-ui/react-use-layout-effect": "npm:1.1.2"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 8808fab0b26e30da9b50070a426b3ac135132c360b23a2a5de331bd06d8b164b10cd5561573dd17530172ba67dde428057fbf9a1f5fae2cba3cc66f118e72406
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-use-escape-keydown@npm:1.0.3":
   version: 1.0.3
   resolution: "@radix-ui/react-use-escape-keydown@npm:1.0.3"
@@ -5290,6 +5555,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-use-escape-keydown@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@radix-ui/react-use-escape-keydown@npm:1.1.2"
+  dependencies:
+    "@radix-ui/react-use-callback-ref": "npm:1.1.2"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 3fce06fbb986b21712db2ba3ec52b79c0928c7341983b3f08b878258d6b6f35247882c87a990bc1cd30ca44662cfe86733263d3b00cbdf34252311b8c7195138
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-use-layout-effect@npm:1.0.1":
   version: 1.0.1
   resolution: "@radix-ui/react-use-layout-effect@npm:1.0.1"
@@ -5315,6 +5595,19 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 9bf87ece1845c038ed95863cfccf9d75f557c2400d606343bab0ab3192b9806b9840e6aa0a0333fdf3e83cf9982632852192f3e68d7d8367bc8c788dfdf8e62b
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-layout-effect@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@radix-ui/react-use-layout-effect@npm:1.1.2"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: c7fc76744a4d37b5010eac33eda6439db2ac4d657e2bb5f596236e60aa4384ac88a7b2e3ebc1c88312c5c536a40081cc85ae6d70c0bba4bb8702d302b8ff07f7
   languageName: node
   linkType: hard
 
@@ -5361,6 +5654,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-use-rect@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@radix-ui/react-use-rect@npm:1.1.2"
+  dependencies:
+    "@radix-ui/rect": "npm:1.1.2"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: eafaa88ea33bfb3761a81a3badb73ecf99c613aa7c10e53dac08fee3457d21f4dfd1e65b5a47e7925e4aa1da60f2793404183353d4d21e85aae4009c76de64d4
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-use-size@npm:1.1.0":
   version: 1.1.0
   resolution: "@radix-ui/react-use-size@npm:1.1.0"
@@ -5373,6 +5681,21 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 4c8b89037597fdc1824d009e0c941b510c7c6c30f83024cc02c934edd748886786e7d9f36f57323b02ad29833e7fa7e8974d81969b4ab33d8f41661afa4f30a6
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-size@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@radix-ui/react-use-size@npm:1.1.2"
+  dependencies:
+    "@radix-ui/react-use-layout-effect": "npm:1.1.2"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 0a088412bb831fd1d59f9058352aca384c2d0a07b894b35707b3486eea4a1d8a37a04fb117379f9a8a46a921b0092f97b29b517689c8f97029ec73eb68973521
   languageName: node
   linkType: hard
 
@@ -5415,10 +5738,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-visually-hidden@npm:1.2.6":
+  version: 1.2.6
+  resolution: "@radix-ui/react-visually-hidden@npm:1.2.6"
+  dependencies:
+    "@radix-ui/react-primitive": "npm:2.1.6"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 24f8bbf63d007a34af9c816558019d0e9f3db89aa9de0b29bdd8f86647a351db9d82ed8510bbb5e4c122afaf3606b9bfcd626c3757c56927819e9e4ea8feb6e1
+  languageName: node
+  linkType: hard
+
 "@radix-ui/rect@npm:1.1.0":
   version: 1.1.0
   resolution: "@radix-ui/rect@npm:1.1.0"
   checksum: a26ff7f8708fb5f2f7949baad70a6b2a597d761ee4dd4aadaf1c1a33ea82ea23dfef6ce6366a08310c5d008cdd60b2e626e4ee03fa342bd5f246ddd9d427f6be
+  languageName: node
+  linkType: hard
+
+"@radix-ui/rect@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@radix-ui/rect@npm:1.1.2"
+  checksum: 304d648c4b6786755a10eabf2327f40b7c6303bb588174ab6194a5bb032c195c51f3e43395dee1dd37239fa68b63558092f2bc8ce5a14962d5e4303afb0a17ca
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Shows FPC relationship detail in the Fee Juice tab instead of the stats strip. Adds shadcn tooltips everywhere.

## Changes

### Explorer API
- New `GET /l2/.../{address}/fpc-transactions` — returns asFeePayer and asSponsored
- FPC detection now checks both initiator AND msgSender roles (joins tx_public_call_request)
- Fix double-stringify bug in fpc-relationships endpoint

### Explorer UI v2
- **Paid for column** — balance history table in Fee Juice tab now shows which address the FPC paid for
- **Sponsored transaction rows** — when no own balance, Fee Juice tab shows FPC-paid txs instead of empty state
- Removed 'via [FPC]' and 'Pays fees for:' from stats strip (now in tables)
- **shadcn Tooltip** — replaces native title attributes everywhere (balance ?, call type headers, call type/static chips)
- TooltipProvider wraps Shell via providers/
- Grid adjusted to 6 columns when sponsored column present

## Deployment
Merge to main-v4 → CI/CD cascades to production (mainnet v4) and main → production-testnet (testnet v5)